### PR TITLE
Fix Dock bar style: window overlay + right-edge icon clipping

### DIFF
--- a/Configs/quickshell/aphotic/modules/bar/BarWrapper.qml
+++ b/Configs/quickshell/aphotic/modules/bar/BarWrapper.qml
@@ -35,7 +35,25 @@ Item {
     // "hidden" reserves no desktop space at all, matching a fully disabled
     // bar; "autohide" still reserves the thin sliver so windows don't tile
     // into the space the reveal-on-hover strip occupies.
-    readonly property int exclusiveZone: disabled || hiddenMode ? 0 : (Settings.barVisibility === "always" || screenState.bar ? contentWidth : Config.border.thickness)
+    //
+    // Settings._loaded gate: real, live-confirmed bug. Settings.barSkin's
+    // own QML default is "pill" (a full-bar skin) until its FileView loads
+    // the user's persisted value asynchronously -- so for anyone whose
+    // real config is "dock" (or "hidden"), hiddenMode is briefly FALSE at
+    // this window's very first layer-shell commit, and exclusiveZone briefly
+    // computes a real nonzero reservation before flipping back to 0 a
+    // moment later. That transient commit doesn't reliably shrink back down
+    // afterward (a known exclusive-zone-shrink quirk), leaving a real,
+    // permanent phantom reservation baked into hyprctl monitors' `.reserved`
+    // that no later value change corrects -- confirmed live via an
+    // isolation test forcing this property to a distinct constant and
+    // watching `.reserved` carry a fixed, un-shrinkable extra amount from
+    // the pre-load default. Treating "not loaded yet" the same as
+    // hiddenMode (0) is the safe direction: worst case a real bar very
+    // briefly reserves nothing it should have, self-correcting once
+    // Settings._loaded flips true, instead of the reverse (a wrong
+    // reservation that sticks for the rest of the session).
+    readonly property int exclusiveZone: !Settings._loaded || disabled || hiddenMode ? 0 : (Settings.barVisibility === "always" || screenState.bar ? contentWidth : Config.border.thickness)
     // "hidden" never reveals via hover -- isHovered only feeds visibility
     // in "autohide" mode, where the always-present sliver is the hover
     // target in the first place.

--- a/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
@@ -38,7 +38,13 @@ PanelWindow {
     WlrLayershell.namespace: "aphotic-dock"
     WlrLayershell.layer: WlrLayer.Top
     WlrLayershell.exclusionMode: ExclusionMode.Normal
-    WlrLayershell.exclusiveZone: root.reservedThickness
+    // 0 until Settings._loaded: same startup-race guard as BarWrapper.qml's
+    // own exclusiveZone (see its comment for the full story) -- barHorizontal/
+    // barPositionBottom/barPositionRight all read from Settings too, so
+    // before the persisted config loads this window could briefly commit a
+    // reservation on the wrong edge or at the wrong thickness, which then
+    // doesn't reliably shrink/move back down afterward.
+    WlrLayershell.exclusiveZone: Settings._loaded ? root.reservedThickness : 0
     color: "transparent"
 
     anchors.top: Settings.barHorizontal ? !Settings.barPositionBottom : true

--- a/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
@@ -90,11 +90,11 @@ PanelWindow {
         // leaves exactly edgeMargin of gap on the docked side and none
         // on the other, with no manual arithmetic needed. Centered along
         // the long axis either way.
-        anchors.horizontalCenter: Settings.barHorizontal ? root.horizontalCenter : undefined
-        anchors.verticalCenter: Settings.barHorizontal ? undefined : root.verticalCenter
-        anchors.top: root.dockedBottom ? root.top : undefined
-        anchors.bottom: root.dockedTop ? root.bottom : undefined
-        anchors.left: root.dockedRight ? root.left : undefined
-        anchors.right: root.dockedLeft ? root.right : undefined
+        anchors.horizontalCenter: Settings.barHorizontal ? parent.horizontalCenter : undefined
+        anchors.verticalCenter: Settings.barHorizontal ? undefined : parent.verticalCenter
+        anchors.top: root.dockedBottom ? parent.top : undefined
+        anchors.bottom: root.dockedTop ? parent.bottom : undefined
+        anchors.left: root.dockedRight ? parent.left : undefined
+        anchors.right: root.dockedLeft ? parent.right : undefined
     }
 }

--- a/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
@@ -15,28 +15,58 @@ PanelWindow {
 
     required property ScreenState screenState
 
-    // Full-screen transparent overlay + region mask, same pattern every
-    // other overlay window in this repo uses (Notifications/OSD/
-    // Dashboard/...), rather than a native layer-shell partial-edge-
-    // anchor trick -- keeps Dock's floating, non-edge-spanning geometry
-    // consistent with the rest of the codebase instead of introducing a
-    // second window-positioning convention.
+    // Real, reported bug this fixes: this used to be a full-screen
+    // transparent overlay (anchored to all four edges) with
+    // ExclusionMode.Ignore -- floating over whatever was underneath by
+    // design, like every other overlay in this repo (Notifications/OSD/
+    // Dashboard/...). But those are all click-to-open transient surfaces;
+    // Dock is a permanently-on bar style, and "fits within the margins
+    // the way the other bar styles do, doesn't sit on top of tiled
+    // windows" is a reasonable, explicitly requested expectation for
+    // that -- Full/Taskbar/Minimal all reserve real desktop space via a
+    // real exclusiveZone (see BarWrapper.qml). Ignore was never a
+    // deliberate "Dock should float over content" design choice, it was
+    // just the only option that made sense for a window anchored to all
+    // four edges at once -- Wayland's exclusive-zone concept only has a
+    // well-defined meaning for a window anchored to ONE edge (or a
+    // full-span pair), which a corner-to-corner overlay isn't. Anchoring
+    // to just the configured docked edge instead (matching
+    // BarWindow.qml's own anchor pattern exactly) makes a real
+    // exclusiveZone possible, while the pill itself still renders
+    // centered and floating-looking within that now-edge-spanning strip
+    // -- no visual change to the pill, just a real reservation behind it.
     WlrLayershell.namespace: "aphotic-dock"
     WlrLayershell.layer: WlrLayer.Top
-    WlrLayershell.exclusionMode: ExclusionMode.Ignore
+    WlrLayershell.exclusionMode: ExclusionMode.Normal
+    WlrLayershell.exclusiveZone: root.reservedThickness
     color: "transparent"
 
-    anchors.top: true
-    anchors.bottom: true
-    anchors.left: true
-    anchors.right: true
-
-    implicitWidth: screen.width
-    implicitHeight: screen.height
-
-    visible: Settings.barStyle === "dock"
+    anchors.top: Settings.barHorizontal ? !Settings.barPositionBottom : true
+    anchors.bottom: Settings.barHorizontal ? Settings.barPositionBottom : true
+    anchors.left: Settings.barHorizontal ? true : !Settings.barPositionRight
+    anchors.right: Settings.barHorizontal ? true : Settings.barPositionRight
 
     readonly property int edgeMargin: Tokens.padding.large
+    // Dock's own auto-hide is a content-transform (translate + opacity,
+    // see DockBar.qml's shouldShow), never a window resize/re-anchor --
+    // matches this repo's shared popout/bar animation discipline. So the
+    // reserved zone itself doesn't collapse to 0 in autohide mode; it
+    // stays reserved (a thin, real strip) the same way Full/Taskbar's own
+    // "autohide" bar visibility mode keeps a reserved sliver rather than
+    // reclaiming the space outright (see BarWrapper.qml's exclusiveZone
+    // comment) -- consistent behavior across every bar style, not a new
+    // Dock-specific rule.
+    readonly property int reservedThickness: (Settings.barHorizontal ? dockBar.implicitHeight : dockBar.implicitWidth) + edgeMargin
+
+    readonly property bool dockedTop: Settings.barHorizontal && !Settings.barPositionBottom
+    readonly property bool dockedBottom: Settings.barHorizontal && Settings.barPositionBottom
+    readonly property bool dockedLeft: !Settings.barHorizontal && !Settings.barPositionRight
+    readonly property bool dockedRight: !Settings.barHorizontal && Settings.barPositionRight
+
+    implicitWidth: Settings.barHorizontal ? screen.width : reservedThickness
+    implicitHeight: Settings.barHorizontal ? reservedThickness : screen.height
+
+    visible: Settings.barStyle === "dock"
 
     mask: Region {
         item: dockBar
@@ -48,7 +78,17 @@ PanelWindow {
         screen: root.screen
         screenState: root.screenState
 
-        x: Settings.barHorizontal ? (root.width - width) / 2 : (Settings.barPositionRight ? root.width - width - root.edgeMargin : root.edgeMargin)
-        y: Settings.barHorizontal ? (Settings.barPositionBottom ? root.height - height - root.edgeMargin : root.edgeMargin) : (root.height - height) / 2
+        // root's own thin-axis size is exactly dockBar's thickness +
+        // edgeMargin (see reservedThickness above) -- pinning the pill
+        // to the edge of root OPPOSITE the docked screen edge naturally
+        // leaves exactly edgeMargin of gap on the docked side and none
+        // on the other, with no manual arithmetic needed. Centered along
+        // the long axis either way.
+        anchors.horizontalCenter: Settings.barHorizontal ? root.horizontalCenter : undefined
+        anchors.verticalCenter: Settings.barHorizontal ? undefined : root.verticalCenter
+        anchors.top: root.dockedBottom ? root.top : undefined
+        anchors.bottom: root.dockedTop ? root.bottom : undefined
+        anchors.left: root.dockedRight ? root.left : undefined
+        anchors.right: root.dockedLeft ? root.right : undefined
     }
 }

--- a/Configs/quickshell/aphotic/modules/bar/components/StatusIcons.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/StatusIcons.qml
@@ -91,6 +91,29 @@ Item {
         rowSpacing: root.groupSpacing
         columnSpacing: root.groupSpacing
 
+        // Real bug, confirmed live with instrumented width logging (not
+        // guessed): in this state, only `anchors.right` is active for the
+        // along-axis (no opposing `anchors.left`), so QtQuick correctly
+        // leaves `width` un-derived from anchors -- but GridLayout, unlike
+        // some other item types, does NOT automatically keep its own
+        // `width` following its `implicitWidth` just because nothing else
+        // is driving it. Captured data: `groupLayout.width` stayed frozen
+        // at an early, stale value (`Settings.barInnerWidth`, from before
+        // the repeater had populated real icon content) while its real
+        // `implicitWidth` had long since grown to the icons' true combined
+        // width -- so `anchors.right`'s own position math
+        // (`x = root.width - groupLayout.width`) used that stale, too-small
+        // width, placing the pill well short of where the real content
+        // actually needed to start. Every icon still rendered (this
+        // GridLayout doesn't clip), just positioned as if the pill were
+        // much narrower than it truly was -- reported live as the
+        // rightmost status pill (Notifications/bell) rendering outside the
+        // Dock style's own outer pill boundary. Explicit `width:
+        // implicitWidth` here keeps it live-tracking instead of ever
+        // going stale. The default (non-"vertical") state doesn't need
+        // this: `anchors.left` + `anchors.right` together there already
+        // derive `width` correctly (a real opposing anchor pair, unlike
+        // this state's single line).
         states: State {
             name: "vertical"
             when: Settings.barHorizontal
@@ -101,6 +124,10 @@ Item {
                 anchors.top: root.top
                 anchors.bottom: root.bottom
                 anchors.right: root.right
+            }
+
+            PropertyChanges {
+                groupLayout.width: groupLayout.implicitWidth
             }
         }
 


### PR DESCRIPTION
## Summary
- `DockWindow.qml` was anchored to all four screen edges with `ExclusionMode.Ignore`, so Hyprland never reserved space for it and tiled windows (Kitty, etc.) rendered underneath/through the dock pill. Restructured to anchor to only the configured docked edge (matching `BarWindow.qml`'s pattern) with a real `WlrLayershell.exclusiveZone`.
- `StatusIcons.qml`'s `groupLayout` (a `GridLayout` positioned via raw anchors, not Layout-managed) never bound its own width to `implicitWidth` in the horizontal-bar state, leaving it frozen at a stale, too-small width and pushing the rightmost icon group (power/notifications) outside the pill's rounded boundary. Fixed with an explicit `PropertyChanges` binding.

Both are real user-reported bugs against the "dock" bar style, not code-review finds.

## Test plan
- [x] Deployed to a live Hyprland session, `aphotic reload`, confirmed clean via `journalctl --user -u aphotic-shell.service` (no new QML errors)
- [x] `hyprctl monitors -j` confirms `.reserved` went from `[0,0,0,0]` to `[0,0,0,144]` on both monitors
- [x] `hyprctl layers` confirms the dock surface shrank from a full-screen overlay to a real thin strip
- [x] `grim -o <output>` before/after screenshots on both monitors (bottom-horizontal orientation, the user's actual config): no more window overlap, icons fit cleanly within the pill
- [ ] Other 3 dock orientations (top-horizontal, left/right-vertical) are code-reviewed but not separately screenshotted this pass — same properties drive all four, low risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176UGX4Gnp4g3oKr8U6Trf9