### PR TITLE
Dock bar style: add scroll-to-volume and real status icons

### DIFF
--- a/Configs/quickshell/aphotic/modules/bar/DockBar.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockBar.qml
@@ -83,6 +83,17 @@ Item {
     // occlusion check isn't available cheaply via Hyprland's IPC.
     readonly property bool shouldShow: !Settings.dockAutoHide || !Hypr.activeToplevel || hoverHandler.hovered
 
+    // Was entirely absent -- Dock silently lost scroll-to-volume that
+    // every other bar style has (Full/Taskbar/Minimal all define this
+    // identically). Real feature gap, not a design choice like Minimal's
+    // deliberately sparse icon set -- fixed to match.
+    function handleWheel(pos: real, angleDelta: point): void {
+        if (angleDelta.y > 0)
+            Audio.incrementVolume();
+        else if (angleDelta.y < 0)
+            Audio.decrementVolume();
+    }
+
     implicitWidth: pill.width
     implicitHeight: pill.height
     width: Math.max(implicitWidth, hoverTarget.width)
@@ -229,6 +240,21 @@ Item {
             DockWorkspaces {
                 Layout.alignment: Qt.AlignCenter
                 screen: root.screen
+            }
+
+            // Was entirely absent -- Dock silently dropped battery/
+            // network/bluetooth/VPN visibility with no design rationale
+            // documented anywhere (unlike Minimal, whose sparse icon set
+            // is a deliberate, commented design choice). Hover popouts
+            // for these icons don't work here yet (Dock has no
+            // checkPopout/popout-positioning support at all -- a
+            // separate, larger feature gap, already tracked in
+            // docs/ROADMAP.md's Bar section), but the icons themselves
+            // showing real status is the actual "silently lost
+            // information" gap being fixed here.
+            StatusIcons {
+                Layout.alignment: Qt.AlignCenter
+                screenState: root.screenState
             }
 
             Clock {


### PR DESCRIPTION
## What this changes

Last of this session's queued ledger items. Two real, confirmed gaps in the Dock bar style, scoped down from the original "full Dock/Minimal parity" ask after checking whether Minimal's own sparse icon set (a deliberate, already-documented design choice) should change too -- decided (with the user) to leave Minimal alone and only fix Dock.

- Dock had no scroll-to-volume (`handleWheel`); every other bar style already has it.
- Dock had no status icon cluster (battery/network/bluetooth/VPN) at all, with no documented rationale for the gap (unlike Minimal).

## Scope

- [x] Scoped to `DockBar.qml`
- [x] Related README.md Roadmap item: Bar section (Dock/Minimal parity)
- [x] Does not touch install.sh or a systemd unit -- no dev-VM validation needed

## Verification

- `pytest tests/` -- 18/18 pass
- Live: switched to dock style, confirmed via `hyprctl layers` the window was present/correctly sized, then a precisely-cropped screenshot confirmed the pill renders correctly (app icons, workspaces, the new StatusIcons cluster, clock, tray), no QML errors. Restored to `full` afterward.

## Anything the reviewer should know

Hover popouts for the new status icons don't work on Dock yet -- it has no `checkPopout`/popout-positioning support at all. Deliberately not attempted here given the bar/popout hover mechanism was the subject of a whole separate investigation earlier this session (one round of which shipped a real regression). Still tracked as a real, larger, separate feature gap in `docs/ROADMAP.md`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_0176UGX4Gnp4g3oKr8U6Trf9