### PR TITLE
CLI audit: fix duplicate-daemon spawn, sddm permission edge case, ai profile

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_ai.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_ai.sh
@@ -4,7 +4,7 @@
 # @cmd.desc: Check AI backend status, switch the active provider profile
 # @cmd.group: AI
 # @cmd.opt: status         | Show reachability of Claude Code / Ollama, loaded models
-# @cmd.opt: profile <name> | Switch the shell's AI-panel provider/model config
+# @cmd.opt: profile <provider>[:<model>] | Switch the AI panel's active provider (ollama/claude/codex/gemini/chatgpt), optionally the ollama model
 # @cmd.opt: fit [n]        | Hardware-aware model recommendations via llmfit (default top 3)
 
 aphotic_cmd_ai() {
@@ -32,11 +32,52 @@ aphotic_cmd_ai() {
             rm -f /tmp/aphotic-ollama-list
             ;;
         profile)
-            local name="${1:-}"
-            [[ -z "$name" ]] && { aphotic_err "usage: aphotic ai profile <name>"; return 1; }
-            aphotic_json_set "ai.activeProfile" "$name"
-            aphotic_ok "AI panel profile set to '${name}'"
-            aphotic_log "define profiles under ${APHOTIC_CONFIG_HOME}/ai-profiles/ (TODO)"
+            # Real bug this replaces: this used to write "ai.activeProfile"
+            # into shell.json (via aphotic_json_set, which always targets
+            # $APHOTIC_CONFIG_FILE) -- but the AI Chat panel's own config
+            # (activeProvider/ollamaModel/...) lives in a completely
+            # separate file, services/ai/AiConfig.qml's
+            # ~/.config/aphotic/ai-config.json, which nothing ever reads
+            # shell.json's "ai" key from. The old command genuinely could
+            # not have changed anything the panel showed, ever, and the
+            # "define profiles under .../ai-profiles/ (TODO)" log line
+            # promised a directory-of-named-presets system that was never
+            # built. Rebuilt as a real, working shortcut: <provider> or
+            # <provider>:<model> (model only meaningful for ollama, quietly
+            # ignored otherwise), writing directly to AiConfig's own
+            # ai-config.json in its own schema -- AiConfig's FileView
+            # already watches this path (same pattern Themes.qml/theme.json
+            # use), so a running shell picks this up live, no reload needed.
+            aphotic_require jq || return 1
+            local arg="${1:-}" provider model
+            [[ -z "$arg" ]] && { aphotic_err "usage: aphotic ai profile <provider>[:<model>] (provider: ollama, claude, codex, gemini, chatgpt)"; return 1; }
+            provider="${arg%%:*}"
+            model=""
+            [[ "$arg" == *:* ]] && model="${arg#*:}"
+
+            case "$provider" in
+                ollama|claude|codex|gemini|chatgpt) ;;
+                *)
+                    aphotic_err "unknown provider '${provider}' -- must be one of: ollama, claude, codex, gemini, chatgpt"
+                    return 1
+                    ;;
+            esac
+
+            local conf="${APHOTIC_CONFIG_HOME}/ai-config.json" tmp
+            mkdir -p "$APHOTIC_CONFIG_HOME"
+            [[ -f "$conf" ]] || echo '{}' > "$conf"
+            tmp="$(mktemp)"
+            if [[ -n "$model" && "$provider" == "ollama" ]]; then
+                jq --arg p "$provider" --arg m "$model" '.activeProvider = $p | .ollamaModel = $m' "$conf" > "$tmp"
+            else
+                jq --arg p "$provider" '.activeProvider = $p' "$conf" > "$tmp"
+            fi
+            mv "$tmp" "$conf"
+
+            if [[ -n "$model" && "$provider" != "ollama" ]]; then
+                aphotic_warn "':${model}' is ignored -- only the ollama profile has a model to set"
+            fi
+            aphotic_ok "AI panel profile set to '${provider}'$([ -n "$model" ] && [ "$provider" == "ollama" ] && echo " (model: ${model})")"
             ;;
         fit)
             aphotic_require jq || return 1
@@ -84,9 +125,13 @@ aphotic_cmd_ai() {
             cat <<HELP
 Usage: aphotic ai <status|profile|fit> [args]
 
-  status          Show Claude Code / Ollama reachability and loaded models
-  profile <name>  Switch the AI-panel's active provider/model profile
-  fit [n]         Hardware-aware model recommendations via llmfit (default top 3)
+  status                     Show Claude Code / Ollama reachability and loaded models
+  profile <provider>[:<model>]
+                             Switch the AI panel's active provider
+                             (ollama, claude, codex, gemini, chatgpt) --
+                             optionally set the model too (ollama only,
+                             e.g. 'ollama:llama3.1:8b')
+  fit [n]                    Hardware-aware model recommendations via llmfit (default top 3)
 HELP
             ;;
         *)

--- a/Configs/.local/lib/aphotic/commands/cmd_iso.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_iso.sh
@@ -27,7 +27,7 @@ aphotic_cmd_iso() {
             }
             [[ -d "$APHOTIC_ISO_PROFILE_DIR" ]] || {
                 aphotic_err "no archiso profile at ${APHOTIC_ISO_PROFILE_DIR}"
-                aphotic_log "TODO: scaffold releng-based profile here (packages.x86_64, airootfs/, profiledef.sh)"
+                aphotic_log "live/installer ISO building isn't built yet -- this command scaffolds nothing on its own. A real releng-based profile (packages.x86_64, airootfs/, profiledef.sh) needs to exist at that path first; that's planned as a future release, not something to expect working today."
                 return 1
             }
 

--- a/Configs/.local/lib/aphotic/commands/cmd_sddm.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_sddm.sh
@@ -67,7 +67,20 @@ _aphotic_sddm_sync() {
     local dest_conf="${APHOTIC_SDDM_THEME_DIR}/theme.conf"
 
     if [[ -w "${APHOTIC_SDDM_THEME_DIR}/Backgrounds" ]] && [[ -w "$dest_conf" ]]; then
-        cp "$image_path" "${APHOTIC_SDDM_THEME_DIR}/Backgrounds/" &&
+        # A destination file that already exists and isn't itself
+        # writable by us (e.g. a leftover from a `sudo cp` that ran
+        # before this function preferred the sudo-free path -- confirmed
+        # live: one such file, root-owned 644, sat here from an earlier
+        # sync that happened to have a cached sudo credential) makes
+        # plain `cp` fail with Permission Denied even though the
+        # directory itself is world-writable -- `cp` opens the
+        # destination for writing, which needs write on the FILE, not
+        # just the dir. `rm -f` first is safe and correct here
+        # specifically because directory write permission (already
+        # confirmed above) is what actually governs unlink/recreate, so
+        # this cleanly self-heals any such leftover going forward.
+        [[ -e "$dest_bg" ]] && [[ ! -w "$dest_bg" ]] && rm -f "$dest_bg" 2>/dev/null
+        cp "$image_path" "$dest_bg" &&
             sed -i "s|^Background=.*|Background=\"Backgrounds/${filename}\"|" "$dest_conf" &&
             aphotic_ok "sddm background synced to ${filename}"
         return

--- a/Configs/.local/lib/aphotic/commands/cmd_shell.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_shell.sh
@@ -28,6 +28,20 @@ HELP
             ;;
         -d|--daemon|"")
             aphotic_require qs || return 1
+            # Real bug, caught live: this used to start a new daemon
+            # unconditionally, with no check for one already running --
+            # on any normally-installed machine (aphotic-shell.service
+            # already up), a bare `aphotic shell` silently spawned a
+            # SECOND, conflicting qs instance (confirmed: two visible
+            # bars on screen until the stray was killed by hand). pgrep
+            # is the same check CONTRIBUTING.md's own verification
+            # section already tells contributors to run by hand
+            # (`pgrep -f "qs -c aphotic"`) -- reused here so the CLI
+            # enforces what the docs already ask a human to check.
+            if pgrep -f "qs -c aphotic" >/dev/null 2>&1; then
+                aphotic_warn "a quickshell daemon is already running -- use 'aphotic reload' to restart it, not 'aphotic shell' again"
+                return 1
+            fi
             aphotic_log "starting quickshell daemon (qs -c aphotic)..."
             nohup qs -c aphotic >>"${APHOTIC_STATE_HOME}/shell.log" 2>&1 &
             disown


### PR DESCRIPTION
## What this changes

Ran every top-level `aphotic <cmd>` with no args to check for crashes or surprising behavior (per request). Found and fixed two real bugs live during the audit itself, plus rebuilt `aphotic ai profile` which had never actually worked on any machine.

## Scope

- [x] Scoped to CLI fixes only (`Configs/.local/lib/aphotic/commands/*.sh`)
- [x] Related README.md Roadmap item: N/A (bug fixes)
- [x] Does not touch `install.sh` or a systemd unit -- no dev-VM validation needed

## Verification

- `bash -n` clean on all four touched files
- `pytest tests/` -- 18/18 pass (unrelated but confirms nothing broke)
- Live-tested `aphotic shell` no-args: now warns instead of spawning a duplicate daemon
- Live-tested `aphotic ai profile ollama:llama3.1:8b` and an invalid name: correct file written / correct rejection, restored to the real active provider afterward
- `aphotic sddm sync` fix addresses a real Permission Denied hit during this exact audit session

## Anything the reviewer should know

Found while auditing, not by reasoning about the code: `aphotic shell` (no args) genuinely spawned a second quickshell daemon on top of the systemd-managed one, visible as two bars on screen. Caught and killed immediately; this PR is the real fix.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_0176UGX4Gnp4g3oKr8U6Trf9