### PR TITLE
Agent graph: temporal fade, category color, session hue, replay animation

### DIFF
--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -82,6 +82,10 @@ QtObject {
         }
     }
 
+    function sessionColor(hue: real): color {
+        return Qt.hsla(((hue % 360) + 360) % 360 / 360, 0.5, 0.62, 1);
+    }
+
     onSessionsChanged: root.rebuild()
     onAreaWidthChanged: root.rebuild()
     onAreaHeightChanged: root.rebuild()
@@ -94,6 +98,7 @@ QtObject {
         for (let s = 0; s < list.length; s++) {
             const session = list[s];
             const rootIndex = nodes.length;
+            const sessionColor = root.sessionColor(session.hue ?? 0);
             nodes.push({
                 key: session.id,
                 kind: "session",
@@ -106,7 +111,8 @@ QtObject {
                 startedAt: session.startedAt ?? 0,
                 endedAt: session.endedAt ?? 0,
                 cwd: session.cwd ?? "",
-                callCount: session.nodes.length
+                callCount: session.nodes.length,
+                sessionColor: sessionColor
             });
 
             const visible = session.nodes.slice(-root.maxNodesPerSession);
@@ -130,7 +136,8 @@ QtObject {
                     endedAt: node.endedAt ?? 0,
                     durationMs: node.durationMs ?? 0,
                     category: category,
-                    categoryColor: root.categoryColor(category)
+                    categoryColor: root.categoryColor(category),
+                    sessionColor: sessionColor
                 });
             }
 

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -28,6 +28,22 @@ QtObject {
     readonly property real _toolRadius: Math.min(root.areaWidth, root.areaHeight) * 0.19
     readonly property real _subRadius: Math.min(root.areaWidth, root.areaHeight) * 0.11
 
+    readonly property real fadeFloor: 0.35
+    readonly property real fadeHalfLifeMs: 900000
+
+    function fadeFor(node, nowMs: real): real {
+        if (!node || node.status === "running")
+            return 1;
+        if (node.kind === "session" && node.status !== "ended")
+            return 1;
+        const endedAt = node.endedAt || node.startedAt;
+        if (!endedAt)
+            return 1;
+        const age = Math.max(0, nowMs - endedAt);
+        const halved = Math.pow(0.5, age / root.fadeHalfLifeMs);
+        return root.fadeFloor + (1 - root.fadeFloor) * halved;
+    }
+
     onSessionsChanged: root.rebuild()
     onAreaWidthChanged: root.rebuild()
     onAreaHeightChanged: root.rebuild()
@@ -50,6 +66,7 @@ QtObject {
                 status: session.status,
                 parent: -1,
                 startedAt: session.startedAt ?? 0,
+                endedAt: session.endedAt ?? 0,
                 cwd: session.cwd ?? "",
                 callCount: session.nodes.length
             });

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -4,6 +4,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import qs.services
 
 QtObject {
     id: root
@@ -44,6 +45,43 @@ QtObject {
         return root.fadeFloor + (1 - root.fadeFloor) * halved;
     }
 
+    function categoryFor(tool: string): string {
+        switch (tool) {
+        case "Read":
+        case "Write":
+        case "Edit":
+        case "Glob":
+        case "Grep":
+        case "NotebookEdit":
+            return "file";
+        case "Bash":
+            return "shell";
+        case "WebFetch":
+        case "WebSearch":
+            return "web";
+        case "Agent":
+        case "Task":
+            return "agent";
+        default:
+            return "other";
+        }
+    }
+
+    function categoryColor(category: string): color {
+        switch (category) {
+        case "file":
+            return Colours.palette.m3secondary;
+        case "shell":
+            return Colours.palette.m3tertiary;
+        case "web":
+            return Colours.palette.m3primary;
+        case "agent":
+            return Qt.tint(Colours.palette.m3secondary, Qt.alpha(Colours.palette.m3tertiary, 0.5));
+        default:
+            return Colours.palette.m3surfaceContainerHigh;
+        }
+    }
+
     onSessionsChanged: root.rebuild()
     onAreaWidthChanged: root.rebuild()
     onAreaHeightChanged: root.rebuild()
@@ -74,6 +112,7 @@ QtObject {
             const visible = session.nodes.slice(-root.maxNodesPerSession);
             const indexByNode = ({});
             for (const node of visible) {
+                const category = root.categoryFor(node.tool);
                 indexByNode[node.id] = nodes.length;
                 nodes.push({
                     key: `${session.id}|${node.id}`,
@@ -89,7 +128,9 @@ QtObject {
                     parentId: node.parentId,
                     startedAt: node.startedAt ?? 0,
                     endedAt: node.endedAt ?? 0,
-                    durationMs: node.durationMs ?? 0
+                    durationMs: node.durationMs ?? 0,
+                    category: category,
+                    categoryColor: root.categoryColor(category)
                 });
             }
 

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphReplay.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphReplay.qml
@@ -21,11 +21,13 @@ QtObject {
     readonly property real progress: root.durationMs > 0 ? Math.min(1, root._clockMs / root.durationMs) : 0
     readonly property var stamps: root._stamps
     readonly property bool finished: root.loaded && root._cursor >= root.events.length
+    readonly property bool catchingUp: root._pendingTarget > root._cursor
 
     property int _cursor: 0
     property var _sessions: []
     property real _clockMs: 0
     property var _stamps: []
+    property int _pendingTarget: -1
 
     readonly property int maxGapMs: 1200
 
@@ -44,6 +46,7 @@ QtObject {
         root._stamps = stamps;
         root._clockMs = 0;
         root._cursor = 0;
+        root._pendingTarget = -1;
         root._sessions = [];
         root.playing = false;
     }
@@ -79,14 +82,23 @@ QtObject {
         let target = 0;
         while (target < root._stamps.length && root._stamps[target] <= root._clockMs)
             target++;
-        root._advanceTo(target);
+        root._queueTo(target);
     }
 
     function seekToIndex(index: int): void {
         root.playing = false;
         const clamped = Math.max(0, Math.min(root.events.length, index + 1));
         root._clockMs = clamped === 0 ? 0 : root._stamps[clamped - 1];
-        root._advanceTo(clamped);
+        root._queueTo(clamped);
+    }
+
+    function _queueTo(target: int): void {
+        if (target <= root._cursor) {
+            root._pendingTarget = -1;
+            root._advanceTo(target);
+            return;
+        }
+        root._pendingTarget = target;
     }
 
     function _advanceTo(target: int): void {
@@ -116,6 +128,18 @@ QtObject {
             root._advanceTo(target);
             if (root._cursor >= root.events.length)
                 root.playing = false;
+        }
+    }
+
+    property Timer _catchupTick: Timer {
+        interval: 40
+        repeat: true
+        running: root.catchingUp
+        onTriggered: {
+            const step = Math.min(AgentGraphService.replayStepEvents, root._pendingTarget - root._cursor);
+            root._advanceTo(root._cursor + Math.max(1, step));
+            if (root._cursor >= root._pendingTarget)
+                root._pendingTarget = -1;
         }
     }
 }

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -356,10 +356,8 @@ Item {
                                 : node.errored
                                     ? Qt.alpha(Colours.palette.m3error, 0.85)
                                     : Qt.alpha(node.modelData.categoryColor ?? Colours.palette.m3surfaceContainerHigh, 0.92)
-                        border.width: 1
-                        border.color: node.isSession || node.running || node.errored
-                            ? "transparent"
-                            : Qt.alpha(Colours.palette.m3outlineVariant, 0.8)
+                        border.width: 1.5
+                        border.color: Qt.alpha(node.modelData.sessionColor ?? Colours.palette.m3outlineVariant, node.isSession ? 0.85 : 0.55)
 
                         readonly property color ink: Colours.contrastOn(pill.color)
 

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -453,7 +453,7 @@ Item {
         implicitWidth: tipContent.implicitWidth + Tokens.padding.large * 2
         implicitHeight: tipContent.implicitHeight + Tokens.padding.medium * 2
         radius: Tokens.rounding.large
-        color: Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.97)
+        color: Qt.alpha(Colours.palette.m3surfaceContainerHigh, 0.97)
         border.width: 1
         border.color: Colours.palette.m3outlineVariant
         z: 10
@@ -530,7 +530,7 @@ Item {
             implicitWidth: 28
             implicitHeight: 28
             radius: Tokens.rounding.full
-            color: Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+            color: Qt.alpha(Colours.palette.m3surfaceContainerHigh, 0.9)
             border.width: 1
             border.color: Colours.palette.m3outlineVariant
 

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -355,15 +355,13 @@ Item {
                                 ? Qt.alpha(root.accent, 0.8)
                                 : node.errored
                                     ? Qt.alpha(Colours.palette.m3error, 0.85)
-                                    : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.92)
+                                    : Qt.alpha(node.modelData.categoryColor ?? Colours.palette.m3surfaceContainerHigh, 0.92)
                         border.width: 1
                         border.color: node.isSession || node.running || node.errored
                             ? "transparent"
                             : Qt.alpha(Colours.palette.m3outlineVariant, 0.8)
 
-                        readonly property color ink: node.isSession || node.running || node.errored
-                            ? Colours.contrastOn(pill.color)
-                            : Colours.palette.m3onSurfaceVariant
+                        readonly property color ink: Colours.contrastOn(pill.color)
 
                         Behavior on scale {
                             Anim { type: Anim.EmphasizedSmall }

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -98,7 +98,7 @@ Item {
     Timer {
         interval: 1000
         repeat: true
-        running: root.visible && root.anyFlowing
+        running: root.visible
         triggeredOnStart: true
         onTriggered: root.nowMs = Date.now()
     }
@@ -310,8 +310,10 @@ Item {
                     readonly property bool hovered: root.hoveredIndex === node.index
                     readonly property bool selected: root.selectedIndex === node.index
                     readonly property color stateColour: node.errored ? Colours.palette.m3error : root.accent
+                    readonly property real fade: graphLayout.fadeFor(node.modelData, root.nowMs)
+                    readonly property real fadeScale: 0.9 + 0.1 * node.fade
 
-                    opacity: node.ended ? 0.5 : 1
+                    opacity: node.fade
 
                     Behavior on opacity {
                         Anim { type: Anim.DefaultEffects }
@@ -346,7 +348,7 @@ Item {
                         implicitWidth: Math.max(node.isSession ? 26 : 20, content.implicitWidth + (node.isSession ? Tokens.padding.large : Tokens.padding.medium))
                         implicitHeight: node.isSession ? 32 : 26
                         radius: Tokens.rounding.full
-                        scale: node.selected ? 1.12 : node.hovered ? 1.09 : node.running ? 1.06 : 1
+                        scale: node.fadeScale * (node.selected ? 1.12 : node.hovered ? 1.09 : node.running ? 1.06 : 1)
                         color: node.isSession
                             ? Qt.alpha(root.accent, node.ended ? 0.3 : 0.85)
                             : node.running

--- a/Configs/quickshell/aphotic/modules/agentgraph/ReplayBar.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/ReplayBar.qml
@@ -111,7 +111,7 @@ ColumnLayout {
                         implicitWidth: chipLabel.implicitWidth + Tokens.padding.medium
                         implicitHeight: 24
                         radius: Tokens.rounding.full
-                        color: chip.active ? Colours.palette.m3primary : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+                        color: chip.active ? Colours.palette.m3primary : Qt.alpha(Colours.palette.m3surfaceContainerHigh, 0.9)
                         border.width: 1
                         border.color: chip.active ? "transparent" : Colours.palette.m3outlineVariant
 
@@ -156,7 +156,7 @@ ColumnLayout {
             implicitWidth: 28
             implicitHeight: 28
             radius: Tokens.rounding.full
-            color: accented ? Colours.palette.m3primary : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+            color: accented ? Colours.palette.m3primary : Qt.alpha(Colours.palette.m3surfaceContainerHigh, 0.9)
             border.width: 1
             border.color: accented ? "transparent" : Colours.palette.m3outlineVariant
 
@@ -199,7 +199,7 @@ ColumnLayout {
             implicitWidth: speedLabel.implicitWidth + Tokens.padding.medium
             implicitHeight: 26
             radius: Tokens.rounding.full
-            color: Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+            color: Qt.alpha(Colours.palette.m3surfaceContainerHigh, 0.9)
             border.width: 1
             border.color: Colours.palette.m3outlineVariant
 

--- a/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
@@ -66,7 +66,7 @@ StyledRect {
                 implicitWidth: replayLabel.implicitWidth + Tokens.padding.medium
                 implicitHeight: 24
                 radius: Tokens.rounding.full
-                color: root.replayMode ? Colours.palette.m3primary : Qt.alpha(Colours.tPalette.m3surfaceContainerHigh, 0.9)
+                color: root.replayMode ? Colours.palette.m3primary : Qt.alpha(Colours.palette.m3surfaceContainerHigh, 0.9)
                 border.width: 1
                 border.color: root.replayMode ? "transparent" : Colours.palette.m3outlineVariant
 
@@ -122,6 +122,7 @@ StyledRect {
         GraphView {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            visible: root.visible
             sessions: root.replayMode ? replay.sessions : AgentGraphService.sessions
         }
 

--- a/Configs/quickshell/aphotic/modules/dashboard/DashboardContent.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/DashboardContent.qml
@@ -49,8 +49,8 @@ ColumnLayout {
         id: tabFrame
 
         Layout.alignment: Qt.AlignHCenter
-        Layout.preferredWidth: tabLoader.implicitWidth + Tokens.padding.extraLarge * 2
-        Layout.preferredHeight: tabLoader.implicitHeight + Tokens.padding.extraLarge * 2
+        Layout.preferredWidth: (root.currentTab === "agentGraph" ? agentGraphLoader.implicitWidth : tabLoader.implicitWidth) + Tokens.padding.extraLarge * 2
+        Layout.preferredHeight: (root.currentTab === "agentGraph" ? agentGraphLoader.implicitHeight : tabLoader.implicitHeight) + Tokens.padding.extraLarge * 2
         radius: Tokens.rounding.extraLarge
         color: Qt.alpha(Colours.tPalette.m3surfaceContainer, 0.85)
         border.width: 1
@@ -101,7 +101,7 @@ ColumnLayout {
                 case "aiChat":
                     return aiChatComp;
                 case "agentGraph":
-                    return agentGraphComp;
+                    return null;
                 default:
                     return dashboardComp;
                 }
@@ -116,6 +116,21 @@ ColumnLayout {
                 id: fadeInTimer
                 interval: 1
                 onTriggered: tabLoader.opacity = 1
+            }
+        }
+
+        Loader {
+            id: agentGraphLoader
+
+            anchors.centerIn: parent
+            active: InstallProfile.aiEnabled
+            asynchronous: true
+            visible: agentGraphLoader.opacity > 0
+            opacity: root.currentTab === "agentGraph" ? 1 : 0
+            sourceComponent: agentGraphComp
+
+            Behavior on opacity {
+                Anim { type: Anim.DefaultEffects }
             }
         }
     }
@@ -147,6 +162,8 @@ ColumnLayout {
     }
     Component {
         id: agentGraphComp
-        AgentGraphTab {}
+        AgentGraphTab {
+            visible: agentGraphLoader.opacity > 0
+        }
     }
 }

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -104,6 +104,13 @@ Singleton {
         root._apply(record);
     }
 
+    function _hueForSession(id: string): int {
+        let hash = 0;
+        for (let i = 0; i < id.length; i++)
+            hash = (hash * 31 + id.charCodeAt(i)) | 0;
+        return Math.abs(hash) % 360;
+    }
+
     function _blankSession(record): var {
         return {
             id: record.sessionId,
@@ -113,6 +120,7 @@ Singleton {
             startedAt: record.t ?? 0,
             updatedAt: record.t ?? 0,
             endedAt: 0,
+            hue: root._hueForSession(record.sessionId),
             nodes: [],
             agentParents: ({})
         };

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -31,6 +31,7 @@ Singleton {
     readonly property int layoutHz: root.tier === "lite" ? 30 : 60
     readonly property int maxEvents: root.tier === "full" ? 2400 : root.tier === "standard" ? 1200 : 600
     readonly property int edgeParticles: root.tier === "full" ? 6 : root.tier === "standard" ? 3 : 1
+    readonly property int replayStepEvents: root.tier === "full" ? 1 : root.tier === "standard" ? 2 : 6
     readonly property bool anyRunning: root._sessions.some(s => s.status === "running")
 
     readonly property bool _gpuContended: AgentProviders.ollamaLoadedModels.length > 0


### PR DESCRIPTION
## Summary
Five independently-revertable commits improving the agent graph view:

- **Temporal fade** — completed nodes decay in opacity/scale based on time since they ended (15 min half-life, 0.35 floor) instead of a flat "ended" dim. Running nodes and live sessions stay full weight. Computed once in `GraphLayout` off wall-clock time, so live view and replay share the same curve.
- **Categorical color** — completed tool/subagent nodes fill by category (file ops, shell, web, subagent spawn, other), mapped from `agent_hook.py`'s real `tool_name` values and resolved through `Colours`' M3 role system (no hardcoded hex). Independent of fade.
- **Per-session hue** — each session gets a stable hue derived from a deterministic hash of its session ID, assigned at `session_start` and stored on the session record in `AgentGraphService`. Replay reproduces the same hue as the original run. Rendered as the node border/ring; category color stays the fill.
- **Replay animation** — forward seeks/scrubs in `GraphReplay` now queue a target and step through intervening events on a timer, reusing the existing edge-particle "state drives motion" system, instead of folding straight to the end state. Step size is tier-gated the same way `edgeParticles` already is. Backward jumps still fold instantly.
- **Tab-load perf fix** — the Agent Graph tab now loads in its own asynchronous, pre-warmed Loader kept alive across tab switches, instead of a synchronous swap-Loader that rebuilt everything (including the `Shape`/`CurveRenderer` shader pipeline) on every first visit. Also fixes a pre-existing `Colours.tPalette.m3surfaceContainerHigh`/`m3outlineVariant` typo (those properties live on `Colours.palette`, not `tPalette`) in the agent-graph-scoped files this touches.

All new state (fade curve, category mapping, session hue) is single-sourced in `AgentGraphService`/`GraphLayout`, shared between the live view and replay. Hardware tiering respected throughout (`replayStepEvents` gated the same way `edgeParticles` already is).

## Test plan
- [x] Live-synced each commit's files into a running shell session and restarted `aphotic-shell.service` after every change; verified no Hyprland/bar regressions and a clean shell log (no warnings) after the final commit.
- [x] Manually validated fade/category-color/session-hue/replay-animation against the real live session and a synthetic 4-session/672-event replay run spanning all tool categories.
- [x] Reviewer: spot-check at/near the 300-node-per-session cap on full tier (a real single-session run with ~470 tool calls is available for this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018of5Mu1tkQ5qNQjWyd9tUo