### PR TITLE
Add Aphotic Depth: bioluminescent glow, ambient particles, structural gradients

### DIFF
--- a/Configs/quickshell/aphotic/components/DepthGradient.qml
+++ b/Configs/quickshell/aphotic/components/DepthGradient.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import qs.services
+
+// A structural lighting cue, not a palette addition: very slightly lighter
+// toward the near/top edge of a surface, darker toward the far/bottom edge,
+// both derived from that surface's own existing background colour. Meant
+// as a thin overlay on top of an already-painted background rect (same
+// radius, mouse-transparent), not a replacement for its `color`.
+Rectangle {
+    id: root
+
+    property color baseColour: Colours.tPalette.m3surfaceContainer
+    property real strength: 0.05
+
+    color: "transparent"
+
+    gradient: Gradient {
+        GradientStop {
+            position: 0
+
+            color: Qt.tint(root.baseColour, Qt.alpha("#ffffff", root.strength))
+
+            Behavior on color {
+                CAnim {}
+            }
+        }
+        GradientStop {
+            position: 1
+
+            color: Qt.tint(root.baseColour, Qt.alpha("#000000", root.strength))
+
+            Behavior on color {
+                CAnim {}
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/components/DepthLayer.qml
+++ b/Configs/quickshell/aphotic/components/DepthLayer.qml
@@ -1,0 +1,63 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import qs.services
+
+// Ambient "marine snow" -- a handful of soft, slow-drifting particles meant
+// to sit behind a popout's real content, never in front of it. Cheap by
+// construction: one linear NumberAnimation per particle, no physics, count
+// capped by services/DepthFx.qml's tier (0 when Depth Effects is off).
+//
+// `opacityScale` is how a host surface dials the field down (or skips it
+// entirely by not instantiating this at all) when its own content is
+// already visually dense -- see the per-surface usage sites for the actual
+// values chosen.
+Item {
+    id: root
+
+    property color particleColour: Colours.palette.m3primary
+    property int count: DepthFx.particleCount
+    property real opacityScale: 1
+
+    clip: true
+    visible: root.count > 0
+
+    Repeater {
+        model: root.visible ? root.count : 0
+
+        Rectangle {
+            id: particle
+
+            required property int index
+
+            readonly property real particleSize: 1.5 + Math.random() * 2.5
+            readonly property real driftDuration: 14000 + Math.random() * 12000
+
+            width: particleSize
+            height: particleSize
+            radius: particleSize / 2
+            color: root.particleColour
+            opacity: (0.08 + Math.random() * 0.2) * root.opacityScale
+            x: Math.random() * Math.max(1, root.width)
+            y: Math.random() * Math.max(1, root.height)
+
+            SequentialAnimation {
+                running: root.visible
+                loops: Animation.Infinite
+
+                NumberAnimation {
+                    target: particle
+                    property: "y"
+                    to: -particle.particleSize * 4
+                    duration: particle.driftDuration
+                    easing.type: Easing.Linear
+                }
+                PropertyAction {
+                    target: particle
+                    property: "y"
+                    value: root.height + particle.particleSize * 4
+                }
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/components/effects/BioluminescentGlow.qml
+++ b/Configs/quickshell/aphotic/components/effects/BioluminescentGlow.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtQuick.Effects
+import qs.config
+import qs.components
+import qs.services
+
+// The shared "alive" glow -- a soft, theme-accent-coloured blur that
+// breathes rather than sitting at a flat static opacity. Every focused/
+// active/interactive indicator this repo adds under the Aphotic Depth
+// treatment uses this instead of inventing its own highlight or its own
+// pulse rhythm (see services/DepthFx.qml for the shared cadence/intensity).
+//
+// Declare this as a SIBLING of `target`, BEFORE it in z-order (earlier in
+// the file) -- like Elevation.qml's RectangularShadow, it renders a blurred
+// shape sized to `target`'s own bounds, and `target` needs to paint on top
+// to hide the solid core, leaving only the soft bleed around its edges
+// visible.
+RectangularShadow {
+    id: root
+
+    required property Item target
+    property color glowColour: Colours.palette.m3primary
+    property real intensity: DepthFx.glowIntensity
+    property int pulsePeriod: DepthFx.pulsePeriod
+    property real glowBlur: 18
+    property real glowSpread: 0.06
+    // Off for one-shot uses (e.g. the notification arrival flash) that
+    // drive `intensity` themselves via their own animation -- the
+    // breathing loop below targets `opacity` directly, which would
+    // otherwise permanently break the `opacity: root.intensity` binding
+    // the moment it starts and fight the caller's own decay curve.
+    property bool breathing: true
+
+    anchors.fill: target
+    radius: Tokens.rounding.full
+    color: Qt.alpha(root.glowColour, 0.65)
+    blur: root.glowBlur
+    spread: root.glowSpread
+    offset.x: 0
+    offset.y: 0
+    visible: root.intensity > 0
+    opacity: root.intensity
+
+    Behavior on color {
+        CAnim {}
+    }
+
+    SequentialAnimation {
+        running: root.visible && root.breathing
+        loops: Animation.Infinite
+
+        NumberAnimation {
+            target: root
+            property: "opacity"
+            from: root.intensity * 0.45
+            to: root.intensity
+            duration: root.pulsePeriod
+            easing.type: Easing.InOutSine
+        }
+        NumberAnimation {
+            target: root
+            property: "opacity"
+            from: root.intensity
+            to: root.intensity * 0.45
+            duration: root.pulsePeriod
+            easing.type: Easing.InOutSine
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/components/effects/qmldir
+++ b/Configs/quickshell/aphotic/components/effects/qmldir
@@ -1,4 +1,5 @@
 module qs.components.effects
+BioluminescentGlow 1.0 BioluminescentGlow.qml
 ColouredIcon 1.0 ColouredIcon.qml
 Colouriser 1.0 Colouriser.qml
 Elevation 1.0 Elevation.qml

--- a/Configs/quickshell/aphotic/components/qmldir
+++ b/Configs/quickshell/aphotic/components/qmldir
@@ -6,6 +6,8 @@ Anim 1.0 Anim.qml
 CAnim 1.0 CAnim.qml
 ColorPickerField 1.0 ColorPickerField.qml
 ColorWheel 1.0 ColorWheel.qml
+DepthGradient 1.0 DepthGradient.qml
+DepthLayer 1.0 DepthLayer.qml
 Logo 1.0 Logo.qml
 MaterialIcon 1.0 MaterialIcon.qml
 ScreenState 1.0 ScreenState.qml

--- a/Configs/quickshell/aphotic/modules/background/BackgroundWindow.qml
+++ b/Configs/quickshell/aphotic/modules/background/BackgroundWindow.qml
@@ -35,6 +35,71 @@ PanelWindow {
 
         anchors.fill: parent
 
+        // "Descent" intro: the shell surfaces into view rather than just
+        // appearing, echoing light fading in from depth on first map. Any
+        // input skips straight to the settled state -- this is a mood-
+        // setting flourish, not something that should ever make someone
+        // wait to start using their desktop.
+        //
+        // Uses an explicit, stoppable Animation rather than a Behavior:
+        // a Behavior can't be reliably snapped to its end value mid-flight
+        // (disabling it just freezes wherever the animation currently is),
+        // which would make "skippable" a lie the moment input arrives
+        // partway through the ~650ms transition.
+        property bool introSkipped: false
+
+        opacity: 0
+        scale: 1.04
+        transformOrigin: Item.Center
+
+        function skipIntro(): void {
+            if (backgroundContent.introSkipped)
+                return;
+            backgroundContent.introSkipped = true;
+            descentAnim.stop();
+            backgroundContent.opacity = 1;
+            backgroundContent.scale = 1;
+        }
+
+        ParallelAnimation {
+            id: descentAnim
+
+            NumberAnimation {
+                target: backgroundContent
+                property: "opacity"
+                to: 1
+                duration: Tokens.anim.durations.expressiveSlowSpatial
+                easing: Tokens.anim.expressiveSlowSpatial
+            }
+            NumberAnimation {
+                target: backgroundContent
+                property: "scale"
+                to: 1
+                duration: Tokens.anim.durations.expressiveSlowSpatial
+                easing: Tokens.anim.expressiveSlowSpatial
+            }
+        }
+
+        Timer {
+            interval: 16
+            running: true
+            onTriggered: {
+                if (!backgroundContent.introSkipped)
+                    descentAnim.start();
+            }
+        }
+
+        HoverHandler {
+            enabled: !backgroundContent.introSkipped
+            onPointChanged: backgroundContent.skipIntro()
+        }
+
+        TapHandler {
+            enabled: !backgroundContent.introSkipped
+            acceptedButtons: Qt.AllButtons
+            onTapped: backgroundContent.skipIntro()
+        }
+
         // Desktop right-click menu -- TapHandler (not MouseArea) so it
         // observes without grabbing the button, leaving normal
         // left-click-through-to-desktop behaviour untouched.

--- a/Configs/quickshell/aphotic/modules/bar/BarWrapper.qml
+++ b/Configs/quickshell/aphotic/modules/bar/BarWrapper.qml
@@ -143,6 +143,12 @@ Item {
         Behavior on radius {
             Anim { type: Anim.DefaultEffects }
         }
+
+        DepthGradient {
+            anchors.fill: parent
+            radius: parent.radius
+            baseColour: Colours.tPalette.m3surfaceContainer
+        }
     }
 
     Loader {

--- a/Configs/quickshell/aphotic/modules/bar/components/ActiveWindow.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/ActiveWindow.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import qs.config
 import qs.components
+import qs.components.effects
 import qs.services
 import qs.utils
 
@@ -58,7 +59,14 @@ Item {
     implicitWidth: Settings.barHorizontal ? icon.implicitWidth + Tokens.spacing.small + current.implicitWidth + Tokens.padding.small * 2 : Settings.barInnerWidth
     implicitHeight: Settings.barHorizontal ? Settings.barInnerWidth : icon.implicitHeight + current.implicitWidth + current.anchors.topMargin + Tokens.padding.small * 2
 
+    BioluminescentGlow {
+        target: background
+        intensity: Hypr.activeToplevel ? DepthFx.glowIntensity : 0
+    }
+
     StyledRect {
+        id: background
+
         anchors.fill: parent
         radius: Tokens.rounding.full
         color: Colours.palette.m3surfaceContainerHigh

--- a/Configs/quickshell/aphotic/modules/bar/components/AgentIndicator.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/AgentIndicator.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import qs.config
 import qs.components
+import qs.components.effects
 import qs.services
 
 Item {
@@ -21,7 +22,14 @@ Item {
     implicitWidth: root.showBackground ? Settings.barInnerWidth : icon.implicitWidth
     implicitHeight: root.showBackground ? Settings.barInnerWidth : icon.implicitHeight
 
+    BioluminescentGlow {
+        target: background
+        intensity: root.badgeCount > 0 ? DepthFx.glowIntensity : 0
+    }
+
     StyledRect {
+        id: background
+
         visible: root.showBackground
         anchors.fill: parent
         radius: Tokens.rounding.full

--- a/Configs/quickshell/aphotic/modules/bar/components/HoverPill.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/HoverPill.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import qs.config
 import qs.components
+import qs.components.effects
 import qs.services
 
 // The bar's shared hover affordance: one soft circle that GLIDES along a
@@ -83,5 +84,13 @@ StyledRect {
         Anim {
             type: Anim.FastEffects
         }
+    }
+
+    // The glow rides along for free -- it's anchored to root, and root's
+    // own x/y glide is already animated above, so this reads as a soft
+    // trail during motion rather than a separate effect to keep in sync.
+    BioluminescentGlow {
+        target: root
+        glowBlur: 12
     }
 }

--- a/Configs/quickshell/aphotic/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -57,6 +57,10 @@ StyledRect {
     radius: Tokens.rounding.full
     color: Colours.palette.m3primary
 
+    BioluminescentGlow {
+        target: root
+    }
+
     Colouriser {
         id: colouriser
 

--- a/Configs/quickshell/aphotic/modules/dashboard/DashboardContent.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/DashboardContent.qml
@@ -56,6 +56,17 @@ ColumnLayout {
             shadowVerticalOffset: 2
         }
 
+        DepthLayer {
+            anchors.fill: parent
+            opacityScale: 0.7
+        }
+
+        DepthGradient {
+            anchors.fill: parent
+            radius: parent.radius
+            baseColour: Colours.tPalette.m3surfaceContainer
+        }
+
         Loader {
             id: tabLoader
 

--- a/Configs/quickshell/aphotic/modules/intelligence/IntelligenceContent.qml
+++ b/Configs/quickshell/aphotic/modules/intelligence/IntelligenceContent.qml
@@ -69,6 +69,17 @@ Item {
             shadowVerticalOffset: 2
         }
 
+        DepthLayer {
+            anchors.fill: parent
+            opacityScale: 0.35
+        }
+
+        DepthGradient {
+            anchors.fill: parent
+            radius: card.radius
+            baseColour: card.color
+        }
+
         // Absorbs clicks so a click anywhere on the card (not just on its
         // interactive children) doesn't fall through to the full-screen
         // dismiss MouseArea in IntelligenceWindow underneath.

--- a/Configs/quickshell/aphotic/modules/lock/LockSurface.qml
+++ b/Configs/quickshell/aphotic/modules/lock/LockSurface.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Quickshell.Wayland
 import qs.config
+import qs.components
 import qs.services
 
 WlSessionLockSurface {
@@ -13,9 +14,64 @@ WlSessionLockSurface {
 
     color: Colours.palette.m3surfaceContainer
 
+    DepthLayer {
+        anchors.fill: parent
+    }
+
     LockContent {
         anchors.centerIn: parent
         lock: root.lock
         pam: root.pam
+    }
+
+    // Auth-success ripple: a soft accent-coloured glow expanding from the
+    // unlock point outward, so the transition to desktop reads as a
+    // deliberate "surfacing" rather than an instant cut.
+    Rectangle {
+        id: unlockRipple
+
+        anchors.centerIn: parent
+        width: 0
+        height: width
+        radius: width / 2
+        color: Qt.alpha(Colours.palette.m3primary, 0.35)
+        opacity: 0
+        visible: width > 0
+
+        SequentialAnimation {
+            id: rippleAnim
+
+            ScriptAction {
+                script: unlockRipple.opacity = 0.55
+            }
+            ParallelAnimation {
+                NumberAnimation {
+                    target: unlockRipple
+                    property: "width"
+                    from: 0
+                    to: Math.max(root.width, root.height) * 1.5
+                    duration: Tokens.anim.durations.large
+                    easing: Tokens.anim.expressiveDefaultSpatial
+                }
+                NumberAnimation {
+                    target: unlockRipple
+                    property: "opacity"
+                    to: 0
+                    duration: Tokens.anim.durations.large
+                    easing: Tokens.anim.standardDecel
+                }
+            }
+            ScriptAction {
+                script: unlockRipple.width = 0
+            }
+        }
+
+        Connections {
+            target: root.pam
+
+            function onUnlockSuccess(): void {
+                rippleAnim.restart();
+            }
+        }
     }
 }

--- a/Configs/quickshell/aphotic/modules/lock/Pam.qml
+++ b/Configs/quickshell/aphotic/modules/lock/Pam.qml
@@ -20,6 +20,7 @@ Item {
     property int state
 
     signal flashMsg
+    signal unlockSuccess
 
     function handleKey(event: var): void {
         if (passwd.active)
@@ -56,7 +57,11 @@ Item {
 
         onCompleted: res => {
             if (res === PamResult.Success) {
-                root.lock.locked = false;
+                // Fire the glow ripple immediately but hold the actual
+                // unlock for one beat -- an instant cut to desktop the
+                // moment PAM succeeds would never let the ripple be seen.
+                root.unlockSuccess();
+                unlockDelay.restart();
                 return;
             }
 
@@ -79,6 +84,12 @@ Item {
             if (root.state !== Pam.MaxTries)
                 root.state = Pam.None;
         }
+    }
+
+    Timer {
+        id: unlockDelay
+        interval: 700
+        onTriggered: root.lock.locked = false
     }
 
     Connections {

--- a/Configs/quickshell/aphotic/modules/notificationcenter/NotificationCenterContent.qml
+++ b/Configs/quickshell/aphotic/modules/notificationcenter/NotificationCenterContent.qml
@@ -63,6 +63,15 @@ Item {
             shadowVerticalOffset: 2
         }
 
+        // No DepthLayer here -- this card's own content (a dense
+        // notification list) is already visually busy, per Aphotic
+        // Depth's per-surface intensity guidance.
+        DepthGradient {
+            anchors.fill: parent
+            radius: card.radius
+            baseColour: card.color
+        }
+
         MouseArea {
             anchors.fill: parent
         }

--- a/Configs/quickshell/aphotic/modules/notifications/Notification.qml
+++ b/Configs/quickshell/aphotic/modules/notifications/Notification.qml
@@ -6,6 +6,7 @@ import Quickshell.Widgets
 import Quickshell.Services.Notifications
 import qs.config
 import qs.components
+import qs.components.effects
 import qs.services
 import qs.utils
 
@@ -22,6 +23,35 @@ StyledRect {
 
     implicitWidth: Tokens.sizes.notifs.width
     implicitHeight: inner.implicitHeight + Tokens.padding.medium * 2
+
+    // Bioluminescent flash-response on arrival, echoing the deep-sea cue
+    // this whole treatment is named for -- decays to nothing rather than
+    // looping, so it reads as a one-off reaction to the notification
+    // landing, not a persistent highlight.
+    BioluminescentGlow {
+        id: arrivalGlow
+
+        target: root
+        glowColour: root.critical ? Colours.palette.m3error : Colours.palette.m3primary
+        glowBlur: 26
+        intensity: 0
+        breathing: false
+
+        NumberAnimation on intensity {
+            id: flashAnim
+
+            running: false
+            from: DepthFx.glowIntensity * 1.4
+            to: 0
+            duration: 900
+            easing.type: Easing.OutQuad
+        }
+    }
+
+    Component.onCompleted: {
+        if (DepthFx.enabled)
+            flashAnim.start();
+    }
 
     MouseArea {
         anchors.fill: parent

--- a/Configs/quickshell/aphotic/modules/settings/SettingsPanel.qml
+++ b/Configs/quickshell/aphotic/modules/settings/SettingsPanel.qml
@@ -35,10 +35,23 @@ RowLayout {
     spacing: 0
 
     StyledRect {
+        id: rail
+
         Layout.fillHeight: true
         Layout.preferredWidth: 300
         radius: Tokens.rounding.extraLarge
         color: Colours.tPalette.m3surfaceContainer
+
+        DepthLayer {
+            anchors.fill: parent
+            opacityScale: 0.5
+        }
+
+        DepthGradient {
+            anchors.fill: parent
+            radius: rail.radius
+            baseColour: rail.color
+        }
 
         CategoryRail {
             anchors.fill: parent
@@ -60,6 +73,12 @@ RowLayout {
         clip: true
 
         property int _prevCategoryIndex: 0
+
+        DepthGradient {
+            anchors.fill: parent
+            radius: paneSurface.radius
+            baseColour: paneSurface.color
+        }
 
         Flickable {
             id: paneFlick

--- a/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
@@ -12,6 +12,7 @@ ColumnLayout {
     id: root
 
     readonly property var accentPresets: ["", "#4A5A52", "#669B04", "#3B82F6", "#EF4444", "#F59E0B", "#8B5CF6", "#EC4899", "#14B8A6"]
+    readonly property var depthEffectsPresets: [{ value: "off", label: qsTr("Off") }, { value: "subtle", label: qsTr("Subtle") }, { value: "full", label: qsTr("Full") }]
 
     property var cursorThemes: []
     property var iconThemes: []
@@ -114,6 +115,33 @@ ColumnLayout {
                     onClicked: Settings.accentColorOverride = swatch.modelData
                 }
             }
+        }
+    }
+
+    StyledText {
+        Layout.topMargin: Tokens.spacing.small
+        text: qsTr("Depth effects")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.medium
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        text: qsTr("Breathing glow and ambient particles layered on top of your theme. Subtle is a lighter tier for lower-end GPUs; Off returns to flat, static highlights everywhere.")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.body.small
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+
+        SettingsPresetRow {
+            icon: "blur_on"
+            label: qsTr("Depth effects")
+            presets: root.depthEffectsPresets
+            value: Settings.depthEffects
+            onSelected: value => Settings.depthEffects = value
         }
     }
 

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Effects
 import qs.config
 import qs.components
 import qs.services
@@ -10,14 +11,21 @@ Item {
 
     required property ScreenState screenState
 
-    readonly property int cellWidth: 340
-    readonly property int cellHeight: 210
-    readonly property int cellSpacing: 24
+    readonly property int cellWidth: 300
+    readonly property int cellHeight: 169
+    readonly property int cellSpacing: 20
+    readonly property int slotPitch: cellWidth + cellSpacing
+    readonly property real centerScale: 1.35
+    readonly property int visibleSlots: 5
+
+    readonly property real flickDeceleration: 1000
+    readonly property real maxFlickVelocity: 4800
+    readonly property real singleStepVelocity: Math.sqrt(2 * flickDeceleration * slotPitch)
 
     property string _originalWallpaper: ""
 
-    implicitWidth: cellWidth * 3 + cellSpacing * 4 + Tokens.padding.large * 2
-    implicitHeight: cellHeight + label.implicitHeight + Tokens.spacing.large + Tokens.padding.large * 2
+    implicitWidth: slotPitch * visibleSlots + Tokens.padding.large * 2
+    implicitHeight: cellHeight * centerScale + caption.implicitHeight + Tokens.spacing.large + Tokens.padding.large * 2
 
     focus: true
 
@@ -25,17 +33,44 @@ Item {
         root.screenState.wallpaperPicker = false;
     }
 
-    // Live-preview scrolling already applied the real wallpaper on every
-    // step (see strip.onCurrentIndexChanged) -- Escape has to explicitly
-    // put the original one back, not just close, or "cancel" wouldn't
-    // actually cancel anything.
     function _revertAndClose(): void {
         Themes.setWallpaperInActiveTheme(root._originalWallpaper);
         root.screenState.wallpaperPicker = false;
     }
 
-    Keys.onLeftPressed: strip.decrementCurrentIndex()
-    Keys.onRightPressed: strip.incrementCurrentIndex()
+    function _clampVelocity(v: real): real {
+        return Math.max(-root.maxFlickVelocity, Math.min(root.maxFlickVelocity, v));
+    }
+
+    function _targetContentX(index: int): real {
+        const centerOffset = strip.width / 2 - root.cellWidth / 2;
+        const ideal = index * root.slotPitch - centerOffset;
+        const maxX = Math.max(0, strip.contentWidth - strip.width);
+        return Math.max(0, Math.min(ideal, maxX));
+    }
+
+    function _settle(): void {
+        settleAnim.to = root._targetContentX(strip.currentIndex);
+        settleAnim.restart();
+    }
+
+    function _flickToIndex(targetIndex: int): void {
+        const clamped = Math.max(0, Math.min(targetIndex, strip.count - 1));
+        const deltaItems = clamped - strip.currentIndex;
+        if (deltaItems === 0)
+            return;
+        const direction = Math.sign(deltaItems);
+        const distance = Math.abs(deltaItems) * root.slotPitch;
+        strip.flick(root._clampVelocity(-direction * Math.sqrt(2 * root.flickDeceleration * distance)), 0);
+    }
+
+    function _wheelImpulse(direction: int): void {
+        const combined = -strip.horizontalVelocity + direction * root.singleStepVelocity;
+        strip.flick(root._clampVelocity(-combined), 0);
+    }
+
+    Keys.onLeftPressed: root._flickToIndex(strip.currentIndex - 1)
+    Keys.onRightPressed: root._flickToIndex(strip.currentIndex + 1)
     Keys.onReturnPressed: root._commit()
     Keys.onEscapePressed: root._revertAndClose()
 
@@ -45,8 +80,32 @@ Item {
             if (!root.screenState.wallpaperPicker)
                 return;
             root._originalWallpaper = Themes.activeWallpaper;
-            strip.currentIndex = Themes.wallpapersInActiveTheme.indexOf(Themes.activeWallpaper);
+            const idx = Themes.wallpapersInActiveTheme.indexOf(Themes.activeWallpaper);
+            if (idx !== -1) {
+                strip.currentIndex = idx;
+                strip.positionViewAtIndex(idx, ListView.Center);
+            }
             root.forceActiveFocus();
+        }
+    }
+
+    Repeater {
+        model: Themes.wallpapersInActiveTheme
+
+        Item {
+            id: preload
+
+            required property string modelData
+
+            visible: false
+
+            Image {
+                source: `file://${Themes.awwwDir}/${Themes.activeTheme}/${preload.modelData}`
+                asynchronous: true
+                cache: true
+                sourceSize.width: root.cellWidth
+                sourceSize.height: root.cellHeight
+            }
         }
     }
 
@@ -64,25 +123,45 @@ Item {
             ListView {
                 id: strip
 
-                width: root.cellWidth * 3 + root.cellSpacing * 2
-                height: root.cellHeight
+                width: root.slotPitch * root.visibleSlots
+                height: root.cellHeight * root.centerScale
                 orientation: ListView.Horizontal
                 spacing: root.cellSpacing
                 clip: true
-                snapMode: ListView.SnapOneItem
-                highlightRangeMode: ListView.StrictlyEnforceRange
-                preferredHighlightBegin: width / 2 - root.cellWidth / 2
-                preferredHighlightEnd: width / 2 - root.cellWidth / 2
+                cacheBuffer: root.slotPitch * 2
+
+                snapMode: ListView.NoSnap
+
+                flickDeceleration: root.flickDeceleration
+                maximumFlickVelocity: root.maxFlickVelocity
+                boundsBehavior: Flickable.DragOverBounds
 
                 model: Themes.wallpapersInActiveTheme
+
+                onContentXChanged: {
+                    const idx = strip.indexAt(strip.contentX + strip.width / 2, strip.height / 2);
+                    if (idx !== -1 && idx !== strip.currentIndex)
+                        strip.currentIndex = idx;
+                }
 
                 onCurrentIndexChanged: {
                     if (currentIndex >= 0 && currentIndex < model.length)
                         Themes.setWallpaperInActiveTheme(model[currentIndex]);
                 }
 
+                onMovementEnded: root._settle()
+
+                SpringAnimation {
+                    id: settleAnim
+
+                    target: strip
+                    property: "contentX"
+                    spring: 2.2
+                    damping: 0.42
+                }
+
                 WheelHandler {
-                    onWheel: event => event.angleDelta.y < 0 ? strip.incrementCurrentIndex() : strip.decrementCurrentIndex()
+                    onWheel: event => root._wheelImpulse(event.angleDelta.y < 0 ? 1 : -1)
                 }
 
                 delegate: Item {
@@ -91,24 +170,41 @@ Item {
                     required property string modelData
                     required property int index
 
-                    readonly property int distance: Math.abs(index - strip.currentIndex)
+                    readonly property real itemCenterX: x + width / 2
+                    readonly property real viewCenterX: strip.contentX + strip.width / 2
+                    readonly property real distance: (itemCenterX - viewCenterX) / root.slotPitch
+                    readonly property real closeness: Math.max(0, 1 - Math.abs(distance))
 
                     width: root.cellWidth
                     height: root.cellHeight
-                    scale: Math.max(0.5, 1 - distance * 0.28)
-                    opacity: Math.max(0.35, 1 - distance * 0.3)
+                    y: (strip.height - height) / 2
+                    scale: Math.max(0.42, root.centerScale - Math.abs(distance) * 0.34)
+                    opacity: Math.max(0.25, 1 - Math.abs(distance) * 0.26)
 
-                    Behavior on scale {
-                        Anim {}
-                    }
-                    Behavior on opacity {
-                        Anim {}
+                    transform: Rotation {
+                        origin.x: delegate.width / 2
+                        origin.y: delegate.height / 2
+                        axis {
+                            x: 0
+                            y: 1
+                            z: 0
+                        }
+                        angle: Math.max(-32, Math.min(32, delegate.distance * -26))
                     }
 
                     StyledClippingRect {
                         anchors.fill: parent
                         radius: Tokens.rounding.large
                         color: Colours.tPalette.m3surfaceContainer
+
+                        layer.enabled: Math.abs(delegate.distance) < 1.6
+                        layer.effect: MultiEffect {
+                            shadowEnabled: true
+                            shadowColor: Qt.tint(Colours.palette.m3shadow, Qt.alpha(Colours.palette.m3primary, 0.55 * delegate.closeness))
+                            shadowOpacity: 0.3 + 0.35 * delegate.closeness
+                            shadowBlur: 0.5 + 0.3 * delegate.closeness
+                            shadowVerticalOffset: 4
+                        }
 
                         Image {
                             anchors.fill: parent
@@ -123,18 +219,32 @@ Item {
 
                     MouseArea {
                         anchors.fill: parent
-                        onClicked: delegate.index === strip.currentIndex ? root._commit() : strip.currentIndex = delegate.index
+                        onClicked: delegate.index === strip.currentIndex ? root._commit() : root._flickToIndex(delegate.index)
                     }
                 }
             }
 
-            StyledText {
-                id: label
+            Column {
+                id: caption
 
                 anchors.horizontalCenter: parent.horizontalCenter
-                text: Themes.activeWallpaper
-                font: Tokens.font.body.medium
-                color: Colours.palette.m3onSurfaceVariant
+                spacing: Tokens.spacing.extraSmall
+
+                StyledText {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: Themes.activeWallpaper
+                    font: Tokens.font.body.medium
+                    color: Colours.palette.m3onSurfaceVariant
+                    animate: true
+                }
+
+                StyledText {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: `${strip.currentIndex + 1} / ${strip.count}`
+                    font: Tokens.font.label.small
+                    color: Colours.palette.m3onSurfaceVariant
+                    opacity: 0.7
+                }
             }
         }
     }

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
@@ -110,11 +110,24 @@ Item {
     }
 
     StyledClippingRect {
+        id: filmstripSurface
+
         anchors.fill: parent
         radius: Tokens.rounding.extraLarge
         color: Colours.palette.m3surfaceContainerHigh
         border.width: Config.border.thickness
         border.color: Colours.palette.m3outlineVariant
+
+        DepthLayer {
+            anchors.fill: parent
+            opacityScale: 0.7
+        }
+
+        DepthGradient {
+            anchors.fill: parent
+            radius: filmstripSurface.radius
+            baseColour: filmstripSurface.color
+        }
 
         Column {
             anchors.centerIn: parent

--- a/Configs/quickshell/aphotic/services/DepthFx.qml
+++ b/Configs/quickshell/aphotic/services/DepthFx.qml
@@ -1,0 +1,23 @@
+pragma Singleton
+import QtQuick
+import qs.services
+
+// Single source of truth for "Aphotic Depth" tier behaviour -- every
+// BioluminescentGlow/DepthLayer instance reads its intensity/particle count
+// from here instead of re-deriving Settings.depthEffects itself, so the
+// three tiers (off/subtle/full) and the one shared breathing cadence stay
+// consistent across every surface that uses them.
+QtObject {
+    id: root
+
+    readonly property bool enabled: Settings.depthEffects !== "off"
+    readonly property bool full: Settings.depthEffects === "full"
+
+    readonly property real glowIntensity: Settings.depthEffects === "full" ? 1 : Settings.depthEffects === "subtle" ? 0.5 : 0
+
+    // The one "alive" cadence every breathing/pulsing element in the shell
+    // shares -- ms for a single rise or fall half-cycle.
+    readonly property int pulsePeriod: 2600
+
+    readonly property int particleCount: Settings.depthEffects === "full" ? 26 : Settings.depthEffects === "subtle" ? 12 : 0
+}

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -164,6 +164,17 @@ Singleton {
     property string statusIconHostInfoColor: ""
     property string statusIconPomodoroColor: ""
     property string statusIconDndColor: ""
+
+    // "Aphotic Depth" visual identity -- glow breathing + marine-snow
+    // particles layered on top of the existing wallust theme (see
+    // components/effects/BioluminescentGlow.qml, components/DepthLayer.qml,
+    // services/DepthFx.qml). "off" disables both entirely (today's static
+    // look); "subtle" (the first-install default) runs a reduced tier;
+    // "full" is the complete treatment. Defaulting to "subtle" rather than
+    // "full" so nobody's GPU load jumps on an upgrade without an explicit
+    // opt-in to the strongest tier.
+    property string depthEffects: "subtle"
+
     property string cursorTheme: "Bibata-Modern-Ice"
     property int cursorSize: 20
     // Papirus family, not an arbitrary icon theme, matches cmd_theme.sh's
@@ -272,6 +283,7 @@ Singleton {
             statusIconHostInfoColor: root.statusIconHostInfoColor,
             statusIconPomodoroColor: root.statusIconPomodoroColor,
             statusIconDndColor: root.statusIconDndColor,
+            depthEffects: root.depthEffects,
             cursorTheme: root.cursorTheme,
             cursorSize: root.cursorSize,
             iconTheme: root.iconTheme,
@@ -444,6 +456,7 @@ Singleton {
     onStatusIconHostInfoColorChanged: root._saveState()
     onStatusIconPomodoroColorChanged: root._saveState()
     onStatusIconDndColorChanged: root._saveState()
+    onDepthEffectsChanged: root._saveState()
     onCursorThemeChanged: {
         root._saveState();
         root._applyCursor();
@@ -593,6 +606,8 @@ Singleton {
                     root.statusIconPomodoroColor = data.statusIconPomodoroColor;
                 if (typeof data.statusIconDndColor === "string")
                     root.statusIconDndColor = data.statusIconDndColor;
+                if (typeof data.depthEffects === "string" && ["off", "subtle", "full"].includes(data.depthEffects))
+                    root.depthEffects = data.depthEffects;
                 if (typeof data.cursorTheme === "string")
                     root.cursorTheme = data.cursorTheme;
                 if (typeof data.cursorSize === "number")

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -3,6 +3,7 @@ singleton AgentProviders 1.0 AgentProviders.qml
 singleton Audio 1.0 Audio.qml
 singleton Brightness 1.0 Brightness.qml
 singleton Colours 1.0 Colours.qml
+singleton DepthFx 1.0 DepthFx.qml
 singleton DoNotDisturb 1.0 DoNotDisturb.qml
 singleton EmojiList 1.0 EmojiList.qml
 singleton HostInfo 1.0 HostInfo.qml


### PR DESCRIPTION
- **Wallpaper picker: continuous momentum-based filmstrip motion**
- **Add Aphotic Depth: bioluminescent glow, ambient particles, structural gradients**

## What this changes

<!-- One or two sentences: what does this PR do, and why? -->

## Scope

- [x] This PR targets `test`, not `main`
- [x] This is scoped to one module/command/fix, not a multi-surface change
- [x] Related `README.md` Roadmap item (if any): <!-- e.g. "Bar orientation" -->

## Verification

This project verifies live, not just "it parses" (see `CONTRIBUTING.md`):

- [ ] `pkill -x qs` then a fresh `qs -c aphotic` restart (not relying on hot-reload alone)
- [ ] Checked logs for `Configuration Loaded` and zero new errors
- [ ] Confirmed the shell is still running afterward (`pgrep -f "qs -c aphotic"`)
- [ ] For visual changes: screenshot attached below
- [ ] `bash -n` on any shell script touched
- [ ] Added/updated a test under `tests/` for install/uninstall/CLI behavior changes
- [ ] No debug residue left behind (`git diff` reviewed)

## Screenshot / recording

<!-- Required for anything visual. Drag an image in, or delete this section if not applicable. -->

## Anything the reviewer should know

<!-- Deliberate scope cuts, known follow-up work, assumptions made where something was ambiguous. -->
