### PR TITLE
Fix harness/provider conflation in agent status + Agent Graph

### DIFF
--- a/Configs/.local/lib/aphotic/agent_usage.py
+++ b/Configs/.local/lib/aphotic/agent_usage.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 SCHEMA_VERSION = 1
-PROVIDER_IDS = ("claude", "codex", "ollama")
+PROVIDER_IDS = ("claude", "codex", "opencode")
 
 
 def _sum_transcript(path: Path, today: str) -> tuple[int, dict[str, int]]:

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -104,7 +104,7 @@ QtObject {
                 kind: "session",
                 sessionIndex: s,
                 sessionId: session.id,
-                label: session.model || session.id.slice(0, 8),
+                label: session.modelInfo?.label || session.id.slice(0, 8),
                 tool: "",
                 status: session.status,
                 parent: -1,
@@ -112,6 +112,10 @@ QtObject {
                 endedAt: session.endedAt ?? 0,
                 cwd: session.cwd ?? "",
                 callCount: session.nodes.length,
+                provider: session.modelInfo?.provider ?? "",
+                locality: session.modelInfo?.locality ?? "",
+                quant: session.modelInfo?.quant ?? "",
+                modelRaw: session.modelInfo?.raw ?? session.model ?? "",
                 sessionColor: sessionColor
             });
 

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -409,6 +409,26 @@ Item {
                                 radius: 2.5
                                 color: Qt.alpha(pill.ink, 0.7)
                             }
+
+                            StyledRect {
+                                id: modelBadge
+
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: node.isSession && root.showLabels && (node.modelData.locality || node.modelData.quant)
+                                radius: Tokens.rounding.small
+                                color: Qt.alpha(pill.ink, 0.16)
+                                implicitWidth: badgeText.implicitWidth + Tokens.padding.small
+                                implicitHeight: badgeText.implicitHeight + Tokens.padding.extraSmall
+
+                                StyledText {
+                                    id: badgeText
+
+                                    anchors.centerIn: parent
+                                    text: [node.modelData.locality, node.modelData.quant].filter(Boolean).join(" · ")
+                                    font: Tokens.font.label.small
+                                    color: pill.ink
+                                }
+                            }
                         }
                     }
                 }
@@ -505,6 +525,16 @@ Item {
                 font: Tokens.font.label.small
                 color: Colours.palette.m3outlineVariant
                 elide: Text.ElideLeft
+                maximumLineCount: 1
+                width: Math.min(implicitWidth, 260)
+            }
+
+            StyledText {
+                visible: text.length > 0
+                text: tip.node && tip.node.kind === "session" ? tip.node.modelRaw : ""
+                font: Tokens.font.label.small
+                color: Colours.palette.m3outlineVariant
+                elide: Text.ElideRight
                 maximumLineCount: 1
                 width: Math.min(implicitWidth, 260)
             }

--- a/Configs/quickshell/aphotic/modules/bar/components/AgentIndicator.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/AgentIndicator.qml
@@ -17,7 +17,7 @@ Item {
 
     readonly property var provider: AgentProviders.providers[AgentProviders.selectedIndex] ?? AgentProviders.providers[0]
     readonly property var stat: AgentProviders.stats[AgentProviders.selectedIndex] ?? AgentProviders.stats[0]
-    readonly property int badgeCount: root.provider.id === "ollama" ? root.stat.loadedModels.length : root.stat.sessionCount
+    readonly property int badgeCount: root.stat.sessionCount
 
     // Absent, not hidden, when the installer's `ai` layer is off -- the bar
     // shouldn't leave a gap where a feature the user declined would go.

--- a/Configs/quickshell/aphotic/modules/bar/popouts/AgentPopout.qml
+++ b/Configs/quickshell/aphotic/modules/bar/popouts/AgentPopout.qml
@@ -49,6 +49,7 @@ ColumnLayout {
                 readonly property bool isSelected: modelData.id === AgentProviders.selected
 
                 Layout.fillWidth: true
+                implicitWidth: tabRow.implicitWidth + Tokens.padding.small * 2
                 implicitHeight: tabRow.implicitHeight + Tokens.padding.small * 2
                 radius: Tokens.rounding.normal
                 color: isSelected ? Colours.palette.m3secondaryContainer : "transparent"

--- a/Configs/quickshell/aphotic/modules/bar/popouts/AgentPopout.qml
+++ b/Configs/quickshell/aphotic/modules/bar/popouts/AgentPopout.qml
@@ -86,13 +86,11 @@ ColumnLayout {
 
         readonly property int index: AgentProviders.selectedIndex
         readonly property var stat: AgentProviders.stats[index] ?? ({})
-        readonly property bool isOllama: AgentProviders.selected === "ollama"
 
         Layout.fillWidth: true
         spacing: Tokens.spacing.small / 2
 
         StyledText {
-            visible: !detail.isOllama
             text: qsTr("%1 session(s) running").arg(detail.stat.sessionCount ?? 0)
             font: Tokens.font.title.medium
         }
@@ -103,7 +101,7 @@ ColumnLayout {
         // single tool invocation had zero effect on what the popout
         // showed. One row per currently-running session.
         Repeater {
-            model: !detail.isOllama ? (detail.stat.liveSessions ?? []) : []
+            model: detail.stat.liveSessions ?? []
 
             RowLayout {
                 required property var modelData
@@ -141,28 +139,28 @@ ColumnLayout {
         }
 
         StyledText {
-            visible: !detail.isOllama && detail.stat.availability === "unavailable"
+            visible: detail.stat.availability === "unavailable"
             text: qsTr("No usage data yet")
             color: Colours.palette.m3onSurfaceVariant
             font: Tokens.font.body.small
         }
 
         StyledText {
-            visible: !detail.isOllama && detail.stat.availability === "unsupported"
+            visible: detail.stat.availability === "unsupported"
             text: qsTr("Usage tracking not supported for this CLI version")
             color: Colours.palette.m3onSurfaceVariant
             font: Tokens.font.body.small
         }
 
         StyledText {
-            visible: !detail.isOllama && detail.stat.availability === "available"
+            visible: detail.stat.availability === "available"
             text: qsTr("Today: %1 tokens").arg(detail.stat.todayTokens ?? 0)
             color: Colours.palette.m3onSurfaceVariant
             font: Tokens.font.body.small
         }
 
         Repeater {
-            model: !detail.isOllama && detail.stat.availability === "available" ? (detail.stat.tokensByModel ?? []) : []
+            model: detail.stat.availability === "available" ? (detail.stat.tokensByModel ?? []) : []
 
             RowLayout {
                 required property var modelData
@@ -183,13 +181,6 @@ ColumnLayout {
                     font: Tokens.font.label.medium
                 }
             }
-        }
-
-        StyledText {
-            visible: detail.isOllama
-            text: (detail.stat.loadedModels ?? []).length > 0 ? (detail.stat.loadedModels ?? []).join(", ") : qsTr("No models loaded")
-            font: Tokens.font.title.medium
-            wrapMode: Text.Wrap
         }
     }
 

--- a/Configs/quickshell/aphotic/services/AgentProviders.qml
+++ b/Configs/quickshell/aphotic/services/AgentProviders.qml
@@ -4,31 +4,57 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.services
+import qs.services.ai
 
 // Presence + usage for the bar's agent indicator/panel, one entry per
-// tracked CLI. Two independent data sources feed `stats`: a 5s
-// pgrep/`ollama ps` presence poll (this file), and a 15s FileView read of
-// the aggregate record `aphotic agent usage-update` writes every 15
-// minutes (never parsed here -- this service only reads that file).
+// tracked harness (a CLI that runs a session and executes tool calls --
+// see AgentRoles.qml for the harness/provider distinction). Two
+// independent data sources feed `stats`: a 5s pgrep presence poll (this
+// file), and a 15s FileView read of the aggregate record `aphotic agent
+// usage-update` writes every 15 minutes (never parsed here -- this
+// service only reads that file).
+//
+// Ollama is deliberately NOT one of these entries: it's a provider, not a
+// harness, and a bare Ollama process has no session/command shape to show
+// in this popout. Its loaded-model state is still tracked below, but only
+// as an internal GPU-contention signal for AgentGraphService, never as a
+// Bar tab.
 Singleton {
     id: root
 
-    readonly property var providers: [
-        { id: "claude", label: qsTr("Claude Code"), icon: "smart_toy", processName: "claude", launchCmd: ["claude"] },
-        { id: "codex", label: qsTr("Codex"), icon: "terminal", processName: "codex", launchCmd: ["codex"] },
-        { id: "ollama", label: qsTr("Ollama"), icon: "dns", processName: null, launchCmd: ["ollama"] }
-    ]
+    readonly property var _uiMeta: ({
+        "claude": { icon: "smart_toy", processName: "claude", launchCmd: ["claude"] },
+        "codex": { icon: "terminal", processName: "codex", launchCmd: ["codex"] },
+        "opencode": { icon: "terminal", processName: "opencode", launchCmd: ["opencode"] }
+    })
+
+    // Set of active harness tabs: ids/enablement come from AgentRoles (the
+    // single-sourced role schema); icon/pgrep-name/launch command are Bar-
+    // specific UI metadata, not a classification concern. A harness with
+    // no _uiMeta entry (e.g. Gemini CLI -- no known package/binary in this
+    // repo yet) is skipped rather than shown with dead detection.
+    readonly property var providers: AgentRoles.harnesses
+        .filter(h => root._uiMeta[h.id])
+        .map(h => ({
+            id: h.id,
+            label: h.label,
+            icon: root._uiMeta[h.id].icon,
+            processName: root._uiMeta[h.id].processName,
+            launchCmd: root._uiMeta[h.id].launchCmd
+        }))
 
     property var stats: providers.map(() => ({
         sessionCount: 0,
-        loadedModels: [],
         todayTokens: 0,
         tokensByModel: [],
         availability: "unavailable",
         liveSessions: []
     }))
 
-    readonly property var ollamaLoadedModels: root.stats[root.providers.findIndex(p => p.id === "ollama")]?.loadedModels ?? []
+    // Ollama's loaded-model state, tracked independently of the harness
+    // `providers`/`stats` pair above -- AgentGraphService reads this to
+    // demote render tier when the GPU is busy serving a local model.
+    property var ollamaLoadedModels: []
 
     readonly property string selected: Settings.agentSelectedProvider
     readonly property int selectedIndex: providers.findIndex(p => p.id === root.selected)
@@ -38,21 +64,10 @@ Singleton {
         Settings.agentSelectedProvider = root.providers[next].id;
     }
 
-    // Right-click contract per spec: always launch (no focus-existing
-    // fallback) -- Ollama specifically launches `ollama run <model>` for
-    // its first loaded model rather than a bare launchCmd, and no-ops if
-    // no model is loaded (nothing sensible to launch).
     function launchSelected(): void {
         const provider = root.providers[root.selectedIndex];
         if (!provider)
             return;
-        if (provider.id === "ollama") {
-            const loaded = root.stats[root.selectedIndex]?.loadedModels ?? [];
-            if (loaded.length === 0)
-                return;
-            Quickshell.execDetached(["kitty", "-e", "ollama", "run", loaded[0]]);
-            return;
-        }
         Quickshell.execDetached(["kitty", "-e", ...provider.launchCmd]);
     }
 
@@ -89,13 +104,22 @@ Singleton {
     }
 
     Process {
+        id: opencodePgrep
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const n = parseInt(text.trim(), 10);
+                root._setStat(root._findIndex("opencode"), { sessionCount: isNaN(n) ? 0 : n });
+            }
+        }
+    }
+
+    Process {
         id: ollamaPs
         command: ["ollama", "ps"]
         stdout: StdioCollector {
             onStreamFinished: {
                 const lines = text.trim().split("\n").slice(1).filter(l => l.length > 0);
-                const models = lines.map(l => l.trim().split(/\s+/)[0]).filter(Boolean);
-                root._setStat(root._findIndex("ollama"), { loadedModels: models });
+                root.ollamaLoadedModels = lines.map(l => l.trim().split(/\s+/)[0]).filter(Boolean);
             }
         }
     }
@@ -106,8 +130,12 @@ Singleton {
         repeat: true
         triggeredOnStart: true
         onTriggered: {
-            claudePgrep.exec(["pgrep", "-x", "-c", "claude"]);
-            codexPgrep.exec(["pgrep", "-x", "-c", "codex"]);
+            if (root._findIndex("claude") !== -1)
+                claudePgrep.exec(["pgrep", "-x", "-c", "claude"]);
+            if (root._findIndex("codex") !== -1)
+                codexPgrep.exec(["pgrep", "-x", "-c", "codex"]);
+            if (root._findIndex("opencode") !== -1)
+                opencodePgrep.exec(["pgrep", "-x", "-c", "opencode"]);
             ollamaPs.running = true;
         }
     }
@@ -122,14 +150,14 @@ Singleton {
                 const data = JSON.parse(text());
                 if (data.schemaVersion !== 1)
                     return;
-                for (const id of ["claude", "codex", "ollama"]) {
-                    const p = data.providers?.[id];
-                    if (!p)
+                for (const p of root.providers) {
+                    const usage = data.providers?.[p.id];
+                    if (!usage)
                         continue;
-                    root._setStat(root._findIndex(id), {
-                        availability: p.availability ?? "unavailable",
-                        todayTokens: p.todayTokens ?? 0,
-                        tokensByModel: p.tokensByModel ?? []
+                    root._setStat(root._findIndex(p.id), {
+                        availability: usage.availability ?? "unavailable",
+                        todayTokens: usage.todayTokens ?? 0,
+                        tokensByModel: usage.tokensByModel ?? []
                     });
                 }
             } catch (e) {
@@ -155,7 +183,10 @@ Singleton {
     // folder-watch API exists for "list of files in a directory that
     // changes", so this still re-lists on the same 5s cadence as
     // presence polling above rather than reacting to individual file
-    // writes.
+    // writes. Claude Code is currently the only harness with a hook
+    // system that populates this directory -- Codex/OpenCode stay
+    // presence-only (see docs/AGENT_TRACKING.md) until they ship an
+    // equivalent.
     Process {
         id: sessionLister
         stdout: StdioCollector {

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -575,7 +575,7 @@ Singleton {
                     root.taskbarGrouping = data.taskbarGrouping;
                 if (typeof data.minimalShowDnd === "boolean")
                     root.minimalShowDnd = data.minimalShowDnd;
-                if (typeof data.agentSelectedProvider === "string" && ["claude", "codex", "ollama"].includes(data.agentSelectedProvider))
+                if (typeof data.agentSelectedProvider === "string" && ["claude", "codex", "opencode"].includes(data.agentSelectedProvider))
                     root.agentSelectedProvider = data.agentSelectedProvider;
                 if (typeof data.agentGraphQuality === "string" && ["auto", "lite", "standard", "full"].includes(data.agentGraphQuality))
                     root.agentGraphQuality = data.agentGraphQuality;

--- a/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentGraphService.qml
@@ -8,6 +8,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.services
+import qs.services.ai
 
 Singleton {
     id: root
@@ -112,11 +113,52 @@ Singleton {
         return Math.abs(hash) % 360;
     }
 
+    // Parsed once per session_start (see applyTo below), never per frame --
+    // a harness reports whatever backend it's actually using in the same
+    // `model` field regardless of whether that's a hosted cloud model or a
+    // local one served through a provider like unsloth/Ollama/LM Studio
+    // (e.g. "unsloth/Qwen3.8-27B-GGUF:Q4_K_M" vs "claude-opus-4-x"), so
+    // this is a string-classification problem, not a second process to
+    // detect. Known provider ids from AgentRoles take priority; a cloud/
+    // local heuristic on the string shape is the fallback for anything
+    // that doesn't name a known provider outright.
+    function parseModelInfo(modelString: string): var {
+        const raw = modelString ?? "";
+        if (!raw)
+            return { label: "", provider: "", locality: "", quant: "", raw: "" };
+
+        const lower = raw.toLowerCase();
+        let provider = "";
+        for (const p of AgentRoles.providers) {
+            if (lower.includes(p.id.toLowerCase())) {
+                provider = p.id;
+                break;
+            }
+        }
+
+        let locality = provider ? AgentRoles.localityFor(provider) : "";
+        if (!locality) {
+            if (/\.gguf\b/i.test(raw) || /\bQ\d(?:_\d)?(?:_K)?(?:_[SML])?\b/i.test(raw) || raw.includes("/"))
+                locality = "local";
+            else if (/^(claude|gpt|o[0-9]|gemini)[-:]/i.test(raw))
+                locality = "cloud";
+        }
+
+        const quantMatch = raw.match(/\bQ\d(?:_\d)?(?:_K)?(?:_[SML])?\b/i);
+        const ggufMatch = raw.match(/[\w.-]+\.gguf\b/i);
+        const quant = quantMatch ? quantMatch[0] : (ggufMatch ? ggufMatch[0] : "");
+
+        const label = raw.length > 28 ? `${raw.slice(0, 25)}…` : raw;
+
+        return { label: label, provider: provider, locality: locality, quant: quant, raw: raw };
+    }
+
     function _blankSession(record): var {
         return {
             id: record.sessionId,
             status: "idle",
             model: record.model ?? "",
+            modelInfo: root.parseModelInfo(record.model ?? ""),
             cwd: record.cwd ?? "",
             startedAt: record.t ?? 0,
             updatedAt: record.t ?? 0,
@@ -161,6 +203,7 @@ Singleton {
         } else if (record.event === "session_start") {
             session.status = "idle";
             session.model = record.model ?? session.model;
+            session.modelInfo = root.parseModelInfo(session.model);
         }
         if (record.cwd)
             session.cwd = record.cwd;

--- a/Configs/quickshell/aphotic/services/ai/AgentRoles.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentRoles.qml
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Single source of harness/provider role + locality for every AI CLI this
+// shell knows about. A harness (Claude Code, Codex, OpenCode, Gemini CLI)
+// runs a session and executes tool calls; a provider (Ollama, unsloth, LM
+// Studio, huggingface-cli) only serves inference and never gets its own
+// Bar tab or Agent Graph node -- it's read as an annotation on whichever
+// harness is using it as a backend. Optional [agents.<id>] tables in
+// aphotic.toml override the built-in defaults below, read the same
+// regex-over-known-keys way InstallProfile.qml reads [install].
+Singleton {
+    id: root
+
+    readonly property var _defaults: [
+        { id: "claude", label: "Claude Code", role: "harness", locality: null },
+        { id: "codex", label: "Codex", role: "harness", locality: null },
+        { id: "opencode", label: "OpenCode", role: "harness", locality: null },
+        { id: "geminicli", label: "Gemini CLI", role: "harness", locality: null },
+        { id: "ollama", label: "Ollama", role: "provider", locality: "local" },
+        { id: "unsloth", label: "unsloth", role: "provider", locality: "local" },
+        { id: "lms", label: "LM Studio", role: "provider", locality: "local" },
+        { id: "huggingface-cli", label: "Hugging Face CLI", role: "provider", locality: "local" }
+    ]
+
+    property var _overrides: ({})
+
+    readonly property var entries: root._defaults.map(d => {
+        const o = root._overrides[d.id] ?? {};
+        return {
+            id: d.id,
+            label: d.label,
+            role: o.role ?? d.role,
+            locality: d.locality,
+            enabled: o.enabled ?? true
+        };
+    })
+
+    readonly property var harnesses: root.entries.filter(e => e.role === "harness" && e.enabled)
+    readonly property var providers: root.entries.filter(e => e.role === "provider" && e.enabled)
+
+    function roleFor(id: string): string {
+        return (root.entries.find(e => e.id === id) ?? {}).role ?? "";
+    }
+
+    function localityFor(id: string): string {
+        return (root.entries.find(e => e.id === id) ?? {}).locality ?? "";
+    }
+
+    function isEnabled(id: string): bool {
+        const e = root.entries.find(e => e.id === id);
+        return e ? e.enabled : true;
+    }
+
+    FileView {
+        path: `${Quickshell.env("HOME")}/Aphotic-Hypr/aphotic.toml`
+        watchChanges: true
+        onFileChanged: reload()
+        onLoaded: {
+            const raw = text();
+            const sectionRe = /\[agents\.([a-zA-Z0-9_-]+)\]\s*\n([^\[]*)/g;
+            const next = {};
+            let m;
+            while ((m = sectionRe.exec(raw)) !== null) {
+                const id = m[1];
+                const body = m[2];
+                const enabledMatch = body.match(/enabled\s*=\s*(true|false)/);
+                const roleMatch = body.match(/role\s*=\s*"([^"]*)"/);
+                const entry = {};
+                if (enabledMatch)
+                    entry.enabled = enabledMatch[1] === "true";
+                if (roleMatch)
+                    entry.role = roleMatch[1];
+                next[id] = entry;
+            }
+            root._overrides = next;
+        }
+        onLoadFailed: {
+            root._overrides = {};
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/ai/qmldir
+++ b/Configs/quickshell/aphotic/services/ai/qmldir
@@ -1,5 +1,6 @@
 module qs.services.ai
 singleton AgentGraphService 1.0 AgentGraphService.qml
+singleton AgentRoles 1.0 AgentRoles.qml
 singleton AiConfig 1.0 AiConfig.qml
 singleton AiKeys 1.0 AiKeys.qml
 singleton AiProviders 1.0 AiProviders.qml

--- a/aphotic.toml.example
+++ b/aphotic.toml.example
@@ -16,3 +16,14 @@ position = "top"          # top | left
 [system]
 nvidia = false
 aur_helper = "yay"
+
+# Optional overrides for the Bar agent-status popout / Agent Graph's
+# built-in harness/provider table (Configs/quickshell/aphotic/services/
+# ai/AgentRoles.qml). Omit entirely to use the built-in defaults -- known
+# harnesses (claude, codex, opencode, geminicli) and providers (ollama,
+# unsloth, lms, huggingface-cli) already ship correctly classified.
+# [agents.codex]
+# enabled = false   # hide Codex from the popout even if it's installed
+#
+# [agents.ollama]
+# role = "harness"  # only if you've wired something that makes this true


### PR DESCRIPTION
## What this changes

Aphotic's Bar agent-status popout and Agent Graph conflated two distinct roles: **harnesses** (Claude Code, Codex, OpenCode — run a session, execute tool calls) and **providers** (Ollama, unsloth, LM Studio, huggingface-cli — inference-only backends with no tool-execution loop). Concretely, Ollama had its own popout tab purely because `ollama ps` reported a loaded model, with no tie to actual agent activity. This PR corrects that classification bug across the Bar, a new shared role schema, and the Agent Graph, in three separable commits.

## Scope

- [ ] This is scoped to one module/command/fix, not a multi-surface change

This is intentionally a multi-surface change — see "Anything the reviewer should know" below for why, and the three separable commits for how it splits.

- [ ] Related `README.md` Roadmap item (if any):
- [ ] If this touches `install.sh` or a systemd unit file: validated on the dev VM (not just CI) — note the result below

Doesn't touch `install.sh` or any systemd unit — scoped to Quickshell/QML runtime behavior + `agent_usage.py`, so no dev-VM validation needed.

## Commits

1. **`AgentRoles.qml`** (new singleton, `services/ai/`) — single source of harness/provider role + locality for every AI CLI this shell knows about. Optional `[agents.<id>]` tables in `aphotic.toml` can override the built-in defaults (documented in `aphotic.toml.example`), read the same regex-over-known-keys way `InstallProfile.qml` already reads `[install]`.
2. **Bar popout** — `AgentProviders.qml` drops the Ollama tab entirely and sources its harness list from `AgentRoles.harnesses`; every `isOllama`-branched block in `AgentPopout.qml`/`AgentIndicator.qml` is deleted as dead UI. OpenCode is added with the same presence+usage treatment Codex already has (full live-session stats aren't possible for either until they ship a Claude-Code-hook equivalent — stays honestly partial, not claimed parity). Ollama's loaded-model polling is kept internally (`ollamaLoadedModels`) since `AgentGraphService` reads it for GPU-contention render-tier demotion.
3. **Agent Graph** — `GraphLayout.qml` previously dumped the raw `session.model` string straight into the node label. `AgentGraphService.parseModelInfo()` now classifies that string once on `session_start` (cached on the session object, never re-parsed per frame): known provider ids from `AgentRoles` take priority for local/cloud classification, falling back to a shape heuristic (gguf/quant markers vs bare cloud model ids) otherwise. A `.gguf`/quant-suffix badge (`Q4_K_M`-style) is extracted into its own field. `GraphView.qml` renders a small locality/quant badge on session nodes, full raw string moved to the tooltip.

## Verification

- [x] `agent_usage.py`: `py_compile` + a smoke test confirming `build_usage_record` still works with the new `PROVIDER_IDS` (`claude`, `codex`, `opencode`)
- [x] `parseModelInfo`'s regex logic unit-tested standalone in Node against the exact `unsloth/Qwen3.8-27B-GGUF:Q4_K_M` case plus cloud model ids, bare `.gguf` paths, and empty strings
- [ ] `qmllint` — attempted but non-functional in this sandbox (crashes silently with no output on any input, including a deliberately broken test file — not a signal on this diff specifically)
- [ ] Live `qs -c aphotic` restart / log check / screenshot — no display server reachable from this sandbox; **left for your review**

## Anything the reviewer should know

- This is a real architecture fix, not a small tweak — three files' worth of hardcoded provider lists collapse into one schema, so it touches the Bar, a new singleton, and the Agent Graph. Split into three separable commits so each is reviewable on its own.
- Gemini CLI is in `AgentRoles.qml`'s static table as `role: "harness"` (schema-complete) but **not** wired into the Bar's live presence poll — no known package/binary for it exists anywhere in this repo (verified: zero references outside the unrelated Quick-Chat `gemini` HTTP-chat id). Flagged rather than guessed.
- ChatGPT / Gemini (chat) stay exclusively in the separate Quick Chat surface (`AiProviders.qml`) — not part of this role table at all.
- unsloth / LM Studio / huggingface-cli get schema entries (role + locality) only — no new live process detection built in this PR (scoped down deliberately).
- `docs/AGENT_TRACKING.md` updated locally for consistency, but that directory is gitignored (local notes only) so it's not part of this diff.