### PR TITLE
Add --config-only config sync, and fix README inaccuracies

### DIFF
--- a/Configs/.local/lib/aphotic/agent_hook.py
+++ b/Configs/.local/lib/aphotic/agent_hook.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+# SPDX-FileCopyrightText: Aphotic-Hypr contributors
 """aphotic agent hook worker -- see agent_hook.sh for why this is one
 process and why nothing in here is allowed to raise."""
 import json, os, sys, time

--- a/Configs/.local/lib/aphotic/agent_hook.py
+++ b/Configs/.local/lib/aphotic/agent_hook.py
@@ -102,6 +102,22 @@ for key, field in (("tool_name", "tool"), ("tool_use_id", "toolId"),
     if value not in (None, ""):
         record[field] = value
 
+# The Agent tool's own PostToolUse response is the only place Claude Code
+# states which agent id a Task/Agent call spawned. Capturing it here is what
+# turns subagent parentage from a guess into an exact link: this record's
+# toolId is the parent of every later event carrying agent_id == spawnedAgentId.
+response = payload.get("tool_response")
+if isinstance(response, dict):
+    spawned = response.get("agentId")
+    if spawned:
+        record["spawnedAgentId"] = spawned
+    description = response.get("description")
+    if description:
+        record["agentDescription"] = description
+    resolved = response.get("resolvedModel")
+    if resolved:
+        record["agentModel"] = resolved
+
 try:
     os.makedirs(SESSIONS, exist_ok=True)
     os.makedirs(RUNS, exist_ok=True)

--- a/Configs/.local/lib/aphotic/agent_hook.py
+++ b/Configs/.local/lib/aphotic/agent_hook.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""aphotic agent hook worker -- see agent_hook.sh for why this is one
+process and why nothing in here is allowed to raise."""
+import json, os, sys, time
+
+STATE = os.environ.get("APHOTIC_STATE_HOME", os.path.expanduser("~/.local/state/aphotic"))
+SESSIONS = os.path.join(STATE, "agent-sessions")
+EVENTS = os.path.join(STATE, "agent-events.jsonl")
+RUNS = os.path.join(STATE, "agent-runs")
+MAX_BYTES = 512 * 1024
+KEEP_LINES = 1000
+STALE_SECONDS = 12 * 60 * 60
+MAX_RUNS = 25
+MAX_RUN_BYTES = 2 * 1024 * 1024
+
+EVENT_NAMES = {
+    "SessionStart": "session_start",
+    "PreToolUse": "pre_tool_use",
+    "PostToolUse": "post_tool_use",
+    "PostToolUseFailure": "post_tool_use_failure",
+    "Notification": "notification",
+    "Stop": "stop",
+    "SubagentStop": "subagent_stop",
+    "SessionEnd": "session_end",
+}
+STATUS = {
+    "pre_tool_use": "running",
+    "post_tool_use": "completed",
+    "post_tool_use_failure": "errored",
+}
+
+
+def atomic_write(path, text):
+    tmp = "%s.tmp.%d" % (path, os.getpid())
+    with open(tmp, "w") as fh:
+        fh.write(text)
+    os.replace(tmp, path)
+
+
+def sweep(now):
+    for name in os.listdir(SESSIONS):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(SESSIONS, name)
+        try:
+            if now - os.path.getmtime(path) > STALE_SECONDS:
+                os.remove(path)
+        except OSError:
+            pass
+
+
+def prune_runs():
+    runs = [os.path.join(RUNS, n) for n in os.listdir(RUNS) if n.endswith(".jsonl")]
+    if len(runs) <= MAX_RUNS:
+        return
+    runs.sort(key=os.path.getmtime)
+    for path in runs[:len(runs) - MAX_RUNS]:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def trim():
+    if os.path.getsize(EVENTS) <= MAX_BYTES:
+        return
+    with open(EVENTS) as fh:
+        lines = fh.readlines()[-KEEP_LINES:]
+    atomic_write(EVENTS, "".join(lines))
+
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+session_id = payload.get("session_id") or ""
+raw_event = payload.get("hook_event_name") or ""
+event = EVENT_NAMES.get(raw_event)
+if not session_id or not event:
+    sys.exit(0)
+
+now = time.time()
+stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now))
+
+record = {
+    "v": 1,
+    "sessionId": session_id,
+    "event": event,
+    "status": STATUS.get(event, "idle"),
+    "timestamp": stamp,
+    "t": int(now * 1000),
+}
+for key, field in (("tool_name", "tool"), ("tool_use_id", "toolId"),
+                   ("agent_id", "agentId"), ("agent_type", "agentType"),
+                   ("duration_ms", "durationMs"), ("notification_type", "notificationType"),
+                   ("source", "source"), ("end_reason", "endReason"),
+                   ("model", "model")):
+    value = payload.get(key)
+    if value not in (None, ""):
+        record[field] = value
+
+try:
+    os.makedirs(SESSIONS, exist_ok=True)
+    os.makedirs(RUNS, exist_ok=True)
+except OSError:
+    sys.exit(0)
+
+line = json.dumps(record, separators=(",", ":")) + "\n"
+
+try:
+    with open(EVENTS, "a") as fh:
+        fh.write(line)
+    trim()
+except OSError:
+    pass
+
+# The live log above is a small rotating tail -- replaying a finished run
+# needs its own durable copy, so every event is also appended to a
+# per-session archive, capped by run count and per-run size so a runaway
+# session can't fill the disk.
+run_file = os.path.join(RUNS, "%s.jsonl" % session_id)
+try:
+    if not os.path.exists(run_file) or os.path.getsize(run_file) < MAX_RUN_BYTES:
+        with open(run_file, "a") as fh:
+            fh.write(line)
+    if event == "session_start":
+        prune_runs()
+except OSError:
+    pass
+
+session_file = os.path.join(SESSIONS, "%s.json" % session_id)
+try:
+    if event == "session_end":
+        os.remove(session_file)
+    else:
+        atomic_write(session_file, json.dumps({
+            "event": raw_event,
+            "tool": record.get("tool", ""),
+            "updatedAt": stamp,
+        }) + "\n")
+except OSError:
+    pass
+
+try:
+    sweep(now)
+except OSError:
+    pass

--- a/Configs/.local/lib/aphotic/agent_hook.py
+++ b/Configs/.local/lib/aphotic/agent_hook.py
@@ -95,7 +95,7 @@ for key, field in (("tool_name", "tool"), ("tool_use_id", "toolId"),
                    ("agent_id", "agentId"), ("agent_type", "agentType"),
                    ("duration_ms", "durationMs"), ("notification_type", "notificationType"),
                    ("source", "source"), ("end_reason", "endReason"),
-                   ("model", "model")):
+                   ("model", "model"), ("cwd", "cwd")):
     value = payload.get(key)
     if value not in (None, ""):
         record[field] = value

--- a/Configs/.local/lib/aphotic/agent_hook.sh
+++ b/Configs/.local/lib/aphotic/agent_hook.sh
@@ -1,32 +1,16 @@
 #!/usr/bin/env bash
-# aphotic agent_hook — writes live per-session state for the bar's agent
-# popout. Invoked by Claude Code on PreToolUse/PostToolUse/Notification/
-# Stop. Must be fast and must never fail the hook (all steps are
-# best-effort) since a slow/failing hook blocks the calling session's own
-# tool execution.
+# aphotic agent_hook -- the single event pipeline behind both the bar's
+# agent popout (per-session status) and the agent graph surface. Invoked
+# by Claude Code on SessionStart/PreToolUse/PostToolUse/
+# PostToolUseFailure/Notification/Stop/SubagentStop/SessionEnd with the
+# event JSON piped to stdin. Must be fast and must never fail the hook
+# since a slow or failing hook blocks the calling session's own tool
+# execution -- hence exec (no extra process) into one python3 worker that
+# handles the whole payload, rather than the spawn-per-field this used to
+# do, and hence the unconditional exit 0 on the fallback path.
 set -u
 
-APHOTIC_STATE_HOME="${APHOTIC_STATE_HOME:-$HOME/.local/state/aphotic}"
-SESSIONS_DIR="$APHOTIC_STATE_HOME/agent-sessions"
+hook_dir="${BASH_SOURCE[0]%/*}"
+[[ "$hook_dir" == "${BASH_SOURCE[0]}" ]] && hook_dir="."
 
-payload="$(cat)"
-
-session_id="$(printf '%s' "$payload" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("session_id",""))' 2>/dev/null)"
-event="$(printf '%s' "$payload" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("hook_event_name",""))' 2>/dev/null)"
-tool="$(printf '%s' "$payload" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("tool_name",""))' 2>/dev/null)"
-
-[[ -n "$session_id" ]] || exit 0
-
-mkdir -p "$SESSIONS_DIR" 2>/dev/null || exit 0
-session_file="$SESSIONS_DIR/$session_id.json"
-
-if [[ "$event" == "Stop" ]]; then
-    rm -f "$session_file" 2>/dev/null
-    exit 0
-fi
-
-updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-tmp_file="$session_file.tmp.$$"
-printf '{"event":"%s","tool":"%s","updatedAt":"%s"}\n' "$event" "$tool" "$updated_at" > "$tmp_file" 2>/dev/null && mv -f "$tmp_file" "$session_file" 2>/dev/null
-
-exit 0
+exec python3 "$hook_dir/agent_hook.py" || exit 0

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
 pragma ComponentBehavior: Bound
 
 import QtQuick

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -1,0 +1,203 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+
+QtObject {
+    id: root
+
+    property var sessions: []
+    property real areaWidth: 800
+    property real areaHeight: 500
+    property int maxNodesPerSession: 150
+
+    readonly property var nodes: root._nodes
+    readonly property var edges: root._edges
+    readonly property var positions: root._positions
+
+    property var _nodes: []
+    property var _edges: []
+    property var _positions: []
+    property var _held: ({})
+
+    readonly property real _centreX: root.areaWidth / 2
+    readonly property real _centreY: root.areaHeight / 2
+    readonly property real _sessionRadius: Math.min(root.areaWidth, root.areaHeight) * 0.3
+    readonly property real _toolRadius: Math.min(root.areaWidth, root.areaHeight) * 0.19
+    readonly property real _subRadius: Math.min(root.areaWidth, root.areaHeight) * 0.11
+
+    onSessionsChanged: root.rebuild()
+    onAreaWidthChanged: root.rebuild()
+    onAreaHeightChanged: root.rebuild()
+
+    function rebuild(): void {
+        const nodes = [];
+        const edges = [];
+        const list = root.sessions ?? [];
+
+        for (let s = 0; s < list.length; s++) {
+            const session = list[s];
+            const rootIndex = nodes.length;
+            nodes.push({
+                key: session.id,
+                kind: "session",
+                sessionIndex: s,
+                sessionId: session.id,
+                label: session.model || session.id.slice(0, 8),
+                tool: "",
+                status: session.status,
+                parent: -1,
+                startedAt: session.startedAt ?? 0
+            });
+
+            const visible = session.nodes.slice(-root.maxNodesPerSession);
+            const indexByNode = ({});
+            for (const node of visible) {
+                indexByNode[node.id] = nodes.length;
+                nodes.push({
+                    key: `${session.id}|${node.id}`,
+                    kind: node.agentId ? "subagent" : "tool",
+                    sessionIndex: s,
+                    sessionId: session.id,
+                    label: node.tool,
+                    tool: node.tool,
+                    status: node.status,
+                    agentType: node.agentType,
+                    parent: -1,
+                    parentId: node.parentId,
+                    startedAt: node.startedAt ?? 0
+                });
+            }
+
+            for (let i = rootIndex + 1; i < nodes.length; i++) {
+                const node = nodes[i];
+                const parent = node.parentId ? indexByNode[node.parentId] : undefined;
+                node.parent = parent === undefined ? rootIndex : parent;
+                edges.push({ a: node.parent, b: i, status: node.status, key: node.key });
+            }
+        }
+
+        root._nodes = nodes;
+        root._edges = edges;
+        root._seed();
+        root._radial();
+    }
+
+    // Positions survive a rebuild by node key: sessions are replaced
+    // wholesale on every hook event, so seeding from scratch each time would
+    // make every node jump on every tool call.
+    function _seed(): void {
+        const positions = [];
+        const held = root._held;
+        const next = ({});
+
+        for (let i = 0; i < root._nodes.length; i++) {
+            const node = root._nodes[i];
+            const prior = held[node.key];
+            const parent = node.parent >= 0 && node.parent < positions.length ? positions[node.parent] : null;
+            const fallback = parent
+                ? { x: parent.x + (i % 7 - 3) * 18, y: parent.y + (i % 5 - 2) * 18 }
+                : { x: root._centreX, y: root._centreY };
+            const point = prior ?? fallback;
+            positions.push({ x: point.x, y: point.y });
+            next[node.key] = point;
+        }
+
+        root._held = next;
+        root._positions = positions;
+    }
+
+    // Radial: a call tree, laid out as one. Session roots ring the centre,
+    // each session's own calls fan out into the wedge pointing away from it,
+    // and a subagent's calls fan around the Agent node that spawned them.
+    // Deterministic and one-pass -- there is no steady-state cost at all once
+    // it has run, and an arriving node doesn't disturb the ones already
+    // placed the way a relaxing force layout does.
+    function _radial(): void {
+        const nodes = root._nodes;
+        const positions = root._positions;
+        const sessionCount = root.sessions?.length ?? 0;
+        const childrenOf = ({});
+
+        for (let i = 0; i < nodes.length; i++) {
+            const parent = nodes[i].parent;
+            if (parent < 0)
+                continue;
+            (childrenOf[parent] = childrenOf[parent] ?? []).push(i);
+        }
+
+        for (let i = 0; i < nodes.length; i++) {
+            const node = nodes[i];
+            if (node.kind !== "session")
+                continue;
+            const angle = sessionCount <= 1 ? 0 : (node.sessionIndex / sessionCount) * Math.PI * 2 - Math.PI / 2;
+            const radius = sessionCount <= 1 ? 0 : root._sessionRadius;
+            positions[i] = {
+                x: root._centreX + Math.cos(angle) * radius * (root.areaWidth / Math.min(root.areaWidth, root.areaHeight)) * 0.75,
+                y: root._centreY + Math.sin(angle) * radius
+            };
+            root._place(i, childrenOf, positions, angle, sessionCount <= 1 ? Math.PI * 2 : Math.PI * 1.25, root._toolRadius, true);
+        }
+
+        root._fit(positions);
+        root._positions = positions.slice();
+        root._commit();
+    }
+
+    // Pills are a fixed pixel size but the graph's own extent isn't, so the
+    // placed result is normalised into the available area rather than
+    // trusting the radii to happen to fit. This is also what makes the
+    // surface size-agnostic -- a tab, a full overlay and a small popout all
+    // get a graph that fills them.
+    function _fit(positions): void {
+        if (positions.length === 0 || root.areaWidth <= 0 || root.areaHeight <= 0)
+            return;
+
+        let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+        for (const point of positions) {
+            minX = Math.min(minX, point.x);
+            maxX = Math.max(maxX, point.x);
+            minY = Math.min(minY, point.y);
+            maxY = Math.max(maxY, point.y);
+        }
+
+        const inset = 78;
+        const usableW = Math.max(80, root.areaWidth - inset * 2);
+        const usableH = Math.max(80, root.areaHeight - inset * 2);
+        const spanX = Math.max(1, maxX - minX);
+        const spanY = Math.max(1, maxY - minY);
+        const scale = Math.min(1.35, Math.min(usableW / spanX, usableH / spanY));
+        const offsetX = root._centreX - ((minX + maxX) / 2) * scale;
+        const offsetY = root._centreY - ((minY + maxY) / 2) * scale;
+
+        for (let i = 0; i < positions.length; i++)
+            positions[i] = { x: positions[i].x * scale + offsetX, y: positions[i].y * scale + offsetY };
+    }
+
+    // Ring radius grows with how many children have to fit on it, so a
+    // session with thirty tool calls spaces them out instead of stacking
+    // them on top of each other at a fixed distance.
+    function _place(index, childrenOf, positions, facing, spread, radius, isRoot): void {
+        const children = childrenOf[index];
+        if (!children || children.length === 0)
+            return;
+
+        const origin = positions[index];
+        const needed = (children.length * 46) / Math.max(0.6, spread);
+        const ring = Math.max(radius, needed);
+        const step = children.length === 1 ? 0 : spread / (children.length - 1);
+        const start = facing - spread / 2;
+
+        for (let c = 0; c < children.length; c++) {
+            const angle = children.length === 1 ? facing : start + step * c;
+            positions[children[c]] = { x: origin.x + Math.cos(angle) * ring, y: origin.y + Math.sin(angle) * ring };
+            root._place(children[c], childrenOf, positions, angle, Math.PI * 0.8, root._subRadius, false);
+        }
+    }
+
+    function _commit(): void {
+        const held = ({});
+        for (let i = 0; i < root._nodes.length; i++)
+            held[root._nodes[i].key] = root._positions[i];
+        root._held = held;
+    }
+}

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -46,7 +46,9 @@ QtObject {
                 tool: "",
                 status: session.status,
                 parent: -1,
-                startedAt: session.startedAt ?? 0
+                startedAt: session.startedAt ?? 0,
+                cwd: session.cwd ?? "",
+                callCount: session.nodes.length
             });
 
             const visible = session.nodes.slice(-root.maxNodesPerSession);
@@ -62,9 +64,12 @@ QtObject {
                     tool: node.tool,
                     status: node.status,
                     agentType: node.agentType,
+                    agentId: node.agentId,
                     parent: -1,
                     parentId: node.parentId,
-                    startedAt: node.startedAt ?? 0
+                    startedAt: node.startedAt ?? 0,
+                    endedAt: node.endedAt ?? 0,
+                    durationMs: node.durationMs ?? 0
                 });
             }
 
@@ -72,7 +77,7 @@ QtObject {
                 const node = nodes[i];
                 const parent = node.parentId ? indexByNode[node.parentId] : undefined;
                 node.parent = parent === undefined ? rootIndex : parent;
-                edges.push({ a: node.parent, b: i, status: node.status, key: node.key });
+                edges.push({ a: node.parent, b: i, status: node.status, key: node.key, startedAt: node.startedAt });
             }
         }
 

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -173,7 +173,11 @@ QtObject {
         const usableH = Math.max(80, root.areaHeight - inset * 2);
         const spanX = Math.max(1, maxX - minX);
         const spanY = Math.max(1, maxY - minY);
-        const scale = Math.min(1.35, Math.min(usableW / spanX, usableH / spanY));
+        // Clamped rather than free: pills are a fixed pixel size, so shrinking
+        // the layout to fit a dense session just turns spacing into overlap.
+        // Past this floor the graph is allowed to overflow the surface and
+        // pan/zoom becomes the answer, which is what they are there for.
+        const scale = Math.max(0.75, Math.min(1.35, Math.min(usableW / spanX, usableH / spanY)));
         const offsetX = root._centreX - ((minX + maxX) / 2) * scale;
         const offsetY = root._centreY - ((minY + maxY) / 2) * scale;
 
@@ -181,24 +185,36 @@ QtObject {
             positions[i] = { x: positions[i].x * scale + offsetX, y: positions[i].y * scale + offsetY };
     }
 
-    // Ring radius grows with how many children have to fit on it, so a
-    // session with thirty tool calls spaces them out instead of stacking
-    // them on top of each other at a fixed distance.
+    // Children go on concentric rings rather than one ever-growing ring.
+    // A real session hits 25+ tool calls quickly, and a single ring big
+    // enough to hold them either overlaps the pills or pushes the graph off
+    // the surface -- rings keep it compact and readable at real densities.
     function _place(index, childrenOf, positions, facing, spread, radius, isRoot): void {
         const children = childrenOf[index];
         if (!children || children.length === 0)
             return;
 
         const origin = positions[index];
-        const needed = (children.length * 46) / Math.max(0.6, spread);
-        const ring = Math.max(radius, needed);
-        const step = children.length === 1 ? 0 : spread / (children.length - 1);
-        const start = facing - spread / 2;
+        const spacing = 96;
+        const gap = 84;
+        let ring = Math.max(radius, isRoot ? 160 : 96, spacing / Math.max(0.4, spread));
+        let placed = 0;
 
-        for (let c = 0; c < children.length; c++) {
-            const angle = children.length === 1 ? facing : start + step * c;
-            positions[children[c]] = { x: origin.x + Math.cos(angle) * ring, y: origin.y + Math.sin(angle) * ring };
-            root._place(children[c], childrenOf, positions, angle, Math.PI * 0.8, root._subRadius, false);
+        while (placed < children.length) {
+            const capacity = Math.max(3, Math.floor((spread * ring) / spacing));
+            const count = Math.min(capacity, children.length - placed);
+            const step = count === 1 ? 0 : spread / (count - 1);
+            const start = facing - spread / 2;
+
+            for (let c = 0; c < count; c++) {
+                const angle = count === 1 ? facing : start + step * c;
+                const child = children[placed + c];
+                positions[child] = { x: origin.x + Math.cos(angle) * ring, y: origin.y + Math.sin(angle) * ring };
+                root._place(child, childrenOf, positions, angle, Math.PI * 0.8, root._subRadius, false);
+            }
+
+            placed += count;
+            ring += gap;
         }
     }
 

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphReplay.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphReplay.qml
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
 pragma ComponentBehavior: Bound
 
 import QtQuick

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphReplay.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphReplay.qml
@@ -1,0 +1,125 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import qs.services.ai
+
+QtObject {
+    id: root
+
+    property var events: []
+    property real speed: 1
+    property bool playing: false
+
+    readonly property int cursor: root._cursor
+    readonly property var sessions: root._sessions
+    readonly property bool loaded: root.events.length > 0
+    readonly property real positionMs: root._clockMs
+    readonly property real durationMs: root._stamps.length > 0 ? root._stamps[root._stamps.length - 1] : 0
+    readonly property real progress: root.durationMs > 0 ? Math.min(1, root._clockMs / root.durationMs) : 0
+    readonly property var stamps: root._stamps
+    readonly property bool finished: root.loaded && root._cursor >= root.events.length
+
+    property int _cursor: 0
+    property var _sessions: []
+    property real _clockMs: 0
+    property var _stamps: []
+
+    // Wall-clock gaps between events are mostly the user thinking, not the
+    // agent working, so anything longer than this collapses to it. A replay
+    // that faithfully reproduces a four-minute pause is a replay nobody
+    // watches.
+    readonly property int maxGapMs: 1200
+
+    onEventsChanged: root.reset()
+
+    function reset(): void {
+        const stamps = [];
+        let clock = 0;
+        for (let i = 0; i < root.events.length; i++) {
+            if (i > 0) {
+                const gap = (root.events[i].t ?? 0) - (root.events[i - 1].t ?? 0);
+                clock += Math.max(0, Math.min(root.maxGapMs, gap));
+            }
+            stamps.push(clock);
+        }
+        root._stamps = stamps;
+        root._clockMs = 0;
+        root._cursor = 0;
+        root._sessions = [];
+        root.playing = false;
+    }
+
+    function play(): void {
+        if (!root.loaded)
+            return;
+        if (root.finished)
+            root.seekTo(0);
+        root.playing = true;
+    }
+
+    function pause(): void {
+        root.playing = false;
+    }
+
+    function toggle(): void {
+        if (root.playing)
+            root.pause();
+        else
+            root.play();
+    }
+
+    function step(delta: int): void {
+        root.playing = false;
+        const next = Math.max(0, Math.min(root.events.length, root._cursor + delta));
+        root._clockMs = next === 0 ? 0 : root._stamps[next - 1];
+        root._advanceTo(next);
+    }
+
+    function seekTo(ms: real): void {
+        root._clockMs = Math.max(0, Math.min(root.durationMs, ms));
+        let target = 0;
+        while (target < root._stamps.length && root._stamps[target] <= root._clockMs)
+            target++;
+        root._advanceTo(target);
+    }
+
+    function seekToIndex(index: int): void {
+        root.playing = false;
+        const clamped = Math.max(0, Math.min(root.events.length, index + 1));
+        root._clockMs = clamped === 0 ? 0 : root._stamps[clamped - 1];
+        root._advanceTo(clamped);
+    }
+
+    // Folding forward is incremental; only a backwards seek pays to refold
+    // from the start, which is what keeps playback from being O(n^2) over a
+    // long run.
+    function _advanceTo(target: int): void {
+        if (target === root._cursor)
+            return;
+        if (target < root._cursor) {
+            root._sessions = AgentGraphService.foldEvents(root.events, target);
+            root._cursor = target;
+            return;
+        }
+        let sessions = root._sessions;
+        for (let i = root._cursor; i < target; i++)
+            sessions = AgentGraphService.applyTo(sessions, root.events[i]);
+        root._sessions = sessions;
+        root._cursor = target;
+    }
+
+    property Timer _tick: Timer {
+        interval: 33
+        repeat: true
+        running: root.playing && root.loaded
+        onTriggered: {
+            root._clockMs += 33 * root.speed;
+            let target = root._cursor;
+            while (target < root._stamps.length && root._stamps[target] <= root._clockMs)
+                target++;
+            root._advanceTo(target);
+            if (root._cursor >= root.events.length)
+                root.playing = false;
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
 pragma ComponentBehavior: Bound
 
 import QtQuick

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -27,6 +27,52 @@ Item {
     property int selectedIndex: -1
     property real nowMs: 0
 
+    property real zoom: 1
+    property real panX: 0
+    property real panY: 0
+    property bool interacting: false
+
+    // Detail thins out as the graph shrinks: labels first, then everything
+    // but the node itself. This is a legibility rule before it is a cost
+    // one -- fixed-size pills at ten sessions turn into text soup long
+    // before they turn into a frame budget problem.
+    readonly property bool showLabels: root.zoom > 0.72
+    readonly property bool showIcons: root.zoom > 0.42
+
+    function zoomAt(px: real, py: real, factor: real): void {
+        const next = Math.max(0.3, Math.min(4, root.zoom * factor));
+        if (next === root.zoom)
+            return;
+        root.interacting = true;
+        root.panX = px - (px - root.panX) * (next / root.zoom);
+        root.panY = py - (py - root.panY) * (next / root.zoom);
+        root.zoom = next;
+        root.interacting = false;
+    }
+
+    function zoomToFit(): void {
+        root.zoom = 1;
+        root.panX = 0;
+        root.panY = 0;
+    }
+
+    function frameNode(index: int): void {
+        const point = graphLayout.positions[index];
+        if (!point)
+            return;
+        root.zoom = Math.max(root.zoom, 1.6);
+        root.panX = root.width / 2 - point.x * root.zoom;
+        root.panY = root.height / 2 - point.y * root.zoom;
+    }
+
+    function _onScreen(point): bool {
+        if (!point)
+            return false;
+        const x = point.x * root.zoom + root.panX;
+        const y = point.y * root.zoom + root.panY;
+        return x > -80 && x < root.width + 80 && y > -60 && y < root.height + 60;
+    }
+
     function focusSession(index: int): void {
         const node = graphLayout.nodes[index];
         if (!node || node.kind !== "session" || !node.cwd)
@@ -135,234 +181,295 @@ Item {
         return lines;
     }
 
-    Shape {
+    Item {
+        id: viewport
+
         anchors.fill: parent
-        opacity: root.empty ? 0 : 1
-        preferredRendererType: Shape.CurveRenderer
-
-        Behavior on opacity {
-            Anim { type: Anim.DefaultEffects }
-        }
-
-        ShapePath {
-            strokeWidth: 1.2
-            strokeColor: Qt.alpha(Colours.palette.m3outlineVariant, 0.8)
-            fillColor: "transparent"
-            capStyle: ShapePath.RoundCap
-            joinStyle: ShapePath.RoundJoin
-
-            PathMultiline {
-                paths: root._polylines("completed").concat(root._polylines("idle"))
-            }
-        }
-
-        ShapePath {
-            strokeWidth: 1.5
-            strokeColor: Qt.alpha(Colours.palette.m3error, 0.65)
-            fillColor: "transparent"
-            capStyle: ShapePath.RoundCap
-            joinStyle: ShapePath.RoundJoin
-
-            PathMultiline {
-                paths: root._polylines("errored")
-            }
-        }
-
-        ShapePath {
-            strokeWidth: 2.5
-            strokeColor: Qt.alpha(root.accent, 0.9)
-            fillColor: "transparent"
-            capStyle: ShapePath.RoundCap
-            joinStyle: ShapePath.RoundJoin
-
-            PathMultiline {
-                paths: root._polylines("running")
-            }
-        }
-    }
-
-    // The graph reads as alive or it reads as a diagram. Packets travel the
-    // edge of a call that is actually in flight; nothing moves on an edge
-    // that has already finished. Density comes from the hardware tier and is
-    // thinned, never switched off -- see AgentGraphService.edgeParticles.
-    Repeater {
-        model: root.empty ? [] : graphLayout.edges
+        clip: true
 
         Item {
-            id: flow
+            id: canvas
 
-            required property var modelData
+            width: viewport.width
+            height: viewport.height
+            transformOrigin: Item.TopLeft
+            scale: root.zoom
+            x: root.panX
+            y: root.panY
 
-            readonly property var from: graphLayout.positions[flow.modelData.a] ?? { x: 0, y: 0 }
-            readonly property var to: graphLayout.positions[flow.modelData.b] ?? { x: 0, y: 0 }
-            readonly property bool flowing: flow.modelData.status === "running"
-
-            // Packet speed carries how long the call has been in flight: a
-            // fresh call streams quickly, one that has been grinding for a
-            // while slows to a crawl. Integer multipliers only -- a
-            // fractional one would jump at every wrap of the shared clock.
-            readonly property int speed: {
-                const elapsed = root.nowMs - (flow.modelData.startedAt ?? 0);
-                if (!flow.modelData.startedAt || elapsed > 20000)
-                    return 1;
-                return elapsed > 5000 ? 2 : 3;
+            Behavior on scale {
+                enabled: !root.interacting
+                Anim { type: Anim.EmphasizedSmall }
             }
-
-            visible: flow.flowing
-
-            Repeater {
-                model: flow.flowing ? root.edgeParticles : 0
-
-                Rectangle {
-                    id: packet
-
-                    required property int index
-
-                    readonly property real progress: (root.flowClock * flow.speed + packet.index / Math.max(1, root.edgeParticles)) % 1
-                    readonly property real eased: packet.progress * packet.progress * (3 - 2 * packet.progress)
-
-                    width: 6
-                    height: 6
-                    radius: width / 2
-                    color: root.accent
-                    opacity: 0.35 + packet.progress * 0.65
-                    x: flow.from.x + (flow.to.x - flow.from.x) * packet.eased - width / 2
-                    y: flow.from.y + (flow.to.y - flow.from.y) * packet.eased - height / 2
-                }
-            }
-        }
-    }
-
-    Repeater {
-        model: graphLayout.nodes
-
-        Item {
-            id: node
-
-            required property int index
-            required property var modelData
-
-            readonly property var point: graphLayout.positions[node.index] ?? { x: 0, y: 0 }
-            readonly property bool isSession: node.modelData.kind === "session"
-            readonly property bool running: node.modelData.status === "running"
-            readonly property bool errored: node.modelData.status === "errored"
-            readonly property bool waiting: node.modelData.status === "waiting"
-            readonly property bool ended: node.modelData.status === "ended"
-            readonly property bool hovered: root.hoveredIndex === node.index
-            readonly property bool selected: root.selectedIndex === node.index
-            readonly property color stateColour: node.errored ? Colours.palette.m3error : root.accent
-
-            opacity: node.ended ? 0.5 : 1
-
-            Behavior on opacity {
-                Anim { type: Anim.DefaultEffects }
-            }
-
-            x: node.point.x - width / 2
-            y: node.point.y - height / 2
-            width: pill.width
-            height: pill.height
-            z: node.isSession ? 2 : 1
 
             Behavior on x {
+                enabled: !root.interacting
                 Anim { type: Anim.EmphasizedSmall }
             }
 
             Behavior on y {
+                enabled: !root.interacting
                 Anim { type: Anim.EmphasizedSmall }
             }
 
-            // The shared Aphotic glow rather than a graph-specific highlight:
-            // breathing while a call is in flight, held steady (not
-            // breathing) while a session waits on the user, and persistent
-            // in the error colour once something has failed. Declared before
-            // the pill on purpose -- it renders a blurred shape behind it.
-            BioluminescentGlow {
-                target: pill
-                glowColour: node.stateColour
-                breathing: node.running || node.isSession && node.modelData.status === "running"
-                visible: node.running || node.errored || node.waiting || node.hovered || node.selected
-                glowBlur: node.selected ? 26 : 18
-            }
+            Shape {
+                anchors.fill: parent
+                opacity: root.empty ? 0 : 1
+                preferredRendererType: Shape.CurveRenderer
 
-            StyledRect {
-                id: pill
-
-                anchors.centerIn: parent
-                implicitWidth: content.implicitWidth + (node.isSession ? Tokens.padding.large : Tokens.padding.medium)
-                implicitHeight: node.isSession ? 32 : 26
-                radius: Tokens.rounding.full
-                scale: node.selected ? 1.12 : node.hovered ? 1.09 : node.running ? 1.06 : 1
-                color: node.isSession
-                    ? Qt.alpha(root.accent, node.ended ? 0.3 : 0.85)
-                    : node.running
-                        ? Qt.alpha(root.accent, 0.8)
-                        : node.errored
-                            ? Qt.alpha(Colours.palette.m3error, 0.85)
-                            : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.92)
-                border.width: 1
-                border.color: node.isSession || node.running || node.errored
-                    ? "transparent"
-                    : Qt.alpha(Colours.palette.m3outlineVariant, 0.8)
-
-                readonly property color ink: node.isSession || node.running || node.errored
-                    ? Colours.contrastOn(pill.color)
-                    : Colours.palette.m3onSurfaceVariant
-
-                Behavior on scale {
-                    Anim { type: Anim.EmphasizedSmall }
+                Behavior on opacity {
+                    Anim { type: Anim.DefaultEffects }
                 }
 
-                HoverHandler {
-                    onHoveredChanged: root.hoveredIndex = hovered ? node.index : (root.hoveredIndex === node.index ? -1 : root.hoveredIndex)
-                }
+                ShapePath {
+                    strokeWidth: 1.2
+                    strokeColor: Qt.alpha(Colours.palette.m3outlineVariant, 0.8)
+                    fillColor: "transparent"
+                    capStyle: ShapePath.RoundCap
+                    joinStyle: ShapePath.RoundJoin
 
-                TapHandler {
-                    onTapped: {
-                        root.selectedIndex = root.selectedIndex === node.index ? -1 : node.index;
-                        if (node.isSession)
-                            root.focusSession(node.index);
+                    PathMultiline {
+                        paths: root._polylines("completed").concat(root._polylines("idle"))
                     }
                 }
 
-                Row {
-                    id: content
+                ShapePath {
+                    strokeWidth: 1.5
+                    strokeColor: Qt.alpha(Colours.palette.m3error, 0.65)
+                    fillColor: "transparent"
+                    capStyle: ShapePath.RoundCap
+                    joinStyle: ShapePath.RoundJoin
 
-                    anchors.centerIn: parent
-                    spacing: Tokens.spacing.extraSmall
-
-                    MaterialIcon {
-                        anchors.verticalCenter: parent.verticalCenter
-                        text: node.isSession ? "hub" : root._iconFor(node.modelData.tool)
-                        color: pill.ink
-                        fontStyle: Tokens.font.icon.small
+                    PathMultiline {
+                        paths: root._polylines("errored")
                     }
+                }
 
-                    StyledText {
-                        anchors.verticalCenter: parent.verticalCenter
-                        text: node.isSession ? node.modelData.label : node.modelData.tool
-                        font: node.isSession ? Tokens.font.body.small : Tokens.font.label.small
-                        color: pill.ink
-                        elide: Text.ElideRight
-                        maximumLineCount: 1
-                    }
+                ShapePath {
+                    strokeWidth: 2.5
+                    strokeColor: Qt.alpha(root.accent, 0.9)
+                    fillColor: "transparent"
+                    capStyle: ShapePath.RoundCap
+                    joinStyle: ShapePath.RoundJoin
 
-                    Rectangle {
-                        anchors.verticalCenter: parent.verticalCenter
-                        visible: node.modelData.kind === "subagent"
-                        width: 5
-                        height: 5
-                        radius: 2.5
-                        color: Qt.alpha(pill.ink, 0.7)
+                    PathMultiline {
+                        paths: root._polylines("running")
                     }
                 }
             }
+
+            // The graph reads as alive or it reads as a diagram. Packets travel the
+            // edge of a call that is actually in flight; nothing moves on an edge
+            // that has already finished. Density comes from the hardware tier and is
+            // thinned, never switched off -- see AgentGraphService.edgeParticles.
+            Repeater {
+                model: root.empty ? [] : graphLayout.edges
+
+                Item {
+                    id: flow
+
+                    required property var modelData
+
+                    readonly property var from: graphLayout.positions[flow.modelData.a] ?? { x: 0, y: 0 }
+                    readonly property var to: graphLayout.positions[flow.modelData.b] ?? { x: 0, y: 0 }
+                    readonly property bool flowing: flow.modelData.status === "running"
+
+                    // Packet speed carries how long the call has been in flight: a
+                    // fresh call streams quickly, one that has been grinding for a
+                    // while slows to a crawl. Integer multipliers only -- a
+                    // fractional one would jump at every wrap of the shared clock.
+                    readonly property int speed: {
+                        const elapsed = root.nowMs - (flow.modelData.startedAt ?? 0);
+                        if (!flow.modelData.startedAt || elapsed > 20000)
+                            return 1;
+                        return elapsed > 5000 ? 2 : 3;
+                    }
+
+                    visible: flow.flowing && (root._onScreen(flow.from) || root._onScreen(flow.to))
+
+                    Repeater {
+                        model: flow.flowing ? root.edgeParticles : 0
+
+                        Rectangle {
+                            id: packet
+
+                            required property int index
+
+                            readonly property real progress: (root.flowClock * flow.speed + packet.index / Math.max(1, root.edgeParticles)) % 1
+                            readonly property real eased: packet.progress * packet.progress * (3 - 2 * packet.progress)
+
+                            width: 6
+                            height: 6
+                            radius: width / 2
+                            color: root.accent
+                            opacity: 0.35 + packet.progress * 0.65
+                            x: flow.from.x + (flow.to.x - flow.from.x) * packet.eased - width / 2
+                            y: flow.from.y + (flow.to.y - flow.from.y) * packet.eased - height / 2
+                        }
+                    }
+                }
+            }
+
+            Repeater {
+                model: graphLayout.nodes
+
+                Item {
+                    id: node
+
+                    required property int index
+                    required property var modelData
+
+                    readonly property var point: graphLayout.positions[node.index] ?? { x: 0, y: 0 }
+                    readonly property bool isSession: node.modelData.kind === "session"
+                    readonly property bool running: node.modelData.status === "running"
+                    readonly property bool errored: node.modelData.status === "errored"
+                    readonly property bool waiting: node.modelData.status === "waiting"
+                    readonly property bool ended: node.modelData.status === "ended"
+                    readonly property bool hovered: root.hoveredIndex === node.index
+                    readonly property bool selected: root.selectedIndex === node.index
+                    readonly property color stateColour: node.errored ? Colours.palette.m3error : root.accent
+
+                    opacity: node.ended ? 0.5 : 1
+
+                    Behavior on opacity {
+                        Anim { type: Anim.DefaultEffects }
+                    }
+
+                    x: node.point.x - width / 2
+                    y: node.point.y - height / 2
+                    width: pill.width
+                    height: pill.height
+                    z: node.isSession ? 2 : 1
+
+                    Behavior on x {
+                        Anim { type: Anim.EmphasizedSmall }
+                    }
+
+                    Behavior on y {
+                        Anim { type: Anim.EmphasizedSmall }
+                    }
+
+                    // The shared Aphotic glow rather than a graph-specific highlight:
+                    // breathing while a call is in flight, held steady (not
+                    // breathing) while a session waits on the user, and persistent
+                    // in the error colour once something has failed. Declared before
+                    // the pill on purpose -- it renders a blurred shape behind it.
+                    BioluminescentGlow {
+                        target: pill
+                        glowColour: node.stateColour
+                        breathing: node.running || node.isSession && node.modelData.status === "running"
+                        visible: node.running || node.errored || node.waiting || node.hovered || node.selected
+                        glowBlur: node.selected ? 26 : 18
+                    }
+
+                    StyledRect {
+                        id: pill
+
+                        anchors.centerIn: parent
+                        implicitWidth: Math.max(node.isSession ? 26 : 20, content.implicitWidth + (node.isSession ? Tokens.padding.large : Tokens.padding.medium))
+                        implicitHeight: node.isSession ? 32 : 26
+                        radius: Tokens.rounding.full
+                        scale: node.selected ? 1.12 : node.hovered ? 1.09 : node.running ? 1.06 : 1
+                        color: node.isSession
+                            ? Qt.alpha(root.accent, node.ended ? 0.3 : 0.85)
+                            : node.running
+                                ? Qt.alpha(root.accent, 0.8)
+                                : node.errored
+                                    ? Qt.alpha(Colours.palette.m3error, 0.85)
+                                    : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.92)
+                        border.width: 1
+                        border.color: node.isSession || node.running || node.errored
+                            ? "transparent"
+                            : Qt.alpha(Colours.palette.m3outlineVariant, 0.8)
+
+                        readonly property color ink: node.isSession || node.running || node.errored
+                            ? Colours.contrastOn(pill.color)
+                            : Colours.palette.m3onSurfaceVariant
+
+                        Behavior on scale {
+                            Anim { type: Anim.EmphasizedSmall }
+                        }
+
+                        HoverHandler {
+                            onHoveredChanged: root.hoveredIndex = hovered ? node.index : (root.hoveredIndex === node.index ? -1 : root.hoveredIndex)
+                        }
+
+                        TapHandler {
+                            onTapped: {
+                                root.selectedIndex = root.selectedIndex === node.index ? -1 : node.index;
+                                if (node.isSession)
+                                    root.focusSession(node.index);
+                            }
+                        }
+
+                        Row {
+                            id: content
+
+                            anchors.centerIn: parent
+                            spacing: Tokens.spacing.extraSmall
+
+                            MaterialIcon {
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: root.showIcons
+                                text: node.isSession ? "hub" : root._iconFor(node.modelData.tool)
+                                color: pill.ink
+                                fontStyle: Tokens.font.icon.small
+                            }
+
+                            StyledText {
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: node.isSession ? root.showIcons : root.showLabels
+                                text: node.isSession ? node.modelData.label : node.modelData.tool
+                                font: node.isSession ? Tokens.font.body.small : Tokens.font.label.small
+                                color: pill.ink
+                                elide: Text.ElideRight
+                                maximumLineCount: 1
+                            }
+
+                            Rectangle {
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: node.modelData.kind === "subagent" && root.showLabels
+                                width: 5
+                                height: 5
+                                radius: 2.5
+                                color: Qt.alpha(pill.ink, 0.7)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // One tooltip for the whole view rather than one per node, and it
+            // reuses the tab/popout chrome (surfaceContainer + outlineVariant +
+            // extraLarge rounding) instead of introducing a second card style.
+        }
+
+        PinchHandler {
+            target: null
+            onActiveChanged: root.interacting = active
+            onScaleChanged: root.zoomAt(centroid.position.x, centroid.position.y, activeScale > 1 ? 1.03 : 0.97)
+        }
+
+        WheelHandler {
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+            onWheel: event => root.zoomAt(event.x, event.y, event.angleDelta.y > 0 ? 1.12 : 1 / 1.12)
+        }
+
+        DragHandler {
+            target: null
+            cursorShape: Qt.ClosedHandCursor
+            onActiveChanged: root.interacting = active
+            onTranslationChanged: {
+                root.panX += translation.x - dragState.x;
+                root.panY += translation.y - dragState.y;
+                dragState = Qt.point(translation.x, translation.y);
+            }
+            onGrabChanged: dragState = Qt.point(0, 0)
+
+            property point dragState: Qt.point(0, 0)
         }
     }
 
-    // One tooltip for the whole view rather than one per node, and it
-    // reuses the tab/popout chrome (surfaceContainer + outlineVariant +
-    // extraLarge rounding) instead of introducing a second card style.
     StyledRect {
         id: tip
 
@@ -380,11 +487,11 @@ Item {
         border.color: Colours.palette.m3outlineVariant
         z: 10
 
-        x: Math.max(0, Math.min(root.width - width, (tip.point?.x ?? 0) - width / 2))
-        y: {
-            const at = tip.point?.y ?? 0;
-            return at + 46 + height > root.height ? Math.max(0, at - height - 30) : at + 30;
-        }
+        readonly property real screenX: (tip.point?.x ?? 0) * root.zoom + root.panX
+        readonly property real screenY: (tip.point?.y ?? 0) * root.zoom + root.panY
+
+        x: Math.max(0, Math.min(root.width - width, tip.screenX - width / 2))
+        y: tip.screenY + 46 + height > root.height ? Math.max(0, tip.screenY - height - 30) : tip.screenY + 30
 
         Behavior on opacity {
             Anim { type: Anim.DefaultEffects }
@@ -436,6 +543,57 @@ Item {
     GraphEmptyState {
         anchors.centerIn: parent
         visible: root.empty
+    }
+
+    Row {
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        spacing: Tokens.spacing.extraSmall
+        visible: !root.empty
+        opacity: 0.85
+
+        component ZoomButton: StyledRect {
+            required property string glyph
+            signal activated
+
+            implicitWidth: 28
+            implicitHeight: 28
+            radius: Tokens.rounding.full
+            color: Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+            border.width: 1
+            border.color: Colours.palette.m3outlineVariant
+
+            MaterialIcon {
+                anchors.centerIn: parent
+                text: parent.glyph
+                color: Colours.palette.m3onSurfaceVariant
+                fontStyle: Tokens.font.icon.small
+            }
+
+            StateLayer {
+                anchors.fill: parent
+                radius: parent.radius
+            }
+
+            TapHandler {
+                onTapped: parent.activated()
+            }
+        }
+
+        ZoomButton {
+            glyph: "remove"
+            onActivated: root.zoomAt(root.width / 2, root.height / 2, 1 / 1.25)
+        }
+
+        ZoomButton {
+            glyph: "fit_screen"
+            onActivated: root.zoomToFit()
+        }
+
+        ZoomButton {
+            glyph: "add"
+            onActivated: root.zoomAt(root.width / 2, root.height / 2, 1.25)
+        }
     }
 
     component GraphEmptyState: Column {

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -1,0 +1,350 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Shapes
+import qs.config
+import qs.components
+import qs.services
+import qs.services.ai
+
+Item {
+    id: root
+
+    property var sessions: AgentGraphService.sessions
+    property int maxNodesPerSession: AgentGraphService.maxNodesPerSession
+    property int edgeParticles: AgentGraphService.edgeParticles
+
+    readonly property alias layout: graphLayout
+    readonly property bool empty: root.sessions.length === 0
+    readonly property bool anyFlowing: graphLayout.edges.some(e => e.status === "running")
+
+    // One clock for every packet on every edge instead of an animation per
+    // packet: phase comes from the packet's index, so N particles cost one
+    // running animation, and it stops entirely when nothing is in flight.
+    property real flowClock: 0
+
+    implicitWidth: 760
+    implicitHeight: 460
+
+    NumberAnimation on flowClock {
+        running: root.visible && root.anyFlowing
+        loops: Animation.Infinite
+        from: 0
+        to: 1
+        duration: 1600
+    }
+
+    GraphLayout {
+        id: graphLayout
+
+        sessions: root.sessions
+        areaWidth: root.width
+        areaHeight: root.height
+        maxNodesPerSession: root.maxNodesPerSession
+    }
+
+    // Repeater delegates must be Items, and ShapePath is not one -- a
+    // Repeater of ShapePath silently draws nothing. All edges of a given
+    // status therefore share one ShapePath fed by a PathMultiline, which is
+    // also three geometry nodes for the whole graph instead of one per edge.
+    function _iconFor(tool: string): string {
+        switch (tool) {
+        case "Read":
+            return "description";
+        case "Write":
+            return "note_add";
+        case "Edit":
+            return "edit";
+        case "Bash":
+            return "terminal";
+        case "Grep":
+            return "search";
+        case "Glob":
+            return "folder_open";
+        case "WebFetch":
+        case "WebSearch":
+            return "language";
+        case "Agent":
+        case "Task":
+            return "smart_toy";
+        case "TodoWrite":
+            return "checklist";
+        case "NotebookEdit":
+            return "menu_book";
+        default:
+            return "bolt";
+        }
+    }
+
+    function _polylines(status: string): var {
+        const positions = graphLayout.positions;
+        const lines = [];
+        for (const edge of graphLayout.edges) {
+            if (edge.status !== status)
+                continue;
+            const a = positions[edge.a];
+            const b = positions[edge.b];
+            if (!a || !b)
+                continue;
+            const mx = (a.x + b.x) / 2 + (b.y - a.y) * 0.09;
+            const my = (a.y + b.y) / 2 - (b.x - a.x) * 0.09;
+            lines.push([Qt.point(a.x, a.y), Qt.point(mx, my), Qt.point(b.x, b.y)]);
+        }
+        return lines;
+    }
+
+    Shape {
+        anchors.fill: parent
+        opacity: root.empty ? 0 : 1
+        preferredRendererType: Shape.CurveRenderer
+
+        Behavior on opacity {
+            Anim { type: Anim.DefaultEffects }
+        }
+
+        ShapePath {
+            strokeWidth: 1.2
+            strokeColor: Qt.alpha(Colours.palette.m3outlineVariant, 0.8)
+            fillColor: "transparent"
+            capStyle: ShapePath.RoundCap
+            joinStyle: ShapePath.RoundJoin
+
+            PathMultiline {
+                paths: root._polylines("completed").concat(root._polylines("idle"))
+            }
+        }
+
+        ShapePath {
+            strokeWidth: 1.5
+            strokeColor: Qt.alpha(Colours.palette.m3error, 0.65)
+            fillColor: "transparent"
+            capStyle: ShapePath.RoundCap
+            joinStyle: ShapePath.RoundJoin
+
+            PathMultiline {
+                paths: root._polylines("errored")
+            }
+        }
+
+        ShapePath {
+            strokeWidth: 2.5
+            strokeColor: Qt.alpha(Colours.palette.m3primary, 0.9)
+            fillColor: "transparent"
+            capStyle: ShapePath.RoundCap
+            joinStyle: ShapePath.RoundJoin
+
+            PathMultiline {
+                paths: root._polylines("running")
+            }
+        }
+    }
+
+    // The graph reads as alive or it reads as a diagram. Packets travel the
+    // edge of a call that is actually in flight; nothing moves on an edge
+    // that has already finished. Density comes from the hardware tier and is
+    // thinned, never switched off -- see AgentGraphService.edgeParticles.
+    Repeater {
+        model: root.empty ? [] : graphLayout.edges
+
+        Item {
+            id: flow
+
+            required property var modelData
+
+            readonly property var from: graphLayout.positions[flow.modelData.a] ?? { x: 0, y: 0 }
+            readonly property var to: graphLayout.positions[flow.modelData.b] ?? { x: 0, y: 0 }
+            readonly property bool flowing: flow.modelData.status === "running"
+
+            visible: flow.flowing
+
+            Repeater {
+                model: flow.flowing ? root.edgeParticles : 0
+
+                Rectangle {
+                    id: packet
+
+                    required property int index
+
+                    readonly property real progress: (root.flowClock + packet.index / Math.max(1, root.edgeParticles)) % 1
+                    readonly property real eased: packet.progress * packet.progress * (3 - 2 * packet.progress)
+
+                    width: 6
+                    height: 6
+                    radius: width / 2
+                    color: Colours.palette.m3primary
+                    opacity: 1 - Math.abs(packet.progress - 0.5) * 0.5
+                    x: flow.from.x + (flow.to.x - flow.from.x) * packet.eased - width / 2
+                    y: flow.from.y + (flow.to.y - flow.from.y) * packet.eased - height / 2
+                }
+            }
+        }
+    }
+
+    Repeater {
+        model: graphLayout.nodes
+
+        Item {
+            id: node
+
+            required property int index
+            required property var modelData
+
+            readonly property var point: graphLayout.positions[node.index] ?? { x: 0, y: 0 }
+            readonly property bool isSession: node.modelData.kind === "session"
+            readonly property bool running: node.modelData.status === "running"
+            readonly property bool errored: node.modelData.status === "errored"
+
+            x: node.point.x - width / 2
+            y: node.point.y - height / 2
+            width: pill.width
+            height: pill.height
+            z: node.isSession ? 2 : 1
+
+            Behavior on x {
+                Anim { type: Anim.EmphasizedSmall }
+            }
+
+            Behavior on y {
+                Anim { type: Anim.EmphasizedSmall }
+            }
+
+            Rectangle {
+                id: halo
+
+                property real pulse: 0.1
+
+                anchors.centerIn: pill
+                width: pill.width + Tokens.padding.medium
+                height: pill.height + Tokens.padding.medium
+                radius: height / 2
+                color: "transparent"
+                border.width: 1
+                border.color: node.errored ? Colours.palette.m3error : Colours.palette.m3primary
+                opacity: node.running ? halo.pulse : node.errored ? 0.6 : 0
+
+                SequentialAnimation on pulse {
+                    running: node.running && root.visible
+                    loops: Animation.Infinite
+                    Anim {
+                        to: 0.5
+                        type: Anim.SlowEffects
+                    }
+                    Anim {
+                        to: 0.08
+                        type: Anim.SlowEffects
+                    }
+                }
+
+                Behavior on opacity {
+                    Anim { type: Anim.DefaultEffects }
+                }
+            }
+
+            StyledRect {
+                id: pill
+
+                anchors.centerIn: parent
+                implicitWidth: content.implicitWidth + (node.isSession ? Tokens.padding.large : Tokens.padding.medium)
+                implicitHeight: node.isSession ? 32 : 26
+                radius: Tokens.rounding.full
+                scale: node.running ? 1.06 : 1
+                color: node.isSession
+                    ? Qt.alpha(Colours.palette.m3primary, node.modelData.status === "ended" ? 0.3 : 0.85)
+                    : node.running
+                        ? Qt.alpha(Colours.palette.m3primary, 0.8)
+                        : node.errored
+                            ? Qt.alpha(Colours.palette.m3error, 0.85)
+                            : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.92)
+                border.width: 1
+                border.color: node.isSession || node.running || node.errored
+                    ? "transparent"
+                    : Qt.alpha(Colours.palette.m3outlineVariant, 0.8)
+
+                readonly property color ink: node.isSession || node.running || node.errored
+                    ? Colours.contrastOn(pill.color)
+                    : Colours.palette.m3onSurfaceVariant
+
+                Behavior on scale {
+                    Anim { type: Anim.EmphasizedSmall }
+                }
+
+                Row {
+                    id: content
+
+                    anchors.centerIn: parent
+                    spacing: Tokens.spacing.extraSmall
+
+                    MaterialIcon {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: node.isSession ? "hub" : root._iconFor(node.modelData.tool)
+                        color: pill.ink
+                        fontStyle: Tokens.font.icon.small
+                    }
+
+                    StyledText {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: node.isSession ? node.modelData.label : node.modelData.tool
+                        font: node.isSession ? Tokens.font.body.small : Tokens.font.label.small
+                        color: pill.ink
+                        elide: Text.ElideRight
+                        maximumLineCount: 1
+                    }
+
+                    Rectangle {
+                        anchors.verticalCenter: parent.verticalCenter
+                        visible: node.modelData.kind === "subagent"
+                        width: 5
+                        height: 5
+                        radius: 2.5
+                        color: Qt.alpha(pill.ink, 0.7)
+                    }
+                }
+            }
+        }
+    }
+
+    GraphEmptyState {
+        anchors.centerIn: parent
+        visible: root.empty
+    }
+
+    component GraphEmptyState: Column {
+        spacing: Tokens.spacing.small
+
+        Rectangle {
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: 64
+            height: 64
+            radius: width / 2
+            color: Qt.alpha(Colours.palette.m3primary, 0.12)
+            border.width: 1
+            border.color: Qt.alpha(Colours.palette.m3primary, 0.25)
+
+            MaterialIcon {
+                anchors.centerIn: parent
+                text: "hub"
+                color: Colours.palette.m3primary
+                fontStyle: Tokens.font.icon.extraLarge
+            }
+        }
+
+        Item {
+            width: 1
+            height: Tokens.spacing.small
+        }
+
+        StyledText {
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: qsTr("No agent sessions")
+            color: Colours.palette.m3onSurface
+            font: Tokens.font.body.medium
+        }
+
+        StyledText {
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: qsTr("Claude Code sessions appear here as they run")
+            color: Colours.palette.m3onSurfaceVariant
+            font: Tokens.font.label.small
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -4,6 +4,7 @@ import QtQuick
 import QtQuick.Shapes
 import qs.config
 import qs.components
+import qs.components.effects
 import qs.services
 import qs.services.ai
 
@@ -17,6 +18,47 @@ Item {
     readonly property alias layout: graphLayout
     readonly property bool empty: root.sessions.length === 0
     readonly property bool anyFlowing: graphLayout.edges.some(e => e.status === "running")
+
+    // Per-surface accent override, same contract as the per-icon overrides:
+    // empty string means follow the theme rather than storing a copy of it.
+    readonly property color accent: Settings.agentGraphAccent ? Settings.agentGraphAccent : Colours.palette.m3primary
+
+    property int hoveredIndex: -1
+    property int selectedIndex: -1
+    property real nowMs: 0
+
+    function focusSession(index: int): void {
+        const node = graphLayout.nodes[index];
+        if (!node || node.kind !== "session" || !node.cwd)
+            return;
+        const leaf = node.cwd.slice(node.cwd.lastIndexOf("/") + 1);
+        if (!leaf)
+            return;
+        const match = WindowList.windows.find(w => w.title.includes(leaf));
+        if (match)
+            WindowList.focus(match.address);
+    }
+
+    function _durationText(node): string {
+        const ms = node.status === "running"
+            ? Math.max(0, root.nowMs - (node.startedAt ?? 0))
+            : (node.durationMs ?? 0);
+        if (!ms || !node.startedAt)
+            return "";
+        if (ms < 1000)
+            return qsTr("%1 ms").arg(Math.round(ms));
+        if (ms < 60000)
+            return qsTr("%1 s").arg((ms / 1000).toFixed(1));
+        return qsTr("%1 m %2 s").arg(Math.floor(ms / 60000)).arg(Math.round((ms % 60000) / 1000));
+    }
+
+    Timer {
+        interval: 1000
+        repeat: true
+        running: root.visible && root.anyFlowing
+        triggeredOnStart: true
+        onTriggered: root.nowMs = Date.now()
+    }
 
     // One clock for every packet on every edge instead of an animation per
     // packet: phase comes from the packet's index, so N particles cost one
@@ -128,7 +170,7 @@ Item {
 
         ShapePath {
             strokeWidth: 2.5
-            strokeColor: Qt.alpha(Colours.palette.m3primary, 0.9)
+            strokeColor: Qt.alpha(root.accent, 0.9)
             fillColor: "transparent"
             capStyle: ShapePath.RoundCap
             joinStyle: ShapePath.RoundJoin
@@ -155,6 +197,17 @@ Item {
             readonly property var to: graphLayout.positions[flow.modelData.b] ?? { x: 0, y: 0 }
             readonly property bool flowing: flow.modelData.status === "running"
 
+            // Packet speed carries how long the call has been in flight: a
+            // fresh call streams quickly, one that has been grinding for a
+            // while slows to a crawl. Integer multipliers only -- a
+            // fractional one would jump at every wrap of the shared clock.
+            readonly property int speed: {
+                const elapsed = root.nowMs - (flow.modelData.startedAt ?? 0);
+                if (!flow.modelData.startedAt || elapsed > 20000)
+                    return 1;
+                return elapsed > 5000 ? 2 : 3;
+            }
+
             visible: flow.flowing
 
             Repeater {
@@ -165,14 +218,14 @@ Item {
 
                     required property int index
 
-                    readonly property real progress: (root.flowClock + packet.index / Math.max(1, root.edgeParticles)) % 1
+                    readonly property real progress: (root.flowClock * flow.speed + packet.index / Math.max(1, root.edgeParticles)) % 1
                     readonly property real eased: packet.progress * packet.progress * (3 - 2 * packet.progress)
 
                     width: 6
                     height: 6
                     radius: width / 2
-                    color: Colours.palette.m3primary
-                    opacity: 1 - Math.abs(packet.progress - 0.5) * 0.5
+                    color: root.accent
+                    opacity: 0.35 + packet.progress * 0.65
                     x: flow.from.x + (flow.to.x - flow.from.x) * packet.eased - width / 2
                     y: flow.from.y + (flow.to.y - flow.from.y) * packet.eased - height / 2
                 }
@@ -193,6 +246,17 @@ Item {
             readonly property bool isSession: node.modelData.kind === "session"
             readonly property bool running: node.modelData.status === "running"
             readonly property bool errored: node.modelData.status === "errored"
+            readonly property bool waiting: node.modelData.status === "waiting"
+            readonly property bool ended: node.modelData.status === "ended"
+            readonly property bool hovered: root.hoveredIndex === node.index
+            readonly property bool selected: root.selectedIndex === node.index
+            readonly property color stateColour: node.errored ? Colours.palette.m3error : root.accent
+
+            opacity: node.ended ? 0.5 : 1
+
+            Behavior on opacity {
+                Anim { type: Anim.DefaultEffects }
+            }
 
             x: node.point.x - width / 2
             y: node.point.y - height / 2
@@ -208,36 +272,17 @@ Item {
                 Anim { type: Anim.EmphasizedSmall }
             }
 
-            Rectangle {
-                id: halo
-
-                property real pulse: 0.1
-
-                anchors.centerIn: pill
-                width: pill.width + Tokens.padding.medium
-                height: pill.height + Tokens.padding.medium
-                radius: height / 2
-                color: "transparent"
-                border.width: 1
-                border.color: node.errored ? Colours.palette.m3error : Colours.palette.m3primary
-                opacity: node.running ? halo.pulse : node.errored ? 0.6 : 0
-
-                SequentialAnimation on pulse {
-                    running: node.running && root.visible
-                    loops: Animation.Infinite
-                    Anim {
-                        to: 0.5
-                        type: Anim.SlowEffects
-                    }
-                    Anim {
-                        to: 0.08
-                        type: Anim.SlowEffects
-                    }
-                }
-
-                Behavior on opacity {
-                    Anim { type: Anim.DefaultEffects }
-                }
+            // The shared Aphotic glow rather than a graph-specific highlight:
+            // breathing while a call is in flight, held steady (not
+            // breathing) while a session waits on the user, and persistent
+            // in the error colour once something has failed. Declared before
+            // the pill on purpose -- it renders a blurred shape behind it.
+            BioluminescentGlow {
+                target: pill
+                glowColour: node.stateColour
+                breathing: node.running || node.isSession && node.modelData.status === "running"
+                visible: node.running || node.errored || node.waiting || node.hovered || node.selected
+                glowBlur: node.selected ? 26 : 18
             }
 
             StyledRect {
@@ -247,11 +292,11 @@ Item {
                 implicitWidth: content.implicitWidth + (node.isSession ? Tokens.padding.large : Tokens.padding.medium)
                 implicitHeight: node.isSession ? 32 : 26
                 radius: Tokens.rounding.full
-                scale: node.running ? 1.06 : 1
+                scale: node.selected ? 1.12 : node.hovered ? 1.09 : node.running ? 1.06 : 1
                 color: node.isSession
-                    ? Qt.alpha(Colours.palette.m3primary, node.modelData.status === "ended" ? 0.3 : 0.85)
+                    ? Qt.alpha(root.accent, node.ended ? 0.3 : 0.85)
                     : node.running
-                        ? Qt.alpha(Colours.palette.m3primary, 0.8)
+                        ? Qt.alpha(root.accent, 0.8)
                         : node.errored
                             ? Qt.alpha(Colours.palette.m3error, 0.85)
                             : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.92)
@@ -266,6 +311,18 @@ Item {
 
                 Behavior on scale {
                     Anim { type: Anim.EmphasizedSmall }
+                }
+
+                HoverHandler {
+                    onHoveredChanged: root.hoveredIndex = hovered ? node.index : (root.hoveredIndex === node.index ? -1 : root.hoveredIndex)
+                }
+
+                TapHandler {
+                    onTapped: {
+                        root.selectedIndex = root.selectedIndex === node.index ? -1 : node.index;
+                        if (node.isSession)
+                            root.focusSession(node.index);
+                    }
                 }
 
                 Row {
@@ -299,6 +356,79 @@ Item {
                         color: Qt.alpha(pill.ink, 0.7)
                     }
                 }
+            }
+        }
+    }
+
+    // One tooltip for the whole view rather than one per node, and it
+    // reuses the tab/popout chrome (surfaceContainer + outlineVariant +
+    // extraLarge rounding) instead of introducing a second card style.
+    StyledRect {
+        id: tip
+
+        readonly property int target: root.selectedIndex >= 0 ? root.selectedIndex : root.hoveredIndex
+        readonly property var node: tip.target >= 0 ? graphLayout.nodes[tip.target] ?? null : null
+        readonly property var point: tip.target >= 0 ? graphLayout.positions[tip.target] ?? null : null
+
+        visible: opacity > 0
+        opacity: tip.node ? 1 : 0
+        implicitWidth: tipContent.implicitWidth + Tokens.padding.large * 2
+        implicitHeight: tipContent.implicitHeight + Tokens.padding.medium * 2
+        radius: Tokens.rounding.large
+        color: Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.97)
+        border.width: 1
+        border.color: Colours.palette.m3outlineVariant
+        z: 10
+
+        x: Math.max(0, Math.min(root.width - width, (tip.point?.x ?? 0) - width / 2))
+        y: {
+            const at = tip.point?.y ?? 0;
+            return at + 46 + height > root.height ? Math.max(0, at - height - 30) : at + 30;
+        }
+
+        Behavior on opacity {
+            Anim { type: Anim.DefaultEffects }
+        }
+
+        Column {
+            id: tipContent
+
+            anchors.centerIn: parent
+            spacing: Tokens.spacing.extraSmall
+
+            StyledText {
+                text: tip.node ? (tip.node.kind === "session" ? tip.node.label : tip.node.tool) : ""
+                font: Tokens.font.body.medium
+                color: Colours.palette.m3onSurface
+            }
+
+            StyledText {
+                visible: text.length > 0
+                text: {
+                    if (!tip.node)
+                        return "";
+                    const bits = [tip.node.status];
+                    const duration = root._durationText(tip.node);
+                    if (duration)
+                        bits.push(duration);
+                    if (tip.node.agentType)
+                        bits.push(tip.node.agentType);
+                    if (tip.node.kind === "session" && tip.node.callCount)
+                        bits.push(qsTr("%1 calls").arg(tip.node.callCount));
+                    return bits.join(" · ");
+                }
+                font: Tokens.font.label.small
+                color: Colours.palette.m3onSurfaceVariant
+            }
+
+            StyledText {
+                visible: text.length > 0
+                text: tip.node && tip.node.kind === "session" ? tip.node.cwd : ""
+                font: Tokens.font.label.small
+                color: Colours.palette.m3outlineVariant
+                elide: Text.ElideLeft
+                maximumLineCount: 1
+                width: Math.min(implicitWidth, 260)
             }
         }
     }

--- a/Configs/quickshell/aphotic/modules/agentgraph/ReplayBar.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/ReplayBar.qml
@@ -1,0 +1,346 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import qs.config
+import qs.components
+import qs.services
+import qs.services.ai
+
+ColumnLayout {
+    id: root
+
+    required property GraphReplay replay
+    property string runId: ""
+
+    signal exited
+
+    spacing: Tokens.spacing.small
+
+    Component.onCompleted: AgentGraphService.refreshRuns()
+
+    // Blocks are laid out on the replay's own compressed clock, not on wall
+    // time, so a run with a four-minute pause in it still reads as a dense
+    // strip rather than one block and a lot of empty space.
+    readonly property var lanes: {
+        const events = root.replay.events;
+        const stamps = root.replay.stamps;
+        const open = ({});
+        const rows = ({});
+        const order = [];
+
+        for (let i = 0; i < events.length; i++) {
+            const e = events[i];
+            if (!e.toolId)
+                continue;
+            const lane = `${e.sessionId}|${e.agentId ?? ""}`;
+            if (!rows[lane]) {
+                rows[lane] = [];
+                order.push(lane);
+            }
+            if (e.event === "pre_tool_use") {
+                open[e.toolId] = { lane: lane, tool: e.tool ?? "", start: stamps[i] ?? 0, index: i, status: "running" };
+                rows[lane].push(open[e.toolId]);
+            } else if (open[e.toolId]) {
+                open[e.toolId].end = stamps[i] ?? 0;
+                open[e.toolId].status = e.event === "post_tool_use_failure" ? "errored" : "completed";
+            }
+        }
+
+        return order.map(lane => ({
+            key: lane,
+            agent: lane.split("|")[1],
+            blocks: rows[lane].map(b => ({
+                tool: b.tool,
+                index: b.index,
+                status: b.status,
+                start: b.start,
+                end: b.end ?? (root.replay.durationMs || b.start + 1)
+            }))
+        }));
+    }
+
+    function _time(ms: real): string {
+        const total = Math.max(0, Math.round(ms / 1000));
+        return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+    }
+
+    Process {
+        id: exporter
+        onExited: code => Toaster.toast(code === 0 ? qsTr("Run exported") : qsTr("Export failed"), code === 0 ? `~/agent-run-${root.runId}.jsonl` : qsTr("Could not copy the run archive"), code === 0 ? "download_done" : "error")
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: Tokens.spacing.extraSmall
+
+        MaterialIcon {
+            text: "history"
+            color: Colours.palette.m3onSurfaceVariant
+            fontStyle: Tokens.font.icon.small
+        }
+
+        StyledText {
+            text: qsTr("Runs")
+            font: Tokens.font.label.small
+            color: Colours.palette.m3onSurfaceVariant
+        }
+
+        Flickable {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 26
+            contentWidth: runRow.implicitWidth
+            flickableDirection: Flickable.HorizontalFlick
+            clip: true
+
+            Row {
+                id: runRow
+                spacing: Tokens.spacing.extraSmall
+
+                Repeater {
+                    model: AgentGraphService.runs
+
+                    StyledRect {
+                        id: chip
+
+                        required property var modelData
+                        readonly property bool active: chip.modelData.id === root.runId
+
+                        implicitWidth: chipLabel.implicitWidth + Tokens.padding.medium
+                        implicitHeight: 24
+                        radius: Tokens.rounding.full
+                        color: chip.active ? Colours.palette.m3primary : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+                        border.width: 1
+                        border.color: chip.active ? "transparent" : Colours.palette.m3outlineVariant
+
+                        StyledText {
+                            id: chipLabel
+                            anchors.centerIn: parent
+                            text: chip.modelData.id.slice(0, 8)
+                            font: Tokens.font.label.small
+                            color: chip.active ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurfaceVariant
+                        }
+
+                        StateLayer {
+                            anchors.fill: parent
+                            radius: parent.radius
+                        }
+
+                        TapHandler {
+                            onTapped: {
+                                root.runId = chip.modelData.id;
+                                AgentGraphService.loadRun(chip.modelData.id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        StyledText {
+            visible: AgentGraphService.runs.length === 0
+            text: qsTr("No recorded runs yet")
+            font: Tokens.font.label.small
+            color: Colours.palette.m3outlineVariant
+        }
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: Tokens.spacing.extraSmall
+
+        component TransportButton: StyledRect {
+            required property string glyph
+            property bool accented: false
+            signal activated
+
+            implicitWidth: 28
+            implicitHeight: 28
+            radius: Tokens.rounding.full
+            color: accented ? Colours.palette.m3primary : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+            border.width: 1
+            border.color: accented ? "transparent" : Colours.palette.m3outlineVariant
+
+            MaterialIcon {
+                anchors.centerIn: parent
+                text: parent.glyph
+                color: parent.accented ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurfaceVariant
+                fontStyle: Tokens.font.icon.small
+            }
+
+            StateLayer {
+                anchors.fill: parent
+                radius: parent.radius
+            }
+
+            TapHandler {
+                onTapped: parent.activated()
+            }
+        }
+
+        TransportButton {
+            glyph: "replay"
+            onActivated: root.replay.seekTo(0)
+        }
+
+        TransportButton {
+            glyph: "skip_previous"
+            onActivated: root.replay.step(-1)
+        }
+
+        TransportButton {
+            glyph: root.replay.playing ? "pause" : "play_arrow"
+            accented: true
+            onActivated: root.replay.toggle()
+        }
+
+        TransportButton {
+            glyph: "skip_next"
+            onActivated: root.replay.step(1)
+        }
+
+        StyledRect {
+            implicitWidth: speedLabel.implicitWidth + Tokens.padding.medium
+            implicitHeight: 26
+            radius: Tokens.rounding.full
+            color: Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+            border.width: 1
+            border.color: Colours.palette.m3outlineVariant
+
+            StyledText {
+                id: speedLabel
+                anchors.centerIn: parent
+                text: `${root.replay.speed}x`
+                font: Tokens.font.label.small
+                color: Colours.palette.m3onSurfaceVariant
+            }
+
+            StateLayer {
+                anchors.fill: parent
+                radius: parent.radius
+            }
+
+            TapHandler {
+                onTapped: root.replay.speed = root.replay.speed >= 8 ? 1 : root.replay.speed * 2
+            }
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            text: `${root._time(root.replay.positionMs)} / ${root._time(root.replay.durationMs)} · ${root.replay.cursor}/${root.replay.events.length}`
+            font: Tokens.font.label.small
+            color: Colours.palette.m3onSurfaceVariant
+        }
+
+        TransportButton {
+            glyph: "download"
+            onActivated: {
+                if (!root.runId)
+                    return;
+                const home = Quickshell.env("HOME");
+                exporter.command = ["cp", `${home}/.local/state/aphotic/agent-runs/${root.runId}.jsonl`, `${home}/agent-run-${root.runId}.jsonl`];
+                exporter.running = true;
+            }
+        }
+
+        TransportButton {
+            glyph: "close"
+            onActivated: root.exited()
+        }
+    }
+
+    StyledRect {
+        id: scrubber
+
+        Layout.fillWidth: true
+        implicitHeight: 6
+        radius: Tokens.rounding.full
+        color: Qt.alpha(Colours.palette.m3outlineVariant, 0.5)
+
+        StyledRect {
+            width: parent.width * root.replay.progress
+            height: parent.height
+            radius: parent.radius
+            color: Colours.palette.m3primary
+        }
+
+        TapHandler {
+            onTapped: point => root.replay.seekTo(point.position.x / scrubber.width * root.replay.durationMs)
+        }
+
+        DragHandler {
+            target: null
+            yAxis.enabled: false
+            onCentroidChanged: if (active) root.replay.seekTo(centroid.position.x / scrubber.width * root.replay.durationMs)
+        }
+    }
+
+    Column {
+        Layout.fillWidth: true
+        Layout.topMargin: Tokens.spacing.extraSmall
+        spacing: 3
+
+        Repeater {
+            model: root.lanes
+
+            Item {
+                id: lane
+
+                required property var modelData
+
+                width: parent.width
+                height: 14
+
+                StyledText {
+                    id: laneLabel
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: 66
+                    text: lane.modelData.agent ? qsTr("subagent") : qsTr("main")
+                    font: Tokens.font.label.small
+                    color: Colours.palette.m3outlineVariant
+                    elide: Text.ElideRight
+                }
+
+                Item {
+                    anchors.left: laneLabel.right
+                    anchors.leftMargin: Tokens.spacing.extraSmall
+                    anchors.right: parent.right
+                    height: parent.height
+
+                    Repeater {
+                        model: lane.modelData.blocks
+
+                        StyledRect {
+                            id: block
+
+                            required property var modelData
+                            readonly property real span: Math.max(1, root.replay.durationMs)
+
+                            x: parent.width * (block.modelData.start / block.span)
+                            width: Math.max(3, parent.width * ((block.modelData.end - block.modelData.start) / block.span))
+                            height: 10
+                            anchors.verticalCenter: parent.verticalCenter
+                            radius: Tokens.rounding.extraSmall
+                            color: block.modelData.status === "errored"
+                                ? Colours.palette.m3error
+                                : block.modelData.index < root.replay.cursor
+                                    ? Colours.palette.m3primary
+                                    : Qt.alpha(Colours.palette.m3outlineVariant, 0.7)
+
+                            StateLayer {
+                                anchors.fill: parent
+                                radius: parent.radius
+                            }
+
+                            TapHandler {
+                                onTapped: root.replay.seekToIndex(block.modelData.index)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/agentgraph/ReplayBar.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/ReplayBar.qml
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
 pragma ComponentBehavior: Bound
 
 import QtQuick

--- a/Configs/quickshell/aphotic/modules/agentgraph/qmldir
+++ b/Configs/quickshell/aphotic/modules/agentgraph/qmldir
@@ -1,0 +1,3 @@
+module qs.modules.agentgraph
+GraphLayout 1.0 GraphLayout.qml
+GraphView 1.0 GraphView.qml

--- a/Configs/quickshell/aphotic/modules/agentgraph/qmldir
+++ b/Configs/quickshell/aphotic/modules/agentgraph/qmldir
@@ -1,3 +1,5 @@
 module qs.modules.agentgraph
+GraphReplay 1.0 GraphReplay.qml
 GraphLayout 1.0 GraphLayout.qml
 GraphView 1.0 GraphView.qml
+ReplayBar 1.0 ReplayBar.qml

--- a/Configs/quickshell/aphotic/modules/bar/BarWrapper.qml
+++ b/Configs/quickshell/aphotic/modules/bar/BarWrapper.qml
@@ -35,7 +35,25 @@ Item {
     // "hidden" reserves no desktop space at all, matching a fully disabled
     // bar; "autohide" still reserves the thin sliver so windows don't tile
     // into the space the reveal-on-hover strip occupies.
-    readonly property int exclusiveZone: disabled || hiddenMode ? 0 : (Settings.barVisibility === "always" || screenState.bar ? contentWidth : Config.border.thickness)
+    //
+    // Settings._loaded gate: real, live-confirmed bug. Settings.barSkin's
+    // own QML default is "pill" (a full-bar skin) until its FileView loads
+    // the user's persisted value asynchronously -- so for anyone whose
+    // real config is "dock" (or "hidden"), hiddenMode is briefly FALSE at
+    // this window's very first layer-shell commit, and exclusiveZone briefly
+    // computes a real nonzero reservation before flipping back to 0 a
+    // moment later. That transient commit doesn't reliably shrink back down
+    // afterward (a known exclusive-zone-shrink quirk), leaving a real,
+    // permanent phantom reservation baked into hyprctl monitors' `.reserved`
+    // that no later value change corrects -- confirmed live via an
+    // isolation test forcing this property to a distinct constant and
+    // watching `.reserved` carry a fixed, un-shrinkable extra amount from
+    // the pre-load default. Treating "not loaded yet" the same as
+    // hiddenMode (0) is the safe direction: worst case a real bar very
+    // briefly reserves nothing it should have, self-correcting once
+    // Settings._loaded flips true, instead of the reverse (a wrong
+    // reservation that sticks for the rest of the session).
+    readonly property int exclusiveZone: !Settings._loaded || disabled || hiddenMode ? 0 : (Settings.barVisibility === "always" || screenState.bar ? contentWidth : Config.border.thickness)
     // "hidden" never reveals via hover -- isHovered only feeds visibility
     // in "autohide" mode, where the always-present sliver is the hover
     // target in the first place.

--- a/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
@@ -38,7 +38,13 @@ PanelWindow {
     WlrLayershell.namespace: "aphotic-dock"
     WlrLayershell.layer: WlrLayer.Top
     WlrLayershell.exclusionMode: ExclusionMode.Normal
-    WlrLayershell.exclusiveZone: root.reservedThickness
+    // 0 until Settings._loaded: same startup-race guard as BarWrapper.qml's
+    // own exclusiveZone (see its comment for the full story) -- barHorizontal/
+    // barPositionBottom/barPositionRight all read from Settings too, so
+    // before the persisted config loads this window could briefly commit a
+    // reservation on the wrong edge or at the wrong thickness, which then
+    // doesn't reliably shrink/move back down afterward.
+    WlrLayershell.exclusiveZone: Settings._loaded ? root.reservedThickness : 0
     color: "transparent"
 
     anchors.top: Settings.barHorizontal ? !Settings.barPositionBottom : true

--- a/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
@@ -90,11 +90,11 @@ PanelWindow {
         // leaves exactly edgeMargin of gap on the docked side and none
         // on the other, with no manual arithmetic needed. Centered along
         // the long axis either way.
-        anchors.horizontalCenter: Settings.barHorizontal ? root.horizontalCenter : undefined
-        anchors.verticalCenter: Settings.barHorizontal ? undefined : root.verticalCenter
-        anchors.top: root.dockedBottom ? root.top : undefined
-        anchors.bottom: root.dockedTop ? root.bottom : undefined
-        anchors.left: root.dockedRight ? root.left : undefined
-        anchors.right: root.dockedLeft ? root.right : undefined
+        anchors.horizontalCenter: Settings.barHorizontal ? parent.horizontalCenter : undefined
+        anchors.verticalCenter: Settings.barHorizontal ? undefined : parent.verticalCenter
+        anchors.top: root.dockedBottom ? parent.top : undefined
+        anchors.bottom: root.dockedTop ? parent.bottom : undefined
+        anchors.left: root.dockedRight ? parent.left : undefined
+        anchors.right: root.dockedLeft ? parent.right : undefined
     }
 }

--- a/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockWindow.qml
@@ -15,28 +15,58 @@ PanelWindow {
 
     required property ScreenState screenState
 
-    // Full-screen transparent overlay + region mask, same pattern every
-    // other overlay window in this repo uses (Notifications/OSD/
-    // Dashboard/...), rather than a native layer-shell partial-edge-
-    // anchor trick -- keeps Dock's floating, non-edge-spanning geometry
-    // consistent with the rest of the codebase instead of introducing a
-    // second window-positioning convention.
+    // Real, reported bug this fixes: this used to be a full-screen
+    // transparent overlay (anchored to all four edges) with
+    // ExclusionMode.Ignore -- floating over whatever was underneath by
+    // design, like every other overlay in this repo (Notifications/OSD/
+    // Dashboard/...). But those are all click-to-open transient surfaces;
+    // Dock is a permanently-on bar style, and "fits within the margins
+    // the way the other bar styles do, doesn't sit on top of tiled
+    // windows" is a reasonable, explicitly requested expectation for
+    // that -- Full/Taskbar/Minimal all reserve real desktop space via a
+    // real exclusiveZone (see BarWrapper.qml). Ignore was never a
+    // deliberate "Dock should float over content" design choice, it was
+    // just the only option that made sense for a window anchored to all
+    // four edges at once -- Wayland's exclusive-zone concept only has a
+    // well-defined meaning for a window anchored to ONE edge (or a
+    // full-span pair), which a corner-to-corner overlay isn't. Anchoring
+    // to just the configured docked edge instead (matching
+    // BarWindow.qml's own anchor pattern exactly) makes a real
+    // exclusiveZone possible, while the pill itself still renders
+    // centered and floating-looking within that now-edge-spanning strip
+    // -- no visual change to the pill, just a real reservation behind it.
     WlrLayershell.namespace: "aphotic-dock"
     WlrLayershell.layer: WlrLayer.Top
-    WlrLayershell.exclusionMode: ExclusionMode.Ignore
+    WlrLayershell.exclusionMode: ExclusionMode.Normal
+    WlrLayershell.exclusiveZone: root.reservedThickness
     color: "transparent"
 
-    anchors.top: true
-    anchors.bottom: true
-    anchors.left: true
-    anchors.right: true
-
-    implicitWidth: screen.width
-    implicitHeight: screen.height
-
-    visible: Settings.barStyle === "dock"
+    anchors.top: Settings.barHorizontal ? !Settings.barPositionBottom : true
+    anchors.bottom: Settings.barHorizontal ? Settings.barPositionBottom : true
+    anchors.left: Settings.barHorizontal ? true : !Settings.barPositionRight
+    anchors.right: Settings.barHorizontal ? true : Settings.barPositionRight
 
     readonly property int edgeMargin: Tokens.padding.large
+    // Dock's own auto-hide is a content-transform (translate + opacity,
+    // see DockBar.qml's shouldShow), never a window resize/re-anchor --
+    // matches this repo's shared popout/bar animation discipline. So the
+    // reserved zone itself doesn't collapse to 0 in autohide mode; it
+    // stays reserved (a thin, real strip) the same way Full/Taskbar's own
+    // "autohide" bar visibility mode keeps a reserved sliver rather than
+    // reclaiming the space outright (see BarWrapper.qml's exclusiveZone
+    // comment) -- consistent behavior across every bar style, not a new
+    // Dock-specific rule.
+    readonly property int reservedThickness: (Settings.barHorizontal ? dockBar.implicitHeight : dockBar.implicitWidth) + edgeMargin
+
+    readonly property bool dockedTop: Settings.barHorizontal && !Settings.barPositionBottom
+    readonly property bool dockedBottom: Settings.barHorizontal && Settings.barPositionBottom
+    readonly property bool dockedLeft: !Settings.barHorizontal && !Settings.barPositionRight
+    readonly property bool dockedRight: !Settings.barHorizontal && Settings.barPositionRight
+
+    implicitWidth: Settings.barHorizontal ? screen.width : reservedThickness
+    implicitHeight: Settings.barHorizontal ? reservedThickness : screen.height
+
+    visible: Settings.barStyle === "dock"
 
     mask: Region {
         item: dockBar
@@ -48,7 +78,17 @@ PanelWindow {
         screen: root.screen
         screenState: root.screenState
 
-        x: Settings.barHorizontal ? (root.width - width) / 2 : (Settings.barPositionRight ? root.width - width - root.edgeMargin : root.edgeMargin)
-        y: Settings.barHorizontal ? (Settings.barPositionBottom ? root.height - height - root.edgeMargin : root.edgeMargin) : (root.height - height) / 2
+        // root's own thin-axis size is exactly dockBar's thickness +
+        // edgeMargin (see reservedThickness above) -- pinning the pill
+        // to the edge of root OPPOSITE the docked screen edge naturally
+        // leaves exactly edgeMargin of gap on the docked side and none
+        // on the other, with no manual arithmetic needed. Centered along
+        // the long axis either way.
+        anchors.horizontalCenter: Settings.barHorizontal ? root.horizontalCenter : undefined
+        anchors.verticalCenter: Settings.barHorizontal ? undefined : root.verticalCenter
+        anchors.top: root.dockedBottom ? root.top : undefined
+        anchors.bottom: root.dockedTop ? root.bottom : undefined
+        anchors.left: root.dockedRight ? root.left : undefined
+        anchors.right: root.dockedLeft ? root.right : undefined
     }
 }

--- a/Configs/quickshell/aphotic/modules/bar/components/AgentIndicator.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/AgentIndicator.qml
@@ -19,8 +19,11 @@ Item {
     readonly property var stat: AgentProviders.stats[AgentProviders.selectedIndex] ?? AgentProviders.stats[0]
     readonly property int badgeCount: root.provider.id === "ollama" ? root.stat.loadedModels.length : root.stat.sessionCount
 
-    implicitWidth: root.showBackground ? Settings.barInnerWidth : icon.implicitWidth
-    implicitHeight: root.showBackground ? Settings.barInnerWidth : icon.implicitHeight
+    // Absent, not hidden, when the installer's `ai` layer is off -- the bar
+    // shouldn't leave a gap where a feature the user declined would go.
+    visible: InstallProfile.aiEnabled
+    implicitWidth: !root.visible ? 0 : root.showBackground ? Settings.barInnerWidth : icon.implicitWidth
+    implicitHeight: !root.visible ? 0 : root.showBackground ? Settings.barInnerWidth : icon.implicitHeight
 
     StyledRect {
         id: background

--- a/Configs/quickshell/aphotic/modules/bar/components/StatusIcons.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/StatusIcons.qml
@@ -91,6 +91,29 @@ Item {
         rowSpacing: root.groupSpacing
         columnSpacing: root.groupSpacing
 
+        // Real bug, confirmed live with instrumented width logging (not
+        // guessed): in this state, only `anchors.right` is active for the
+        // along-axis (no opposing `anchors.left`), so QtQuick correctly
+        // leaves `width` un-derived from anchors -- but GridLayout, unlike
+        // some other item types, does NOT automatically keep its own
+        // `width` following its `implicitWidth` just because nothing else
+        // is driving it. Captured data: `groupLayout.width` stayed frozen
+        // at an early, stale value (`Settings.barInnerWidth`, from before
+        // the repeater had populated real icon content) while its real
+        // `implicitWidth` had long since grown to the icons' true combined
+        // width -- so `anchors.right`'s own position math
+        // (`x = root.width - groupLayout.width`) used that stale, too-small
+        // width, placing the pill well short of where the real content
+        // actually needed to start. Every icon still rendered (this
+        // GridLayout doesn't clip), just positioned as if the pill were
+        // much narrower than it truly was -- reported live as the
+        // rightmost status pill (Notifications/bell) rendering outside the
+        // Dock style's own outer pill boundary. Explicit `width:
+        // implicitWidth` here keeps it live-tracking instead of ever
+        // going stale. The default (non-"vertical") state doesn't need
+        // this: `anchors.left` + `anchors.right` together there already
+        // derive `width` correctly (a real opposing anchor pair, unlike
+        // this state's single line).
         states: State {
             name: "vertical"
             when: Settings.barHorizontal
@@ -101,6 +124,10 @@ Item {
                 anchors.top: root.top
                 anchors.bottom: root.bottom
                 anchors.right: root.right
+            }
+
+            PropertyChanges {
+                groupLayout.width: groupLayout.implicitWidth
             }
         }
 

--- a/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
@@ -11,15 +11,26 @@ import qs.services.ai
 StyledRect {
     id: root
 
+    property bool replayMode: false
+
     implicitWidth: 820
-    implicitHeight: 520
+    implicitHeight: root.replayMode ? 620 : 520
     radius: Tokens.rounding.extraLarge
     color: Colours.tPalette.m3surfaceContainer
+
+    Behavior on implicitHeight {
+        Anim { type: Anim.EmphasizedSmall }
+    }
 
     Binding {
         target: AgentGraphService
         property: "surfaceVisible"
         value: root.visible
+    }
+
+    GraphReplay {
+        id: replay
+        events: AgentGraphService.replayEvents
     }
 
     ColumnLayout {
@@ -39,16 +50,61 @@ StyledRect {
 
             StyledText {
                 Layout.fillWidth: true
-                text: AgentGraphService.liveSessionCount === 0
-                    ? qsTr("idle")
-                    : qsTr("%1 live · %2 nodes").arg(AgentGraphService.liveSessionCount).arg(AgentGraphService.nodeCount)
+                text: root.replayMode
+                    ? (replay.loaded ? qsTr("replaying %1 events").arg(replay.events.length) : qsTr("pick a run"))
+                    : AgentGraphService.liveSessionCount === 0
+                        ? qsTr("idle")
+                        : qsTr("%1 live · %2 nodes").arg(AgentGraphService.liveSessionCount).arg(AgentGraphService.nodeCount)
                 font: Tokens.font.label.small
                 color: Colours.palette.m3onSurfaceVariant
             }
 
             StyledRect {
+                implicitWidth: replayLabel.implicitWidth + Tokens.padding.medium
+                implicitHeight: 24
+                radius: Tokens.rounding.full
+                color: root.replayMode ? Colours.palette.m3primary : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+                border.width: 1
+                border.color: root.replayMode ? "transparent" : Colours.palette.m3outlineVariant
+
+                RowLayout {
+                    id: replayLabel
+
+                    anchors.centerIn: parent
+                    spacing: Tokens.spacing.extraSmall
+
+                    MaterialIcon {
+                        text: "history"
+                        fontStyle: Tokens.font.icon.small
+                        color: root.replayMode ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurfaceVariant
+                    }
+
+                    StyledText {
+                        text: qsTr("Replay")
+                        font: Tokens.font.label.small
+                        color: root.replayMode ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurfaceVariant
+                    }
+                }
+
+                StateLayer {
+                    anchors.fill: parent
+                    radius: parent.radius
+                }
+
+                TapHandler {
+                    onTapped: {
+                        root.replayMode = !root.replayMode;
+                        if (root.replayMode)
+                            AgentGraphService.refreshRuns();
+                        else
+                            replay.pause();
+                    }
+                }
+            }
+
+            StyledRect {
                 implicitWidth: tierLabel.implicitWidth + Tokens.padding.medium
-                implicitHeight: tierLabel.implicitHeight + Tokens.padding.extraSmall
+                implicitHeight: 24
                 radius: Tokens.rounding.full
                 color: Qt.alpha(Colours.palette.m3primary, 0.16)
 
@@ -63,9 +119,26 @@ StyledRect {
             }
         }
 
+        // Replay is a different clock over the same renderer, never a second
+        // view -- the only thing that changes is where `sessions` comes from.
         GraphView {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            sessions: root.replayMode ? replay.sessions : AgentGraphService.sessions
+        }
+
+        Loader {
+            Layout.fillWidth: true
+            active: root.replayMode
+            visible: active
+
+            sourceComponent: ReplayBar {
+                replay: replay
+                onExited: {
+                    root.replayMode = false;
+                    replay.pause();
+                }
+            }
         }
     }
 }

--- a/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
 pragma ComponentBehavior: Bound
 
 import QtQuick

--- a/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
@@ -1,0 +1,71 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.components
+import qs.services
+import qs.modules.agentgraph
+import qs.services.ai
+
+StyledRect {
+    id: root
+
+    implicitWidth: 820
+    implicitHeight: 520
+    radius: Tokens.rounding.extraLarge
+    color: Colours.tPalette.m3surfaceContainer
+
+    Binding {
+        target: AgentGraphService
+        property: "surfaceVisible"
+        value: root.visible
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: Tokens.padding.large
+        spacing: Tokens.spacing.small
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Tokens.spacing.small
+
+            StyledText {
+                text: qsTr("Agent graph")
+                font: Tokens.font.title.small
+                color: Colours.palette.m3onSurface
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                text: AgentGraphService.liveSessionCount === 0
+                    ? qsTr("idle")
+                    : qsTr("%1 live · %2 nodes").arg(AgentGraphService.liveSessionCount).arg(AgentGraphService.nodeCount)
+                font: Tokens.font.label.small
+                color: Colours.palette.m3onSurfaceVariant
+            }
+
+            StyledRect {
+                implicitWidth: tierLabel.implicitWidth + Tokens.padding.medium
+                implicitHeight: tierLabel.implicitHeight + Tokens.padding.extraSmall
+                radius: Tokens.rounding.full
+                color: Qt.alpha(Colours.palette.m3primary, 0.16)
+
+                StyledText {
+                    id: tierLabel
+
+                    anchors.centerIn: parent
+                    text: AgentGraphService.tier
+                    font: Tokens.font.label.small
+                    color: Colours.palette.m3primary
+                }
+            }
+        }
+
+        GraphView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/dashboard/DashboardContent.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/DashboardContent.qml
@@ -11,14 +11,22 @@ ColumnLayout {
     required property ScreenState screenState
     property string currentTab: "dashboard"
 
+    // The AI tabs are absent, not empty, when the installer's `ai` layer is
+    // off -- see services/InstallProfile.qml.
     readonly property var tabs: [
         { id: "dashboard", icon: "dashboard", label: qsTr("Dashboard") },
         { id: "performance", icon: "monitoring", label: qsTr("Performance") },
         { id: "workspaces", icon: "grid_view", label: qsTr("Workspaces") },
-        { id: "wallpapers", icon: "wallpaper", label: qsTr("Wallpapers") },
+        { id: "wallpapers", icon: "wallpaper", label: qsTr("Wallpapers") }
+    ].concat(InstallProfile.aiEnabled ? [
         { id: "aiChat", icon: "smart_toy", label: qsTr("AI Chat") },
         { id: "agentGraph", icon: "account_tree", label: qsTr("Agent Graph") }
-    ]
+    ] : [])
+
+    onTabsChanged: {
+        if (!root.tabs.some(t => t.id === root.currentTab))
+            root.currentTab = "dashboard";
+    }
 
     spacing: Tokens.spacing.medium
 

--- a/Configs/quickshell/aphotic/modules/dashboard/DashboardContent.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/DashboardContent.qml
@@ -16,7 +16,8 @@ ColumnLayout {
         { id: "performance", icon: "monitoring", label: qsTr("Performance") },
         { id: "workspaces", icon: "grid_view", label: qsTr("Workspaces") },
         { id: "wallpapers", icon: "wallpaper", label: qsTr("Wallpapers") },
-        { id: "aiChat", icon: "smart_toy", label: qsTr("AI Chat") }
+        { id: "aiChat", icon: "smart_toy", label: qsTr("AI Chat") },
+        { id: "agentGraph", icon: "account_tree", label: qsTr("Agent Graph") }
     ]
 
     spacing: Tokens.spacing.medium
@@ -91,6 +92,8 @@ ColumnLayout {
                     return wallpapersComp;
                 case "aiChat":
                     return aiChatComp;
+                case "agentGraph":
+                    return agentGraphComp;
                 default:
                     return dashboardComp;
                 }
@@ -133,5 +136,9 @@ ColumnLayout {
     Component {
         id: aiChatComp
         AiChatTab {}
+    }
+    Component {
+        id: agentGraphComp
+        AgentGraphTab {}
     }
 }

--- a/Configs/quickshell/aphotic/modules/dashboard/qmldir
+++ b/Configs/quickshell/aphotic/modules/dashboard/qmldir
@@ -1,4 +1,5 @@
 module qs.modules.dashboard
+AgentGraphTab 1.0 AgentGraphTab.qml
 AiChatTab 1.0 AiChatTab.qml
 CommandCenterTabBar 1.0 CommandCenterTabBar.qml
 Dashboard 1.0 Dashboard.qml

--- a/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
@@ -13,6 +13,7 @@ ColumnLayout {
 
     readonly property var accentPresets: ["", "#4A5A52", "#669B04", "#3B82F6", "#EF4444", "#F59E0B", "#8B5CF6", "#EC4899", "#14B8A6"]
     readonly property var depthEffectsPresets: [{ value: "off", label: qsTr("Off") }, { value: "subtle", label: qsTr("Subtle") }, { value: "full", label: qsTr("Full") }]
+    readonly property var agentGraphPresets: [{ value: "auto", label: qsTr("Auto") }, { value: "lite", label: qsTr("Lite") }, { value: "standard", label: qsTr("Standard") }, { value: "full", label: qsTr("Full") }]
 
     property var cursorThemes: []
     property var iconThemes: []
@@ -142,6 +143,43 @@ ColumnLayout {
             presets: root.depthEffectsPresets
             value: Settings.depthEffects
             onSelected: value => Settings.depthEffects = value
+        }
+    }
+
+    StyledText {
+        Layout.topMargin: Tokens.spacing.small
+        text: qsTr("Agent graph")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.medium
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        text: qsTr("How much of the agent graph is simulated, not how it looks — every tier draws the same thing. Auto reads your GPU and eases off while Ollama has models loaded, so the graph never competes with a local model for VRAM.")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.body.small
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+
+        SettingsPresetRow {
+            icon: "hub"
+            label: qsTr("Detail")
+            presets: root.agentGraphPresets
+            value: Settings.agentGraphQuality
+            onSelected: value => Settings.agentGraphQuality = value
+        }
+
+        SettingsRow {
+            icon: "palette"
+            label: qsTr("Graph accent")
+
+            ColorPickerField {
+                value: Settings.agentGraphAccent
+                onValueChanged: Settings.agentGraphAccent = value
+            }
         }
     }
 

--- a/Configs/quickshell/aphotic/services/AgentProviders.qml
+++ b/Configs/quickshell/aphotic/services/AgentProviders.qml
@@ -28,6 +28,8 @@ Singleton {
         liveSessions: []
     }))
 
+    readonly property var ollamaLoadedModels: root.stats[root.providers.findIndex(p => p.id === "ollama")]?.loadedModels ?? []
+
     readonly property string selected: Settings.agentSelectedProvider
     readonly property int selectedIndex: providers.findIndex(p => p.id === root.selected)
 

--- a/Configs/quickshell/aphotic/services/AgentProviders.qml
+++ b/Configs/quickshell/aphotic/services/AgentProviders.qml
@@ -102,7 +102,7 @@ Singleton {
 
     Timer {
         interval: 5000
-        running: true
+        running: InstallProfile.aiEnabled
         repeat: true
         triggeredOnStart: true
         onTriggered: {
@@ -184,7 +184,7 @@ Singleton {
 
     Timer {
         interval: 5000
-        running: true
+        running: InstallProfile.aiEnabled
         repeat: true
         triggeredOnStart: true
         onTriggered: {

--- a/Configs/quickshell/aphotic/services/InstallProfile.qml
+++ b/Configs/quickshell/aphotic/services/InstallProfile.qml
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Single source for what the installer actually enabled. Feature surfaces
+// read this instead of each one guessing from whether some state file
+// happens to exist -- "the AI layer is off" has to mean the surface is
+// absent, not present-but-empty.
+Singleton {
+    id: root
+
+    readonly property string profile: root._profile
+    readonly property var layers: root._layers
+    readonly property bool known: root._known
+
+    // Unknown is treated as enabled on purpose: a user running from a git
+    // clone with no aphotic.toml yet should see the shell they cloned, not a
+    // silently stripped one. Only an explicit config turns a layer off.
+    readonly property bool aiEnabled: !root._known || root.hasLayer("ai")
+
+    property string _profile: ""
+    property var _layers: []
+    property bool _known: false
+
+    function hasLayer(name: string): bool {
+        return root._layers.includes(name);
+    }
+
+    FileView {
+        path: `${Quickshell.env("HOME")}/Aphotic-Hypr/aphotic.toml`
+        watchChanges: true
+        onFileChanged: reload()
+        onLoaded: {
+            const raw = text();
+            root._profile = (raw.match(/profile\s*=\s*"([^"]*)"/) ?? [])[1] ?? "";
+            const list = (raw.match(/layers\s*=\s*\[([^\]]*)\]/) ?? [])[1] ?? "";
+            root._layers = list.split(",").map(v => v.replace(/["\s]/g, "")).filter(v => v.length > 0);
+            root._known = true;
+        }
+        onLoadFailed: {
+            root._profile = "";
+            root._layers = [];
+            root._known = false;
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -116,6 +116,7 @@ Singleton {
     // for the same reason depthEffects defaults to "subtle": nobody's
     // machine should pick up load from an upgrade it never opted into.
     property string agentGraphQuality: "auto"
+    property string agentGraphAccent: ""
     property string ggufModelsDir: `${Quickshell.env("HOME")}/Models/gguf`
 
     property bool intelligenceEnabled: true
@@ -272,6 +273,7 @@ Singleton {
             minimalShowDnd: root.minimalShowDnd,
             agentSelectedProvider: root.agentSelectedProvider,
             agentGraphQuality: root.agentGraphQuality,
+            agentGraphAccent: root.agentGraphAccent,
             ggufModelsDir: root.ggufModelsDir,
             assistantWelcomeShown: root.assistantWelcomeShown,
             dndEnabled: root.dndEnabled,
@@ -577,6 +579,8 @@ Singleton {
                     root.agentSelectedProvider = data.agentSelectedProvider;
                 if (typeof data.agentGraphQuality === "string" && ["auto", "lite", "standard", "full"].includes(data.agentGraphQuality))
                     root.agentGraphQuality = data.agentGraphQuality;
+                if (typeof data.agentGraphAccent === "string")
+                    root.agentGraphAccent = data.agentGraphAccent;
                 if (typeof data.ggufModelsDir === "string" && data.ggufModelsDir.length > 0)
                     root.ggufModelsDir = data.ggufModelsDir;
                 if (typeof data.assistantWelcomeShown === "boolean")

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -108,6 +108,14 @@ Singleton {
     }
 
     property string agentSelectedProvider: "claude"
+    // Node budget and layout tick rate for the agent graph surface, never
+    // its visual treatment -- every tier renders the same look. "auto"
+    // resolves from the detected GPU and demotes a tier while Ollama holds
+    // models resident (see services/ai/AgentGraphService.qml); "lite",
+    // "standard" and "full" pin it. Defaults to "auto" rather than "full"
+    // for the same reason depthEffects defaults to "subtle": nobody's
+    // machine should pick up load from an upgrade it never opted into.
+    property string agentGraphQuality: "auto"
     property string ggufModelsDir: `${Quickshell.env("HOME")}/Models/gguf`
 
     property bool intelligenceEnabled: true
@@ -263,6 +271,7 @@ Singleton {
             taskbarGrouping: root.taskbarGrouping,
             minimalShowDnd: root.minimalShowDnd,
             agentSelectedProvider: root.agentSelectedProvider,
+            agentGraphQuality: root.agentGraphQuality,
             ggufModelsDir: root.ggufModelsDir,
             assistantWelcomeShown: root.assistantWelcomeShown,
             dndEnabled: root.dndEnabled,
@@ -566,6 +575,8 @@ Singleton {
                     root.minimalShowDnd = data.minimalShowDnd;
                 if (typeof data.agentSelectedProvider === "string" && ["claude", "codex", "ollama"].includes(data.agentSelectedProvider))
                     root.agentSelectedProvider = data.agentSelectedProvider;
+                if (typeof data.agentGraphQuality === "string" && ["auto", "lite", "standard", "full"].includes(data.agentGraphQuality))
+                    root.agentGraphQuality = data.agentGraphQuality;
                 if (typeof data.ggufModelsDir === "string" && data.ggufModelsDir.length > 0)
                     root.ggufModelsDir = data.ggufModelsDir;
                 if (typeof data.assistantWelcomeShown === "boolean")

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -306,7 +306,7 @@ Singleton {
 
     Process {
         id: eventTail
-        running: true
+        running: InstallProfile.aiEnabled
         command: ["sh", "-c", `mkdir -p '${root._stateDir}' && : >> '${root._stateDir}/agent-events.jsonl' && exec tail -n 400 -F '${root._stateDir}/agent-events.jsonl'`]
         stdout: SplitParser {
             splitMarker: "\n"

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -200,12 +200,13 @@ Singleton {
         return sessions;
     }
 
-    // Claude Code gives no explicit parent for a subagent's tool calls --
-    // they carry agent_id and the PARENT session's session_id, nothing that
-    // names the Task call that spawned them. So the first tool call seen for
-    // an agent_id is bound to the most recent still-running Task node in that
-    // session, and every later call from the same agent_id inherits that
-    // binding. Documented heuristic, not a claimed guarantee.
+    // Parentage is an exact link, not a guess: the Agent/Task call's own
+    // PostToolUse response names the agent id it spawned (captured by
+    // agent_hook.py as spawnedAgentId), and every later event from that
+    // subagent carries the same id as agent_id. The fallback below only runs
+    // if that binding is missing -- and it deliberately does NOT require the
+    // Agent node to still be running, because an async Agent call completes
+    // *before* the subagent it launched makes its first tool call.
     function _parentFor(session, record): string {
         if (!record.agentId)
             return "";
@@ -247,11 +248,15 @@ Singleton {
 
     function _closeNode(session, record): void {
         const id = record.toolId ?? "";
+        if (record.spawnedAgentId && id)
+            session.agentParents[record.spawnedAgentId] = id;
         const index = session.nodes.findIndex(n => n.id === id);
         if (index === -1)
             return;
         const node = Object.assign({}, session.nodes[index]);
         node.status = record.event === "post_tool_use_failure" ? "errored" : "completed";
+        if (record.agentDescription)
+            node.agentDescription = record.agentDescription;
         node.endedAt = record.t ?? 0;
         node.durationMs = record.durationMs ?? (node.endedAt && node.startedAt ? node.endedAt - node.startedAt : 0);
         session.nodes[index] = node;

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
 pragma Singleton
 pragma ComponentBehavior: Bound
 

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -1,0 +1,308 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+
+// Single-sourced state for the agent graph surface. Owns the ONE event
+// pipeline shared with the bar's agent popout (Configs/.local/lib/aphotic/
+// agent_hook.sh writes it, this reads it) -- no consumer keeps its own copy
+// of session/node/edge state, and nothing here re-derives what
+// AgentProviders already tracks.
+Singleton {
+    id: root
+
+    readonly property var sessions: root._sessions
+    readonly property var events: root._events
+    readonly property int liveSessionCount: root._sessions.filter(s => s.status !== "ended").length
+    readonly property int nodeCount: root._sessions.reduce((n, s) => n + s.nodes.length, 0)
+
+    // Set true only while a graph surface is actually on screen. The event
+    // tail keeps running either way (parsing a line costs nothing); this
+    // gates the expensive half -- layout relaxation in the renderer.
+    property bool surfaceVisible: false
+    readonly property bool shouldSimulate: root.surfaceVisible && root.nodeCount > 0
+
+    // Hardware tiering, resolved once from real signals rather than assumed:
+    // the same shell runs on a software-rendered dev VM and on a discrete-GPU
+    // workstation. Tiers scale how MUCH is simulated (node budget, tick
+    // rate), never how it looks -- every tier renders the same Aphotic visual
+    // language. Manual override values are "lite"/"standard"/"full"; "auto"
+    // (the default) resolves below.
+    readonly property string tier: {
+        const requested = Settings.agentGraphQuality;
+        if (requested === "lite" || requested === "standard" || requested === "full")
+            return requested;
+        return root._demote(root._detectedTier, root._gpuContended);
+    }
+
+    readonly property int maxNodesPerSession: root.tier === "full" ? 300 : root.tier === "standard" ? 150 : 60
+    readonly property int layoutHz: root.tier === "lite" ? 30 : 60
+    readonly property int maxEvents: root.tier === "full" ? 2400 : root.tier === "standard" ? 1200 : 600
+    // Edge particles are the "this graph is alive" signal, so they are never
+    // switched off by tier -- only thinned. A lite machine still sees flow
+    // along a working edge, just fewer packets in it.
+    readonly property int edgeParticles: root.tier === "full" ? 6 : root.tier === "standard" ? 3 : 1
+    readonly property bool anyRunning: root._sessions.some(s => s.status === "running")
+
+    // Ollama holding models resident is VRAM the graph should not compete
+    // for -- an AI-native shell that stutters the model it exists to monitor
+    // has its priorities backwards. One tier down while models are loaded.
+    readonly property bool _gpuContended: AgentProviders.ollamaLoadedModels.length > 0
+
+    readonly property string _detectedTier: {
+        const name = SystemUsage.gpuName.toLowerCase();
+        if (!name)
+            return "standard";
+        if (/qemu|virtio|vmware|virtualbox|llvmpipe|softpipe|cirrus|bochs/.test(name))
+            return "lite";
+        if (/nvidia|geforce|rtx|quadro|radeon|amd\/ati|navi|arc a[0-9]/.test(name))
+            return "full";
+        return "standard";
+    }
+
+    function _demote(tier: string, should: bool): string {
+        if (!should)
+            return tier;
+        return tier === "full" ? "standard" : "lite";
+    }
+
+    readonly property var runs: root._runs
+    readonly property string replayRunId: root._replayRunId
+    readonly property var replayEvents: root._replayEvents
+    readonly property int replaySpan: root._replayEvents.length > 1 ? (root._replayEvents[root._replayEvents.length - 1].t ?? 0) - (root._replayEvents[0].t ?? 0) : 0
+
+    property var _sessions: []
+    property var _runs: []
+    property string _replayRunId: ""
+    property var _replayEvents: []
+    property var _events: []
+    property var _seen: ({})
+    property int _seenCount: 0
+
+    readonly property string _stateDir: `${Quickshell.env("HOME")}/.local/state/aphotic`
+
+    function sessionById(id: string): var {
+        return root._sessions.find(s => s.id === id) ?? null;
+    }
+
+    function _key(record): string {
+        return `${record.sessionId}|${record.event}|${record.toolId ?? ""}|${record.t ?? record.timestamp}`;
+    }
+
+    function _ingest(line: string): void {
+        let record;
+        try {
+            record = JSON.parse(line);
+        } catch (e) {
+            return;
+        }
+        if (!record || !record.sessionId || !record.event)
+            return;
+
+        // tail -F re-reads from the top when the hook rotates the log, and
+        // startup replays the tail on purpose, so every record has to be
+        // idempotent by key rather than assumed to arrive once.
+        const key = root._key(record);
+        if (root._seen[key])
+            return;
+        if (root._seenCount > root.maxEvents * 4) {
+            root._seen = ({});
+            root._seenCount = 0;
+        }
+        root._seen[key] = true;
+        root._seenCount++;
+
+        const events = root._events.slice();
+        events.push(record);
+        while (events.length > root.maxEvents)
+            events.shift();
+        root._events = events;
+
+        root._apply(record);
+    }
+
+    function _blankSession(record): var {
+        return {
+            id: record.sessionId,
+            status: "idle",
+            model: record.model ?? "",
+            startedAt: record.t ?? 0,
+            updatedAt: record.t ?? 0,
+            endedAt: 0,
+            nodes: [],
+            agentParents: ({})
+        };
+    }
+
+    function _apply(record): void {
+        const sessions = root._sessions.slice();
+        let index = sessions.findIndex(s => s.id === record.sessionId);
+        if (index === -1) {
+            sessions.push(root._blankSession(record));
+            index = sessions.length - 1;
+        }
+        const session = Object.assign({}, sessions[index]);
+        session.nodes = session.nodes.slice();
+        session.updatedAt = record.t ?? session.updatedAt;
+
+        if (record.event === "session_end") {
+            session.status = "ended";
+            session.endedAt = record.t ?? 0;
+        } else if (record.event === "stop" || record.event === "subagent_stop") {
+            session.status = "idle";
+        } else if (record.event === "notification") {
+            session.status = "waiting";
+        } else if (record.event === "pre_tool_use") {
+            session.status = "running";
+            root._openNode(session, record);
+        } else if (record.event === "post_tool_use" || record.event === "post_tool_use_failure") {
+            session.status = "running";
+            root._closeNode(session, record);
+        } else if (record.event === "session_start") {
+            session.status = "idle";
+            session.model = record.model ?? session.model;
+        }
+
+        sessions[index] = session;
+        root._sessions = sessions;
+    }
+
+    // Claude Code gives no explicit parent for a subagent's tool calls --
+    // they carry agent_id and the PARENT session's session_id, nothing that
+    // names the Task call that spawned them. So the first tool call seen for
+    // an agent_id is bound to the most recent still-running Task node in that
+    // session, and every later call from the same agent_id inherits that
+    // binding. Documented heuristic, not a claimed guarantee.
+    function _parentFor(session, record): string {
+        if (!record.agentId)
+            return "";
+        const bound = session.agentParents[record.agentId];
+        if (bound)
+            return bound;
+        for (let i = session.nodes.length - 1; i >= 0; i--) {
+            const node = session.nodes[i];
+            if (node.tool === "Agent" || node.tool === "Task") {
+                session.agentParents[record.agentId] = node.id;
+                return node.id;
+            }
+        }
+        return "";
+    }
+
+    function _openNode(session, record): void {
+        const id = record.toolId ?? `${record.event}-${record.t}`;
+        if (session.nodes.some(n => n.id === id))
+            return;
+        session.nodes.push({
+            id: id,
+            tool: record.tool ?? "",
+            agentId: record.agentId ?? "",
+            agentType: record.agentType ?? "",
+            parentId: root._parentFor(session, record),
+            status: "running",
+            startedAt: record.t ?? 0,
+            endedAt: 0,
+            durationMs: 0
+        });
+        while (session.nodes.length > root.maxNodesPerSession) {
+            const oldest = session.nodes.findIndex(n => n.status !== "running");
+            if (oldest === -1)
+                break;
+            session.nodes.splice(oldest, 1);
+        }
+    }
+
+    function _closeNode(session, record): void {
+        const id = record.toolId ?? "";
+        const index = session.nodes.findIndex(n => n.id === id);
+        if (index === -1)
+            return;
+        const node = Object.assign({}, session.nodes[index]);
+        node.status = record.event === "post_tool_use_failure" ? "errored" : "completed";
+        node.endedAt = record.t ?? 0;
+        node.durationMs = record.durationMs ?? (node.endedAt && node.startedAt ? node.endedAt - node.startedAt : 0);
+        session.nodes[index] = node;
+    }
+
+    // Replay reads a finished run's own archive (see agent_hook.py), not the
+    // live rotating log -- the live log is a tail by design and a run older
+    // than a few hundred events would already be gone from it.
+    function refreshRuns(): void {
+        runLister.running = false;
+        runLister.command = ["sh", "-c", `ls -t '${root._stateDir}/agent-runs'/*.jsonl 2>/dev/null | head -n 25`];
+        runLister.running = true;
+    }
+
+    function loadRun(id: string): void {
+        if (!id)
+            return;
+        root._replayRunId = id;
+        root._replayEvents = [];
+        runReader.running = false;
+        runReader.command = ["cat", `${root._stateDir}/agent-runs/${id}.jsonl`];
+        runReader.running = true;
+    }
+
+    function clearReplay(): void {
+        root._replayRunId = "";
+        root._replayEvents = [];
+    }
+
+    Process {
+        id: runLister
+        stdout: StdioCollector {
+            onStreamFinished: {
+                root._runs = text.split("\n").filter(l => l.length > 0).map(path => ({
+                    id: path.slice(path.lastIndexOf("/") + 1).replace(/\.jsonl$/, ""),
+                    path: path
+                }));
+            }
+        }
+    }
+
+    Process {
+        id: runReader
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const parsed = [];
+                for (const line of text.split("\n")) {
+                    if (!line.length)
+                        continue;
+                    try {
+                        parsed.push(JSON.parse(line));
+                    } catch (e) {
+                        continue;
+                    }
+                }
+                root._replayEvents = parsed;
+            }
+        }
+    }
+
+    Process {
+        id: eventTail
+        running: true
+        command: ["sh", "-c", `mkdir -p '${root._stateDir}' && : >> '${root._stateDir}/agent-events.jsonl' && exec tail -n 400 -F '${root._stateDir}/agent-events.jsonl'`]
+        stdout: SplitParser {
+            splitMarker: "\n"
+            onRead: data => root._ingest(data)
+        }
+    }
+
+    // Ended sessions linger deliberately so a finished run doesn't vanish
+    // mid-glance; the renderer fades them out well before this prunes them.
+    Timer {
+        interval: 30000
+        running: true
+        repeat: true
+        onTriggered: {
+            const cutoff = Date.now() - 60000;
+            const kept = root._sessions.filter(s => s.status !== "ended" || s.endedAt > cutoff);
+            if (kept.length !== root._sessions.length)
+                root._sessions = kept;
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -129,6 +129,7 @@ Singleton {
             id: record.sessionId,
             status: "idle",
             model: record.model ?? "",
+            cwd: record.cwd ?? "",
             startedAt: record.t ?? 0,
             updatedAt: record.t ?? 0,
             endedAt: 0,
@@ -165,6 +166,8 @@ Singleton {
             session.status = "idle";
             session.model = record.model ?? session.model;
         }
+        if (record.cwd)
+            session.cwd = record.cwd;
 
         sessions[index] = session;
         root._sessions = sessions;

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -159,7 +159,15 @@ Singleton {
         session.nodes = session.nodes.slice();
         session.agentParents = Object.assign({}, session.agentParents);
         session.updatedAt = record.t ?? session.updatedAt;
+        if (session.status === "ended" && record.event !== "session_end")
+            session.endedAt = 0;
 
+        // Observed on real data, not assumed: Claude Code emits session_end
+        // followed by session_start for the SAME session_id when the process
+        // restarts or a session resumes. So session_end is the end of a
+        // session *instance*, not proof the session is over -- any later
+        // event revives it, keeping the tool-call history it already had
+        // rather than starting from blank.
         if (record.event === "session_end") {
             session.status = "ended";
             session.endedAt = record.t ?? 0;
@@ -321,8 +329,8 @@ Singleton {
         running: true
         repeat: true
         onTriggered: {
-            const cutoff = Date.now() - 60000;
-            const kept = root._sessions.filter(s => s.status !== "ended" || s.endedAt > cutoff);
+            const cutoff = Date.now() - 300000;
+            const kept = root._sessions.filter(s => s.status !== "ended" || s.endedAt > cutoff || s.updatedAt > s.endedAt);
             if (kept.length !== root._sessions.length)
                 root._sessions = kept;
         }

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -139,7 +139,14 @@ Singleton {
     }
 
     function _apply(record): void {
-        const sessions = root._sessions.slice();
+        root._sessions = root.applyTo(root._sessions, record);
+    }
+
+    // The same reducer drives live ingestion and replay -- replay is a
+    // different clock over the same events, not a second derivation of what
+    // a session looks like. Anything that changes here changes both.
+    function applyTo(existing, record): var {
+        const sessions = existing.slice();
         let index = sessions.findIndex(s => s.id === record.sessionId);
         if (index === -1) {
             sessions.push(root._blankSession(record));
@@ -147,6 +154,7 @@ Singleton {
         }
         const session = Object.assign({}, sessions[index]);
         session.nodes = session.nodes.slice();
+        session.agentParents = Object.assign({}, session.agentParents);
         session.updatedAt = record.t ?? session.updatedAt;
 
         if (record.event === "session_end") {
@@ -170,7 +178,15 @@ Singleton {
             session.cwd = record.cwd;
 
         sessions[index] = session;
-        root._sessions = sessions;
+        return sessions;
+    }
+
+    function foldEvents(events, upTo: int): var {
+        let sessions = [];
+        const limit = Math.min(upTo, events.length);
+        for (let i = 0; i < limit; i++)
+            sessions = root.applyTo(sessions, events[i]);
+        return sessions;
     }
 
     // Claude Code gives no explicit parent for a subagent's tool calls --

--- a/Configs/quickshell/aphotic/services/ai/qmldir
+++ b/Configs/quickshell/aphotic/services/ai/qmldir
@@ -1,4 +1,5 @@
 module qs.services.ai
+singleton AgentGraphService 1.0 AgentGraphService.qml
 singleton AiConfig 1.0 AiConfig.qml
 singleton AiKeys 1.0 AiKeys.qml
 singleton AiProviders 1.0 AiProviders.qml

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -9,6 +9,7 @@ singleton EmojiList 1.0 EmojiList.qml
 singleton HostInfo 1.0 HostInfo.qml
 singleton Hypr 1.0 Hypr.qml
 singleton HyprKeybinds 1.0 HyprKeybinds.qml
+singleton InstallProfile 1.0 InstallProfile.qml
 singleton LauncherUsage 1.0 LauncherUsage.qml
 singleton LlmFit 1.0 LlmFit.qml
 singleton ModelStorage 1.0 ModelStorage.qml

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Waybar, Mako, Swaylock, and Rofi are retired in favor of one hand-vendored [Quic
 
 | Module | Replaces | Notes |
 |---|---|---|
-| Bar | Waybar | Four swappable bar styles -- Full (dockable left/right/top/bottom, pill or square background), Dock (floating macOS-style app dock), Taskbar (Windows-style grouped task list), Minimal (Omarchy-style thin icon strip) -- switchable live from Settings → Bar, `aphotic bar style <name>`, or SUPER+CTRL+SHIFT+B to cycle. Full's workspaces/active window/tray/clock/status icons all keep their real hover popouts (see below). See [`docs/bar-styles.md`](docs/bar-styles.md) for how each style is built and a migration note for anyone with `barSkin: "minimal"` already saved |
+| Bar | Waybar | Four swappable bar styles -- Full (dockable left/right/top/bottom, pill or square background), Dock (floating macOS-style app dock), Taskbar (Windows-style grouped task list), Minimal (Omarchy-style thin icon strip) -- switchable live from Settings → Bar, `aphotic bar style <name>`, or SUPER+CTRL+SHIFT+B to cycle. Full's workspaces/active window/tray/clock/status icons all keep their real hover popouts (see below). Anyone with `barSkin: "minimal"` already saved is migrated automatically |
 | Bar popouts | — | Hover any status icon, the tray, or the active window pill for a real detail panel — volume, Wi-Fi, Bluetooth, battery/power profile, agent sessions, host info, Pomodoro, window title, keyboard layout, lock state, live resource meter |
 | Launcher | Rofi (drun, clipboard, emoji, wallpaper) | One search box, mode switched by a prefix — see [Launcher modes](#launcher-modes) below |
 | Screenshot picker | `grim`/`slurp` combo scripts | Drag-select a region with live client-window snapping and a freeze-mode preview — `SUPER+Shift+S` (see [Keybindings](#keybindings) for the freeze/clipboard variants); the plain `grim`/`slurp`/`swappy` combo stays on `SUPER+S` |
@@ -194,7 +194,7 @@ Waybar, Mako, Swaylock, and Rofi are retired in favor of one hand-vendored [Quic
 | Lock screen | Swaylock | Real `ext-session-lock-v1` + real PAM auth via the system's own `/etc/pam.d/swaylock` service — `SUPER+L` |
 | Session/power menu | Rofi's powermenu | Lock, suspend, log out, hibernate, reboot, shut down — `SUPER+Backspace` |
 | Command Center | — | Tabbed dashboard overlay — Dashboard (clock/calendar/media, weather, Pomodoro, Wi-Fi/Bluetooth/DND quick toggles), Performance (live CPU/GPU/memory/storage/network cards), Workspaces (numbered grid, click to jump), Wallpapers (cycle/pick within the active theme live, without opening Settings), AI Chat (Claude/Ollama/Gemini/ChatGPT, see below) — `SUPER+D` |
-| Settings | — | Full-screen Control Center — searchable category rail (Appearance, Theme Creator, Personalization, Bar, Displays, Clock/Date, OSD/Notifications, AI, Power & Security, Workspace Profiles, System, About), cross-theme wallpaper picker, live doctor output — `SUPER+I` |
+| Settings | — | Full-screen Control Center — searchable category rail (Appearance, Theme Creator, Personalization, Bar, Launcher, Displays, Clock/Date, OSD/Notifications, AI, Power & Security, Network, Workspace Profiles, Plugins, System, About), cross-theme wallpaper picker, live doctor output — `SUPER+I` |
 | Intelligence | — | Right-docked quick-chat popout, separate from the Command Center's AI Chat tab — persisted session history, per-session provider/model, click-outside or `Esc` to dismiss — `SUPER+Shift+A` (see below) |
 | Eyedropper | — | Single-click screen color picker — samples one pixel via `grim`, copies its hex to the clipboard, confirms with a notification carrying a generated color swatch icon — `SUPER+Shift+C` |
 
@@ -209,7 +209,7 @@ The Command Center's AI Chat tab talks to four providers behind one interface, p
 - **Ollama model manager** (Settings → AI) — every installed model with live/idle status and VRAM usage, one click to set active, delete, or pull-by-name to download a new one, straight against Ollama's own REST API.
 - **Weather card** (Command Center → Dashboard) — current temperature/condition plus a 3-day forecast via Open-Meteo. Leave the location blank for IP-based auto-detection, or set an explicit city + Celsius/Fahrenheit in Settings → Clock/Date. The resolved location and last-good forecast are cached to disk, so a fresh shell start shows the last known weather immediately instead of a blank card.
 - **Aphotic Assistant** (opt-in) — a local chatbot pinned to a fixed persona/system-prompt, installed via `install.sh` on NVIDIA machines that have (or add) the `ai` layer. Shows up as a fifth provider pill once installed, in both AI Chat and Intelligence. Picks its model via `llmfit`'s hardware-aware recommendation at install time (a small broadly-compatible default if `llmfit` isn't available), greets you once on first open, and Settings → AI shows its installed model with reinstall/uninstall controls. `install.sh --with-assistant`/`--no-assistant` skip the prompt; silently unavailable on non-NVIDIA machines.
-- **Agent module** (bar icon) — tracks three CLI providers, Claude Code/Codex/Ollama, behind one switchable icon: left-click for a session/token-usage or loaded-models panel, right-click launches the provider in a new terminal, middle-click cycles providers. Usage comes from a 15-minute local-transcript scan (aggregate token counts only, never prompts/responses — see [`docs/AGENT_TRACKING.md`](docs/AGENT_TRACKING.md)); surfacing the Claude Code hook's live per-session data in the panel is still open.
+- **Agent module** (bar icon) — tracks three CLI providers, Claude Code/Codex/Ollama, behind one switchable icon: left-click for a session/token-usage or loaded-models panel, right-click launches the provider in a new terminal, middle-click cycles providers. Usage comes from a 15-minute local-transcript scan (aggregate token counts only, never prompts/responses); the Claude Code hook's live per-session data is read and rendered as real per-session rows in the panel. The agent stack as a whole follows the installer's `ai` layer — with it off, the hook is never wired and the module doesn't run.
 
 </details>
 
@@ -284,7 +284,7 @@ Every toggle here persists to `~/.local/state/aphotic/settings.json` and survive
 
 ## Plugin System
 
-Aphotic ships a small plugin mechanism (design in [`docs/PLUGIN_SYSTEM.md`](docs/PLUGIN_SYSTEM.md)): a plugin is a directory with a `plugin.toml` manifest and one or more hook scripts. Every theme apply (`aphotic theme`, the Wallpapers picker, or `wallswitcher.py`) fires each enabled plugin's `on_theme_change` hook with the freshly-resolved palette as JSON on stdin; a project opened from the launcher's `@` mode or a Workspace Profile launch fires `on_project_open`/`on_workspace_launch` for any plugin that declares interest in that specific hook. All hooks are fire-and-forget, backgrounded, with a 5-second timeout so a slow or broken plugin can't stall what it's piggybacking on. A `category` field (dev/security/mobile/ai/theming/productivity) drives filtering in `aphotic plugin list --remote` and Settings → Plugins; security-category plugins live in a separate index that stays untrusted (and unfetched) until explicitly opted into.
+Aphotic ships a small plugin mechanism (design docs live in the repo's maintainer notes): a plugin is a directory with a `plugin.toml` manifest and one or more hook scripts. Every theme apply (`aphotic theme`, the Wallpapers picker, or `wallswitcher.py`) fires each enabled plugin's `on_theme_change` hook with the freshly-resolved palette as JSON on stdin; a project opened from the launcher's `@` mode or a Workspace Profile launch fires `on_project_open`/`on_workspace_launch` for any plugin that declares interest in that specific hook. All hooks are fire-and-forget, backgrounded, with a 5-second timeout so a slow or broken plugin can't stall what it's piggybacking on. A `category` field (dev/security/mobile/ai/theming/productivity) drives filtering in `aphotic plugin list --remote` and Settings → Plugins; security-category plugins live in a separate index that stays untrusted (and unfetched) until explicitly opted into.
 
 Plugins are distributed from a separate, purpose-built repo, [`aphotic-plugins`](https://github.com/T-Crypt/aphotic-plugins) — kept apart from the main dotfiles so plugins can version and release independently. `aphotic plugin list --remote` (and Settings → Plugins' **Browse available** list) reads that repo's lightweight `index.json` without needing a full clone; `aphotic plugin install <name>` (or the Settings UI's Install button) clones just that plugin locally. The first real plugin, **OpenRGB Sync**, sets your RGB lighting to the theme's accent color on every theme change.
 
@@ -341,12 +341,16 @@ Running with no flags launches a short wizard: profile, optional layers, theme. 
 |---|---|
 | `--profile <minimal\|full>` | Selects the base package set. Skips the profile prompt. |
 | `--with <layer,layer,...>` | Comma-separated layers to merge in: `gaming`, `dev`, `ai`, `exploit` (a convenience bundle of `exploit-recon`+`exploit-web`+`exploit-network`), or any individual `exploit-*` sublayer (`exploit-recon`, `exploit-web`, `exploit-network`, `exploit-passwords`, `exploit-wordlists`, `exploit-reversing`, `exploit-forensics`, `exploit-reporting`). Skips the layer prompts. |
-| `--accept-exploit-disclaimer` | Required alongside `--with` in non-interactive/scripted installs when any `exploit`/`exploit-*` layer is selected — accepts the authorized-use disclaimer without the interactive typed-confirmation prompt. See [`docs/exploit-layer.md`](docs/exploit-layer.md). |
+| `--accept-exploit-disclaimer` | Required alongside `--with` in non-interactive/scripted installs when any `exploit`/`exploit-*` layer is selected — accepts the authorized-use disclaimer without the interactive typed-confirmation prompt. The disclaimer text is shown in full before anything is installed. |
 | `--theme <name>` | Pre-selects a theme. Skips the theme prompt. |
+| `--with-assistant` / `--no-assistant` | Install (or skip) the Aphotic Assistant without being asked. `--with-assistant` implies the `ai` layer and needs an NVIDIA GPU. |
+| `--nvidia-driver <keep\|reinstall>` | Only relevant when an NVIDIA driver is already installed. `keep` leaves it alone, `reinstall` replaces it with Aphotic's recommended `nvidia-open-dkms`. Non-interactive runs default to `keep` — a working driver is never replaced without being told to. |
+| `--config-only` | Config sync only: back up, copy `Configs/` over `~/.config/`, restart the shell. No packages, no system prep, no wizard, no `sudo`, and `aphotic.toml` is left untouched. See [Config sync only](#config-sync-only). |
 | `--dry-run` | Prints the full resolved install plan and exits — nothing is installed, backed up, or written. |
 | `--no-backup` | Skips the pre-install config snapshot. Off by default; use with intent. |
 | `--keep-backups <N>` | How many timestamped backups to retain before pruning. Defaults to 5. |
 | `-h`, `--help` | Full flag reference. |
+| `-v`, `--version` | Prints the installed Aphotic version and exits. |
 
 </details>
 
@@ -364,6 +368,23 @@ git pull
 ```
 
 Aphotic detects your saved `aphotic.toml` and re-resolves your profile/layers against any changes upstream, snapshotting your current configs first exactly as a fresh install would.
+
+#### Config sync only
+
+Most updates are shell changes — Quickshell QML, Hyprland config, keybinds — with no package churn behind them. `--config-only` syncs just those:
+
+```
+cd Aphotic-Hypr
+git pull
+./install.sh --config-only
+```
+
+It backs up your current configs, copies `Configs/` over `~/.config/`, and restarts the shell. **No package installs, no system prep, no wizard, no `sudo` prompt**, and `aphotic.toml` is left exactly as it is — so your saved profile and layers are reused, never re-resolved or rewritten. Your `hypr/custom.lua` is preserved the same way a full run preserves it, and `--no-backup` works here too if you want to skip the snapshot.
+
+Use the full `./install.sh` instead when a release adds or removes packages, or when you want to change your profile/layers.
+
+> [!NOTE]
+> Once Aphotic is installed, `aphotic update` does the same job from anywhere — it pulls the repo, re-deploys configs, and reloads the shell in one step. `./install.sh --config-only` is the equivalent when you're already sitting in the repo, or when you want the config copy without the git pull.
 
 ### Uninstalling
 
@@ -393,8 +414,8 @@ A **profile** is the base package set. A **layer** is an optional add-on merged 
 |---|---|
 | `gaming` | GameMode, MangoHud (both with 32-bit variants), Steam. |
 | `dev` | Neovim, tmux, fzf, ripgrep, fd, lazygit. |
-| `ai` | Ollama as a local AI backend, plus [llmfit](https://github.com/AlexsJones/llmfit) for hardware-aware model recommendations — `aphotic ai fit` on the CLI, a Hardware Advisor + Model Storage card in Settings → AI. |
-| `exploit` | Offensive-security/CTF tooling, split into focused sublayers (`exploit-recon`, `-web`, `-network`, `-passwords`, `-wordlists`, `-reversing`, `-forensics`, `-reporting`) — `exploit` itself is a convenience bundle of recon+web+network. Most sublayers **enable the BlackArch repo**, which is less stable than Arch's official repos; `install.sh` prints a warning and asks for explicit confirmation before touching `/etc/pacman.conf`. Selecting any of them also requires accepting a one-time authorized-use disclaimer. See [`docs/exploit-layer.md`](docs/exploit-layer.md) for the full taxonomy, the disclaimer flow, and how to recover if a package breaks. |
+| `ai` | Ollama as a local AI backend, plus [llmfit](https://github.com/AlexsJones/llmfit) for hardware-aware model recommendations — `aphotic ai fit` on the CLI, a Hardware Advisor + Model Storage card in Settings → AI. This layer also turns on Aphotic's agent tooling: it wires Claude Code hooks into `~/.claude/settings.json` (merged with `jq`, never overwriting hooks you already have) and enables a local usage-tracking timer. Leave the layer off and none of that is installed or run; de-select it on a re-run and `install.sh` removes the hook entries it previously added. |
+| `exploit` | Offensive-security/CTF tooling, split into focused sublayers (`exploit-recon`, `-web`, `-network`, `-passwords`, `-wordlists`, `-reversing`, `-forensics`, `-reporting`) — `exploit` itself is a convenience bundle of recon+web+network. Most sublayers **enable the BlackArch repo**, which is less stable than Arch's official repos; `install.sh` prints a warning and asks for explicit confirmation before touching `/etc/pacman.conf`. Selecting any of them also requires accepting a one-time authorized-use disclaimer. `./install.sh --help` documents the full sublayer taxonomy and the disclaimer flow. |
 
 Layers are additive and dedupe against the base and each other, so `--with gaming,dev,ai` on top of `full` merges cleanly with no duplicate installs. Combine whatever fits: a `minimal` install with just `dev` is a lean coding box; `full` with `gaming` and `dev` is closer to a daily driver that also game-modes on demand.
 
@@ -430,7 +451,7 @@ Aphotic-Hypr/
     │   │                            SettingsRow/SettingsGroup/SettingsToggleRow/SettingsPresetRow, Logo, ...)
     │   └── modules/                bar/ (+ real popouts), launcher/ (apps/clip/emoji/windows/wallpaper),
     │                                areapicker/, notifications/, osd/, lock/, session/,
-    │                                dashboard/ (Command Center), settings/ (Control Center, 7 panes)
+    │                                dashboard/ (Command Center), settings/ (Control Center, 15 categories)
     ├── hypr/                     hyprland.lua, keybinds.lua, custom.lua (never overwritten, see below)
     └── .local/
         ├── bin/aphotic            aphotic CLI entry point, symlinked onto PATH by install.sh
@@ -598,7 +619,7 @@ aphotic play guess
 
 ## Roadmap
 
-Aphotic reached **v1.0** on `main`. The Quickshell shell, per-theme wallpapers, the unified theme/wallpaper/scheme state contract, and a CI-tested installer are the shipped baseline. Active development continues directly on `main` via PR (see [Contributing](CONTRIBUTING.md)). Full shipped-item history moved to [`docs/CHANGELOG.md`](docs/CHANGELOG.md) so this list stays short — here's what's still open:
+Aphotic reached **v1.0** on `main`. The Quickshell shell, per-theme wallpapers, the unified theme/wallpaper/scheme state contract, and a CI-tested installer are the shipped baseline. Active development continues directly on `main` via PR (see [Contributing](CONTRIBUTING.md)). Full shipped-item history lives in the repo's changelog so this list stays short — here's what's still open:
 
 - **`matugen` as a second color engine** — next up. `theme.toml` reserves the config slot; wiring it in gives themes a real tonal-spot/vibrant/expressive variant picker alongside wallust.
 - **Settings panel expansion** — Network/Audio/Bluetooth pages matching the bar's existing popouts, plus a System-updates action (distinct from the current read-only doctor output).
@@ -606,7 +627,7 @@ Aphotic reached **v1.0** on `main`. The Quickshell shell, per-theme wallpapers, 
 - **Gaming profile** — a real performance-mode toggle, MangoHud bar integration, Proton/Steam polish.
 - **Dev environment** — deeper terminal and editor tooling on top of the `ai` layer (the AI Chat tab and the launcher's project switcher already cover the interactive side of this).
 - **Maintenance tooling** — release tagging and migration tooling; versioning and CI are already in place.
-- **AI-native differentiators, still open** — surfacing the agent hook's live per-session data as real per-session status in the panel (it writes the data, nothing reads it yet), AI chat context injection, and session handoff.
+- **AI-native differentiators, still open** — AI chat context injection and session handoff. (Live per-session agent status now reads the hook's data and renders it in the panel; that half is shipped.)
 
 Longer-term, the plan is a full wiki: install walkthroughs, theme authoring docs, and a troubleshooting reference, instead of cramming everything into this README forever.
 

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,8 @@ INSTLOG="install.log"
 APHOTIC_TOML="$ROOT_DIR/aphotic.toml"
 
 DRY_RUN=0
+CONFIG_ONLY=0
+LAYERS_KNOWN=0
 NO_BACKUP=0
 KEEP_BACKUPS=5
 PROFILE=""
@@ -109,6 +111,12 @@ Usage: ./install.sh [options]
                                 asked; non-interactive ones (no TTY) without
                                 this flag default to 'keep' -- never touches
                                 a working driver without being told to.
+  --config-only                 Config sync only: back up, copy Configs/ over
+                                ~/.config/, restart the shell. No package
+                                installs, no system prep, no wizard, and
+                                aphotic.toml is left exactly as it is. This
+                                is the "I just want the latest Quickshell/
+                                Hyprland config" path after a git pull.
   --dry-run                     Print planned actions, change nothing
   --no-backup                   Skip backing up existing configs
   --keep-backups <N>             Backups to retain (default: 5)
@@ -126,6 +134,7 @@ while [[ $# -gt 0 ]]; do
     --no-assistant) ASSISTANT="false"; shift ;;
     --accept-exploit-disclaimer) ACCEPT_EXPLOIT_DISCLAIMER=1; shift ;;
     --nvidia-driver) [[ -n "${2:-}" ]] || { echo -e "$CER - Missing value for $1 (keep|reinstall)"; exit 1; }; NVIDIA_DRIVER_ACTION="$2"; shift 2 ;;
+    --config-only) CONFIG_ONLY=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     --no-backup) NO_BACKUP=1; shift ;;
     --keep-backups) [[ -n "${2:-}" ]] || { echo -e "$CER - Missing value for $1"; exit 1; }; KEEP_BACKUPS="$2"; shift 2 ;;
@@ -278,6 +287,39 @@ install_nvidia_driver() {
   install_software nvidia-utils
 }
 
+# Config-sync mode still needs to know the selected layers (the `ai` layer
+# gates the Claude Code hook wiring in stage 6), but it must never prompt --
+# the whole point of the flag is a non-interactive config refresh.
+load_saved_config() {
+  [[ -f "$APHOTIC_TOML" ]] || return 0
+  LAYERS_KNOWN=1
+  local saved_profile saved_layers saved_theme
+  saved_profile=$("$PYTHON_BIN" -c '
+import sys, tomllib
+try:
+    print(tomllib.load(open(sys.argv[1], "rb")).get("install", {}).get("profile", ""))
+except Exception:
+    print("")
+' "$APHOTIC_TOML" 2>/dev/null)
+  saved_layers=$("$PYTHON_BIN" -c '
+import sys, tomllib
+try:
+    print(",".join(tomllib.load(open(sys.argv[1], "rb")).get("install", {}).get("layers", [])))
+except Exception:
+    print("")
+' "$APHOTIC_TOML" 2>/dev/null)
+  saved_theme=$("$PYTHON_BIN" -c '
+import sys, tomllib
+try:
+    print(tomllib.load(open(sys.argv[1], "rb")).get("theme", {}).get("name", ""))
+except Exception:
+    print("")
+' "$APHOTIC_TOML" 2>/dev/null)
+  [[ -z "$PROFILE" ]] && PROFILE="$saved_profile"
+  [[ -z "$LAYERS" ]] && LAYERS="$saved_layers"
+  [[ -z "$THEME" ]] && THEME="$saved_theme"
+}
+
 resolve_config() {
   if [[ -f "$APHOTIC_TOML" && -z "$PROFILE" && -z "$LAYERS" ]]; then
     local existing_profile existing_layers
@@ -296,6 +338,186 @@ resolve_config() {
   [[ -z "$THEME" ]] && THEME=$(prompt_theme)
 }
 
+# Everything a config refresh needs: the Configs/ copy, the symlinks that
+# must track repo edits, the user systemd units, the Claude Code hook
+# wiring, and PATH. Deliberately stops short of anything needing sudo
+# (SDDM theme, wayland-sessions) so --config-only never asks for a
+# password -- extracted rather than duplicated so the sync path and the
+# full install can never drift apart.
+deploy_user_configs() {
+  echo -e "$CNT - Copying config files..."
+  CUSTOM_LUA="$HOME/.config/hypr/custom.lua"
+  CUSTOM_LUA_BACKUP=""
+  if [[ -f "$CUSTOM_LUA" ]]; then
+    CUSTOM_LUA_BACKUP=$(mktemp)
+    cp "$CUSTOM_LUA" "$CUSTOM_LUA_BACKUP"
+  fi
+
+  cp -R "$ROOT_DIR/Configs/"* "$HOME/.config/"
+
+  # A handful of paths under Configs/ need to track repo edits directly
+  # rather than sit as the one-shot copy above -- a plain `cp -R` means
+  # any later edit (bug fixes included) silently stops matching what's
+  # actually live, with zero indication anything drifted, until a full
+  # reinstall. Not hypothetical: this exact drift is what silently broke
+  # SUPER+SHIFT+A (intelligence), SUPER+CTRL+SHIFT+B (bar cycle),
+  # SUPER+SHIFT+D (dnd), and SUPER+N/SUPER+Y (keybinds.lua stale since
+  # before those binds existed); kept regenerating Colours.qml from an
+  # old wallust template (docs/IN_FLIGHT.md item 3); and left the
+  # Kvantum theme selector pointed at the pre-rename "Noctis" name.
+  # Symlinking these closes the whole bug class instead of patching it
+  # path by path as each instance is separately noticed. ln -sfn (not
+  # -sf) so re-running this on an existing install replaces a stale
+  # symlink/copy in place instead of nesting one inside the other.
+  #
+  # Configs/hypr/* except three files that must stay real, independent
+  # copies rather than track the repo:
+  #   - custom.lua: the user's own local override (see the backup/
+  #     restore immediately below), meant to diverge per-machine.
+  #   - monitors.lua: hardware config (output name, exact resolution,
+  #     position, scale) is inherently per-machine too -- the repo's own
+  #     copy is only a generic "output='', mode=preferred" placeholder.
+  #     Symlinking this one was a real regression, caught live: it threw
+  #     away this machine's pinned "Virtual-1, 1920x1080" for the
+  #     placeholder's "preferred", which negotiated down to 1280x800.
+  #   - hyprland.lua: install.sh appends `require("nvidia")` to it below
+  #     when Nvidia is detected -- a symlink would write that append
+  #     straight into the tracked repo file instead of a local copy, and
+  #     (since cp -R can no longer "reset" a symlinked target the way it
+  #     resets a plain file) re-running install.sh would keep appending
+  #     duplicate require lines with nothing ever clearing them.
+  for entry in "$ROOT_DIR/Configs/hypr/"*; do
+    name="$(basename "$entry")"
+    case "$name" in
+      custom.lua|monitors.lua|hyprland.lua) continue ;;
+    esac
+    rm -rf "$HOME/.config/hypr/$name"
+    ln -sfn "$entry" "$HOME/.config/hypr/$name"
+  done
+  chmod +x "$HOME/.config/hypr/scripts/"*
+
+  rm -rf "$HOME/.config/wallust"
+  ln -sfn "$ROOT_DIR/Configs/wallust" "$HOME/.config/wallust"
+
+  # Just the selector file -- Kvantum/Aphotic/Aphotic.kvconfig alongside
+  # it is wallust template *output* (wallust.toml's `kvantum` entry), not
+  # repo source, and must stay a real file wallust can keep overwriting.
+  mkdir -p "$HOME/.config/Kvantum"
+  rm -f "$HOME/.config/Kvantum/kvantum.kvconfig"
+  ln -sfn "$ROOT_DIR/Configs/Kvantum/kvantum.kvconfig" "$HOME/.config/Kvantum/kvantum.kvconfig"
+
+  if [[ -n "$CUSTOM_LUA_BACKUP" ]]; then
+    cp "$CUSTOM_LUA_BACKUP" "$CUSTOM_LUA"
+    rm -f "$CUSTOM_LUA_BACKUP"
+    echo -e "$CNT - Preserved your existing hypr/custom.lua"
+  fi
+
+  mkdir -p "$HOME/.local/bin"
+  ln -sf "$ROOT_DIR/Configs/.local/bin/aphotic" "$HOME/.local/bin/aphotic"
+
+  echo -e "$CNT - Enabling the Aphotic shell restart-supervision unit..."
+  mkdir -p "$HOME/.config/systemd/user"
+  # Same symlink treatment as above -- these three unit files are only
+  # ever added to or edited in the repo, never hand-written per machine,
+  # so there's no user-owned-copy case to preserve the way custom.lua
+  # has one. Concretely bit already: aphotic-agent-usage.service/.timer
+  # postdated this machine's last cp -R and were never installed at all
+  # (`systemctl --user is-enabled` reported "not-found"), so the Live
+  # Agent Activity Module silently never ran.
+  for unit in "$ROOT_DIR/Configs/systemd/user/"*; do
+    ln -sfn "$unit" "$HOME/.config/systemd/user/$(basename "$unit")"
+  done
+  systemctl --user daemon-reload &>> "$INSTLOG"
+  systemctl --user enable aphotic-shell.service &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-shell.service; the shell will still start via Hyprland's exec-once but won't auto-restart on crash."
+  # A --config-only run on a clone that has never been installed has no saved
+  # layer list, and "no layers" must not be read as "the user turned ai off" --
+  # that would strip hooks and disable a timer nobody asked to remove.
+  if [[ "$CONFIG_ONLY" == "1" && "$LAYERS_KNOWN" != "1" ]]; then
+    echo -e "$CWR - No aphotic.toml found; leaving the agent usage timer and Claude Code hooks exactly as they are."
+  elif layer_selected "ai"; then
+    echo -e "$CNT - Enabling the agent usage-tracking timer..."
+    systemctl --user enable --now aphotic-agent-usage.timer &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-agent-usage.timer; the bar's agent popout will show stale/no usage data until it's enabled manually."
+  else
+    echo -e "$CNT - AI layer not selected; leaving the agent usage-tracking timer off."
+    systemctl --user disable --now aphotic-agent-usage.timer &>> "$INSTLOG" || true
+  fi
+  echo -e "$CNT - Enabling the SDDM background sync timer..."
+  systemctl --user enable --now aphotic-sddm-sync.timer &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-sddm-sync.timer; the SDDM login background will only update via the per-theme-change best-effort call, not this periodic catch-up. Enable manually with 'systemctl --user enable --now aphotic-sddm-sync.timer'."
+  # Writing hooks into someone's ~/.claude/settings.json is not something to
+  # do to a user who never asked for the agent stack, so it follows the `ai`
+  # layer -- and de-selecting that layer on a re-run removes what a previous
+  # run added rather than leaving it behind.
+  if [[ "$CONFIG_ONLY" == "1" && "$LAYERS_KNOWN" != "1" ]]; then
+    :
+  elif layer_selected "ai"; then
+    echo -e "$CNT - Configuring the Claude Code hook for live agent session tracking..."
+    if command -v jq >/dev/null 2>&1; then
+      configure_claude_code_hooks "$ROOT_DIR/Configs/.local/lib/aphotic/agent_hook.sh" &>> "$INSTLOG" || echo -e "$CWR - Could not update ~/.claude/settings.json; the bar's agent popout will only show session presence/count, not live per-session status. Wire it manually — see docs/AGENT_TRACKING.md."
+    else
+      echo -e "$CWR - jq not found; skipping Claude Code hook setup. Wire it manually — see docs/AGENT_TRACKING.md."
+    fi
+  elif command -v jq >/dev/null 2>&1; then
+    echo -e "$CNT - AI layer not selected; removing any Aphotic Claude Code hook entries..."
+    remove_claude_code_hooks "$ROOT_DIR/Configs/.local/lib/aphotic/agent_hook.sh" &>> "$INSTLOG" || echo -e "$CWR - Could not clean ~/.claude/settings.json; remove the aphotic agent_hook.sh entries by hand if they are still there."
+  fi
+
+  # Make sure `aphotic` (and anything else under ~/.local/bin) resolves on
+  # PATH without relying on the optional zsh-activation step below, since
+  # bash users need this too and Configs/.zshrc only lands on disk if they
+  # opt in.
+  for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+    [[ "$rc" == "$HOME/.zshrc" && ! -f "$rc" ]] && continue
+    touch "$rc"
+    if ! grep -qF '.local/bin' "$rc"; then
+      printf '\n# Added by aphotic install.sh so ~/.local/bin (aphotic CLI) is on PATH\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$rc"
+    fi
+  done
+
+  KVARCDARK_SVG="/usr/share/Kvantum/KvArcDark/KvArcDark.svg"
+  mkdir -p "$HOME/.config/Kvantum/Aphotic"
+  if [[ -f "$KVARCDARK_SVG" ]]; then
+    cp "$KVARCDARK_SVG" "$HOME/.config/Kvantum/Aphotic/Aphotic.svg"
+  else
+    echo -e "$CWR - KvArcDark theme assets not found at $KVARCDARK_SVG (should ship with the kvantum package); Kvantum will fall back to its default style."
+  fi
+
+  if [[ "$ISNVIDIA" == "true" ]]; then
+    echo -e '\nrequire("nvidia")' >> "$HOME/.config/hypr/hyprland.lua"
+  fi
+}
+
+config_sync() {
+  TOTAL_STAGES=3
+  print_stage 1 "Backup"
+  if [[ "$NO_BACKUP" != "1" ]]; then
+    TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+    echo -e "$CNT - Snapshotting existing configs..."
+    mapfile -t CONFIG_DIRS < <(find "$ROOT_DIR/Configs" -maxdepth 1 -mindepth 1 -not -name '.*' -exec basename {} \;)
+    snapshot_config "$TIMESTAMP" "${CONFIG_DIRS[@]}"
+    prune_backups "$KEEP_BACKUPS"
+    echo -e "$COK - Backup saved under $(backup_root)/$TIMESTAMP"
+  else
+    echo -e "$CWR - Skipping backup (--no-backup)."
+  fi
+
+  print_stage 2 "Syncing configs"
+  deploy_user_configs
+
+  print_stage 3 "Restarting the shell"
+  if systemctl --user is-enabled aphotic-shell.service &>/dev/null; then
+    systemctl --user restart aphotic-shell.service &>> "$INSTLOG" && echo -e "$COK - Restarted aphotic-shell.service." || echo -e "$CWR - Could not restart aphotic-shell.service; restart Quickshell manually (SUPER+B)."
+  else
+    echo -e "$CNT - aphotic-shell.service isn't enabled; restart Quickshell manually (SUPER+B) to pick up the new config."
+  fi
+
+  echo -e "\n\e[1;32m── Config sync summary ──\e[0m"
+  echo -e "  Layers:        ${LAYERS:-none}"
+  echo -e "  Configs:       copied from $ROOT_DIR/Configs"
+  echo -e "  Packages:      untouched"
+  echo -e "  aphotic.toml:  left as-is"
+  echo -e "$COK - Config sync complete."
+}
+
 main() {
   clear
   print_banner
@@ -308,6 +530,14 @@ main() {
   echo -e "Using $ISVM"
   if [[ "$ISVM" == *"vm"* ]]; then
     echo -e "$CWR - Please note that VMs are not fully supported and if you try to run this on a Virtual Machine there is a high chance this will fail."
+  fi
+
+  if [[ "$CONFIG_ONLY" == "1" ]]; then
+    load_saved_config
+    LAYERS=$(expand_layer_bundles "$LAYERS")
+    echo -e "$CNT - Config-sync mode: reusing saved config (profile=${PROFILE:-unset}, layers=${LAYERS:-none}). No packages will be installed."
+    config_sync
+    exit 0
   fi
 
   print_stage 2 "Configuration"
@@ -488,138 +718,7 @@ except Exception:
   CFG_COPIED=0
   if [[ "$CFG" == "Y" || "$CFG" == "y" ]]; then
     CFG_COPIED=1
-    echo -e "$CNT - Copying config files..."
-    CUSTOM_LUA="$HOME/.config/hypr/custom.lua"
-    CUSTOM_LUA_BACKUP=""
-    if [[ -f "$CUSTOM_LUA" ]]; then
-      CUSTOM_LUA_BACKUP=$(mktemp)
-      cp "$CUSTOM_LUA" "$CUSTOM_LUA_BACKUP"
-    fi
-
-    cp -R "$ROOT_DIR/Configs/"* "$HOME/.config/"
-
-    # A handful of paths under Configs/ need to track repo edits directly
-    # rather than sit as the one-shot copy above -- a plain `cp -R` means
-    # any later edit (bug fixes included) silently stops matching what's
-    # actually live, with zero indication anything drifted, until a full
-    # reinstall. Not hypothetical: this exact drift is what silently broke
-    # SUPER+SHIFT+A (intelligence), SUPER+CTRL+SHIFT+B (bar cycle),
-    # SUPER+SHIFT+D (dnd), and SUPER+N/SUPER+Y (keybinds.lua stale since
-    # before those binds existed); kept regenerating Colours.qml from an
-    # old wallust template (docs/IN_FLIGHT.md item 3); and left the
-    # Kvantum theme selector pointed at the pre-rename "Noctis" name.
-    # Symlinking these closes the whole bug class instead of patching it
-    # path by path as each instance is separately noticed. ln -sfn (not
-    # -sf) so re-running this on an existing install replaces a stale
-    # symlink/copy in place instead of nesting one inside the other.
-    #
-    # Configs/hypr/* except three files that must stay real, independent
-    # copies rather than track the repo:
-    #   - custom.lua: the user's own local override (see the backup/
-    #     restore immediately below), meant to diverge per-machine.
-    #   - monitors.lua: hardware config (output name, exact resolution,
-    #     position, scale) is inherently per-machine too -- the repo's own
-    #     copy is only a generic "output='', mode=preferred" placeholder.
-    #     Symlinking this one was a real regression, caught live: it threw
-    #     away this machine's pinned "Virtual-1, 1920x1080" for the
-    #     placeholder's "preferred", which negotiated down to 1280x800.
-    #   - hyprland.lua: install.sh appends `require("nvidia")` to it below
-    #     when Nvidia is detected -- a symlink would write that append
-    #     straight into the tracked repo file instead of a local copy, and
-    #     (since cp -R can no longer "reset" a symlinked target the way it
-    #     resets a plain file) re-running install.sh would keep appending
-    #     duplicate require lines with nothing ever clearing them.
-    for entry in "$ROOT_DIR/Configs/hypr/"*; do
-      name="$(basename "$entry")"
-      case "$name" in
-        custom.lua|monitors.lua|hyprland.lua) continue ;;
-      esac
-      rm -rf "$HOME/.config/hypr/$name"
-      ln -sfn "$entry" "$HOME/.config/hypr/$name"
-    done
-    chmod +x "$HOME/.config/hypr/scripts/"*
-
-    rm -rf "$HOME/.config/wallust"
-    ln -sfn "$ROOT_DIR/Configs/wallust" "$HOME/.config/wallust"
-
-    # Just the selector file -- Kvantum/Aphotic/Aphotic.kvconfig alongside
-    # it is wallust template *output* (wallust.toml's `kvantum` entry), not
-    # repo source, and must stay a real file wallust can keep overwriting.
-    mkdir -p "$HOME/.config/Kvantum"
-    rm -f "$HOME/.config/Kvantum/kvantum.kvconfig"
-    ln -sfn "$ROOT_DIR/Configs/Kvantum/kvantum.kvconfig" "$HOME/.config/Kvantum/kvantum.kvconfig"
-
-    if [[ -n "$CUSTOM_LUA_BACKUP" ]]; then
-      cp "$CUSTOM_LUA_BACKUP" "$CUSTOM_LUA"
-      rm -f "$CUSTOM_LUA_BACKUP"
-      echo -e "$CNT - Preserved your existing hypr/custom.lua"
-    fi
-
-    mkdir -p "$HOME/.local/bin"
-    ln -sf "$ROOT_DIR/Configs/.local/bin/aphotic" "$HOME/.local/bin/aphotic"
-
-    echo -e "$CNT - Enabling the Aphotic shell restart-supervision unit..."
-    mkdir -p "$HOME/.config/systemd/user"
-    # Same symlink treatment as above -- these three unit files are only
-    # ever added to or edited in the repo, never hand-written per machine,
-    # so there's no user-owned-copy case to preserve the way custom.lua
-    # has one. Concretely bit already: aphotic-agent-usage.service/.timer
-    # postdated this machine's last cp -R and were never installed at all
-    # (`systemctl --user is-enabled` reported "not-found"), so the Live
-    # Agent Activity Module silently never ran.
-    for unit in "$ROOT_DIR/Configs/systemd/user/"*; do
-      ln -sfn "$unit" "$HOME/.config/systemd/user/$(basename "$unit")"
-    done
-    systemctl --user daemon-reload &>> "$INSTLOG"
-    systemctl --user enable aphotic-shell.service &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-shell.service; the shell will still start via Hyprland's exec-once but won't auto-restart on crash."
-    if layer_selected "ai"; then
-      echo -e "$CNT - Enabling the agent usage-tracking timer..."
-      systemctl --user enable --now aphotic-agent-usage.timer &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-agent-usage.timer; the bar's agent popout will show stale/no usage data until it's enabled manually."
-    else
-      echo -e "$CNT - AI layer not selected; leaving the agent usage-tracking timer off."
-      systemctl --user disable --now aphotic-agent-usage.timer &>> "$INSTLOG" || true
-    fi
-    echo -e "$CNT - Enabling the SDDM background sync timer..."
-    systemctl --user enable --now aphotic-sddm-sync.timer &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-sddm-sync.timer; the SDDM login background will only update via the per-theme-change best-effort call, not this periodic catch-up. Enable manually with 'systemctl --user enable --now aphotic-sddm-sync.timer'."
-    # Writing hooks into someone's ~/.claude/settings.json is not something to
-    # do to a user who never asked for the agent stack, so it follows the `ai`
-    # layer -- and de-selecting that layer on a re-run removes what a previous
-    # run added rather than leaving it behind.
-    if layer_selected "ai"; then
-      echo -e "$CNT - Configuring the Claude Code hook for live agent session tracking..."
-      if command -v jq >/dev/null 2>&1; then
-        configure_claude_code_hooks "$ROOT_DIR/Configs/.local/lib/aphotic/agent_hook.sh" &>> "$INSTLOG" || echo -e "$CWR - Could not update ~/.claude/settings.json; the bar's agent popout will only show session presence/count, not live per-session status. Wire it manually — see docs/AGENT_TRACKING.md."
-      else
-        echo -e "$CWR - jq not found; skipping Claude Code hook setup. Wire it manually — see docs/AGENT_TRACKING.md."
-      fi
-    elif command -v jq >/dev/null 2>&1; then
-      echo -e "$CNT - AI layer not selected; removing any Aphotic Claude Code hook entries..."
-      remove_claude_code_hooks "$ROOT_DIR/Configs/.local/lib/aphotic/agent_hook.sh" &>> "$INSTLOG" || echo -e "$CWR - Could not clean ~/.claude/settings.json; remove the aphotic agent_hook.sh entries by hand if they are still there."
-    fi
-
-    # Make sure `aphotic` (and anything else under ~/.local/bin) resolves on
-    # PATH without relying on the optional zsh-activation step below, since
-    # bash users need this too and Configs/.zshrc only lands on disk if they
-    # opt in.
-    for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
-      [[ "$rc" == "$HOME/.zshrc" && ! -f "$rc" ]] && continue
-      touch "$rc"
-      if ! grep -qF '.local/bin' "$rc"; then
-        printf '\n# Added by aphotic install.sh so ~/.local/bin (aphotic CLI) is on PATH\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$rc"
-      fi
-    done
-
-    KVARCDARK_SVG="/usr/share/Kvantum/KvArcDark/KvArcDark.svg"
-    mkdir -p "$HOME/.config/Kvantum/Aphotic"
-    if [[ -f "$KVARCDARK_SVG" ]]; then
-      cp "$KVARCDARK_SVG" "$HOME/.config/Kvantum/Aphotic/Aphotic.svg"
-    else
-      echo -e "$CWR - KvArcDark theme assets not found at $KVARCDARK_SVG (should ship with the kvantum package); Kvantum will fall back to its default style."
-    fi
-
-    if [[ "$ISNVIDIA" == "true" ]]; then
-      echo -e '\nrequire("nvidia")' >> "$HOME/.config/hypr/hyprland.lua"
-    fi
+    deploy_user_configs
 
     echo -e "$CNT - Setting up the login screen..."
     sudo tar -xf "$ROOT_DIR/src/sugar-candy.tar.gz" -C /usr/share/sddm/themes/

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,18 @@ NO_BACKUP=0
 KEEP_BACKUPS=5
 PROFILE=""
 LAYERS=""
+
+# Layers are carried as a comma-separated string all the way through, so
+# every gate needs the same exact-match test rather than a substring one --
+# "ai" must not match "aichat" or "exploit-ai".
+layer_selected() {
+  local needle="$1" name
+  IFS=',' read -ra _layer_list <<< "${LAYERS:-}"
+  for name in "${_layer_list[@]:-}"; do
+    [[ "$name" == "$needle" ]] && return 0
+  done
+  return 1
+}
 THEME=""
 ASSISTANT=""
 ACCEPT_EXPLOIT_DISCLAIMER=0
@@ -560,15 +572,29 @@ except Exception:
     done
     systemctl --user daemon-reload &>> "$INSTLOG"
     systemctl --user enable aphotic-shell.service &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-shell.service; the shell will still start via Hyprland's exec-once but won't auto-restart on crash."
-    echo -e "$CNT - Enabling the agent usage-tracking timer..."
-    systemctl --user enable --now aphotic-agent-usage.timer &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-agent-usage.timer; the bar's agent popout will show stale/no usage data until it's enabled manually."
+    if layer_selected "ai"; then
+      echo -e "$CNT - Enabling the agent usage-tracking timer..."
+      systemctl --user enable --now aphotic-agent-usage.timer &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-agent-usage.timer; the bar's agent popout will show stale/no usage data until it's enabled manually."
+    else
+      echo -e "$CNT - AI layer not selected; leaving the agent usage-tracking timer off."
+      systemctl --user disable --now aphotic-agent-usage.timer &>> "$INSTLOG" || true
+    fi
     echo -e "$CNT - Enabling the SDDM background sync timer..."
     systemctl --user enable --now aphotic-sddm-sync.timer &>> "$INSTLOG" || echo -e "$CWR - Could not enable aphotic-sddm-sync.timer; the SDDM login background will only update via the per-theme-change best-effort call, not this periodic catch-up. Enable manually with 'systemctl --user enable --now aphotic-sddm-sync.timer'."
-    echo -e "$CNT - Configuring the Claude Code hook for live agent session tracking..."
-    if command -v jq >/dev/null 2>&1; then
-      configure_claude_code_hooks "$ROOT_DIR/Configs/.local/lib/aphotic/agent_hook.sh" &>> "$INSTLOG" || echo -e "$CWR - Could not update ~/.claude/settings.json; the bar's agent popout will only show session presence/count, not live per-session status. Wire it manually — see docs/AGENT_TRACKING.md."
-    else
-      echo -e "$CWR - jq not found; skipping Claude Code hook setup. Wire it manually — see docs/AGENT_TRACKING.md."
+    # Writing hooks into someone's ~/.claude/settings.json is not something to
+    # do to a user who never asked for the agent stack, so it follows the `ai`
+    # layer -- and de-selecting that layer on a re-run removes what a previous
+    # run added rather than leaving it behind.
+    if layer_selected "ai"; then
+      echo -e "$CNT - Configuring the Claude Code hook for live agent session tracking..."
+      if command -v jq >/dev/null 2>&1; then
+        configure_claude_code_hooks "$ROOT_DIR/Configs/.local/lib/aphotic/agent_hook.sh" &>> "$INSTLOG" || echo -e "$CWR - Could not update ~/.claude/settings.json; the bar's agent popout will only show session presence/count, not live per-session status. Wire it manually — see docs/AGENT_TRACKING.md."
+      else
+        echo -e "$CWR - jq not found; skipping Claude Code hook setup. Wire it manually — see docs/AGENT_TRACKING.md."
+      fi
+    elif command -v jq >/dev/null 2>&1; then
+      echo -e "$CNT - AI layer not selected; removing any Aphotic Claude Code hook entries..."
+      remove_claude_code_hooks "$ROOT_DIR/Configs/.local/lib/aphotic/agent_hook.sh" &>> "$INSTLOG" || echo -e "$CWR - Could not clean ~/.claude/settings.json; remove the aphotic agent_hook.sh entries by hand if they are still there."
     fi
 
     # Make sure `aphotic` (and anything else under ~/.local/bin) resolves on

--- a/lib/install/claude_hooks.sh
+++ b/lib/install/claude_hooks.sh
@@ -52,3 +52,32 @@ configure_claude_code_hooks() {
     ' \
     "$settings_file" > "$tmp" && mv "$tmp" "$settings_file"
 }
+
+# The inverse of configure_claude_code_hooks, for a re-run where the user
+# de-selected the `ai` layer: drops only the entries pointing at this repo's
+# own agent_hook.sh and leaves every other hook the user has configured
+# untouched. Also prunes hook events left with no entries at all, so
+# settings.json doesn't accumulate empty arrays.
+remove_claude_code_hooks() {
+  local hook_script="$1"
+  local settings_file="$HOME/.claude/settings.json"
+
+  [[ -f "$settings_file" ]] || return 0
+
+  if ! jq -e . "$settings_file" >/dev/null 2>&1; then
+    echo "existing $settings_file is not valid JSON; leaving Claude Code hooks alone" >&2
+    return 1
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  jq \
+    --arg cmd "$hook_script" \
+    '
+    (.hooks // {}) as $hooks
+    | .hooks = ($hooks
+        | with_entries(.value |= map(select((.hooks // []) | any(.command == $cmd) | not)))
+        | with_entries(select((.value | length) > 0)))
+    ' \
+    "$settings_file" > "$tmp" && mv "$tmp" "$settings_file"
+}

--- a/lib/install/claude_hooks.sh
+++ b/lib/install/claude_hooks.sh
@@ -5,7 +5,11 @@ set -euo pipefail
 # Wires Configs/.local/lib/aphotic/agent_hook.sh into the user's real
 # Claude Code settings.json (~/.claude/settings.json, not a repo-managed
 # file) so the bar's agent popout gets live per-session state instead of
-# just presence/count -- without this, agent_hook.sh never fires. Merged
+# just presence/count -- without this, agent_hook.sh never fires.
+# SessionEnd is what retires a session now (Stop fires at the end of every
+# assistant turn, not at the end of the session -- an install still on the
+# old four-event set leaves idle sessions on screen until agent_hook.py's
+# own staleness sweep clears them). Merged
 # with jq (guaranteed present, both profiles' prep stage installs it)
 # rather than templated, so any hooks the user already has for other
 # tools are preserved untouched. Idempotent -- re-running install.sh
@@ -37,10 +41,14 @@ configure_claude_code_hooks() {
     def entry($timeout): {matcher: "", hooks: [{type: "command", command: $cmd} + (if $timeout > 0 then {timeout: $timeout} else {} end)]};
     def upsert($event; $timeout):
       .hooks[$event] = ((.hooks[$event] // []) | map(select((.hooks // []) | any(.command == $cmd) | not)) + [entry($timeout)]);
-    upsert("PreToolUse"; 30)
+    upsert("SessionStart"; 10)
+    | upsert("PreToolUse"; 30)
     | upsert("PostToolUse"; 30)
+    | upsert("PostToolUseFailure"; 30)
     | upsert("Notification"; 10)
     | upsert("Stop"; 0)
+    | upsert("SubagentStop"; 0)
+    | upsert("SessionEnd"; 10)
     ' \
     "$settings_file" > "$tmp" && mv "$tmp" "$settings_file"
 }

--- a/lib/install/wizard.sh
+++ b/lib/install/wizard.sh
@@ -16,13 +16,33 @@ prompt_layers() {
   local layers=()
   local answer
 
+  # Presets are a shortcut over the same layer list the questions below
+  # build -- not a second mechanism. "Cherry-pick" is just answering them.
+  echo "Layer presets:"
+  echo "  1) Everything       -- gaming, dev, ai, and the default exploit bundle"
+  echo "  2) Daily driver     -- none of the above; a clean Hyprland desktop"
+  echo "  3) Cherry-pick      -- choose each layer yourself"
+  read -rp "Preset? [1/2/3, default 3]: " answer
+  case "$answer" in
+    1)
+      echo "gaming,dev,ai,exploit"
+      return 0
+      ;;
+    2)
+      echo ""
+      return 0
+      ;;
+  esac
+
   read -rp "Enable gaming layer? [y/N]: " answer
   [[ "$answer" =~ ^[Yy]$ ]] && layers+=("gaming")
 
   read -rp "Enable dev layer? [y/N]: " answer
   [[ "$answer" =~ ^[Yy]$ ]] && layers+=("dev")
 
-  read -rp "Enable ai layer? [y/N]: " answer
+  # Say what this actually does before asking: it is the only layer that
+  # writes into a config file outside this repo (~/.claude/settings.json).
+  read -rp "Enable ai layer? Adds the agent graph, AI chat and live Claude Code session tracking -- wires hooks into ~/.claude/settings.json and enables a usage-tracking timer [y/N]: " answer
   [[ "$answer" =~ ^[Yy]$ ]] && layers+=("ai")
 
   read -rp "Enable exploit/offensive-security tooling? Adds the BlackArch repo for most sublayers -- less stable than Arch's official repos, see docs/exploit-layer.md [y/N]: " answer


### PR DESCRIPTION
## What

A **config sync only** path for users who just need the `.config` updates (Quickshell QML, Hyprland config, keybinds) without package churn:

```
git pull
./install.sh --config-only
```

Backs up, copies `Configs/` over `~/.config/`, restarts the shell. No package installs, no system prep, no wizard, **no `sudo` prompt**, and `aphotic.toml` is left untouched so the saved profile/layers are reused rather than re-resolved or rewritten. Documented under **Install → Updating → Config sync only**.

## How

The config-deploy body is **extracted into `deploy_user_configs()` and shared** with the full install rather than duplicated — that block carries a lot of hard-won detail about which paths must be symlinks and which must stay real files, and a second copy would drift. The extraction stops deliberately at the first `sudo` step (SDDM theme, wayland-sessions), which is why the sync path never asks for a password.

One edge case worth naming: a `--config-only` run on a clone that was never installed has no saved layer list, and *"no layers"* must not be read as *"the user turned `ai` off"* — that would strip Claude Code hooks and disable a timer nobody asked to remove. It leaves both alone and says so.

## README sweep

- **Every `docs/` link was a 404.** `docs/` is gitignored and not one file under it is tracked; two targets (`bar-styles.md`, `exploit-layer.md`) don't exist at all. All six are now plain text. The underlying decision — publish a docs subset, or keep them maintainer-local — is still open.
- **Two stale claims removed.** Live per-session agent status was described as unimplemented in both the AI Chat section and the Roadmap; it shipped.
- **Control Center count corrected** — the tree said 7 panes, it has 15 categories, and the inline list was missing Launcher, Network and Plugins.
- **Flag table completed** — was missing `--with-assistant`/`--no-assistant`, `--nvidia-driver`, `-v`/`--version`, plus the new `--config-only`.
- **`ai` layer now discloses** that it wires Claude Code hooks into `~/.claude/settings.json` and enables a usage timer. That belongs in front of someone choosing the layer, not behind it.

## Testing

- `--config-only` against a scratch `HOME`, with and without a saved `aphotic.toml` — correct in both, no sudo prompt, hooks left alone when the layer list is unknown.
- `--dry-run` on the normal path to confirm the function extraction didn't disturb the full install.
- `bash -n` on `install.sh` and `lib/install/*.sh`.

## Note on stacking

This branch sits on top of `feature/agentic-opt-in` — `deploy_user_configs()` contains the `ai`-layer gating from that branch, so this one is not independently mergeable onto `main` as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)