### PR TITLE
Add explicit Stop control for Ollama in Settings

### DIFF
--- a/Configs/quickshell/aphotic/modules/settings/panes/AiPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/AiPane.qml
@@ -158,6 +158,8 @@ ColumnLayout {
                 description: {
                     if (AiProviders.startingOllama)
                         return qsTr("Starting…");
+                    if (AiProviders.stoppingOllama)
+                        return qsTr("Stopping…");
                     if (AiProviders.ollamaReachable)
                         return qsTr("Running at %1").arg(AiConfig.ollamaHost);
                     return qsTr("Not reachable at %1").arg(AiConfig.ollamaHost);
@@ -170,6 +172,8 @@ ColumnLayout {
                 // trailing slot (a plain Item, not a Layout) silently
                 // collapses to 0x0 instead.
                 RowLayout {
+                    spacing: Tokens.spacing.small
+
                     StyledRect {
                         Layout.preferredHeight: 32
                         Layout.preferredWidth: startLabel.implicitWidth + Tokens.padding.large * 2
@@ -196,6 +200,35 @@ ColumnLayout {
                             anchors.fill: parent
                             enabled: !AiProviders.startingOllama
                             onClicked: AiProviders.startOllama()
+                        }
+                    }
+
+                    StyledRect {
+                        Layout.preferredHeight: 32
+                        Layout.preferredWidth: stopLabel.implicitWidth + Tokens.padding.large * 2
+                        radius: Tokens.rounding.full
+                        visible: AiProviders.ollamaReachable
+                        opacity: AiProviders.stoppingOllama ? 0.5 : 1
+                        color: Colours.layer(Colours.tPalette.m3surfaceContainer, 3)
+
+                        StyledText {
+                            id: stopLabel
+                            anchors.centerIn: parent
+                            text: AiProviders.stoppingOllama ? qsTr("Stopping…") : qsTr("Stop Ollama")
+                            color: Colours.palette.m3onSurfaceVariant
+                            font: Tokens.font.label.small
+                        }
+
+                        StateLayer {
+                            anchors.fill: parent
+                            radius: parent.radius
+                            disabled: AiProviders.stoppingOllama
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            enabled: !AiProviders.stoppingOllama
+                            onClicked: AiProviders.stopOllama()
                         }
                     }
                 }

--- a/Configs/quickshell/aphotic/services/ai/AiProviders.qml
+++ b/Configs/quickshell/aphotic/services/ai/AiProviders.qml
@@ -4,6 +4,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Quickshell
 import Quickshell.Io
+import qs.services
 import qs.services.ai
 
 // Uniform interface over the four AI Chat providers. Claude is the only
@@ -163,6 +164,7 @@ Singleton {
     // is that missing signal, updated explicitly on every attempt.
     property bool ollamaReachable: false
     property bool startingOllama: false
+    property bool stoppingOllama: false
 
     function refreshOllamaModels(): void {
         if (!AiConfig.ollamaHostConfigured) {
@@ -192,6 +194,13 @@ Singleton {
         root.startingOllama = true;
         Quickshell.execDetached(["ollama", "serve"]);
         ollamaStartupRetry.restart();
+    }
+
+    function stopOllama(): void {
+        if (root.stoppingOllama || !root.ollamaReachable)
+            return;
+        root.stoppingOllama = true;
+        ollamaStopProc.exec(["sh", "-c", "pkill -x ollama"]);
     }
 
     function refreshRunningModels(): void {
@@ -262,8 +271,41 @@ Singleton {
             root.refreshOllamaModels();
             if (root.ollamaReachable || attempts >= 8) {
                 stop();
+                if (!root.ollamaReachable)
+                    Toaster.toast(qsTr("Couldn't start Ollama"), qsTr("Not reachable at %1 after starting -- check the ollama binary is installed").arg(AiConfig.ollamaHost), "error");
                 attempts = 0;
                 root.startingOllama = false;
+            }
+        }
+        onRunningChanged: if (running) attempts = 0
+    }
+
+    Process {
+        id: ollamaStopProc
+        onExited: exitCode => {
+            if (exitCode === 127) {
+                root.stoppingOllama = false;
+                Toaster.toast(qsTr("Couldn't stop Ollama"), qsTr("pkill isn't available on this system"), "error");
+                return;
+            }
+            ollamaStopRetry.restart();
+        }
+    }
+
+    Timer {
+        id: ollamaStopRetry
+        interval: 500
+        repeat: true
+        property int attempts: 0
+        onTriggered: {
+            attempts += 1;
+            root.refreshOllamaModels();
+            if (!root.ollamaReachable || attempts >= 6) {
+                stop();
+                if (root.ollamaReachable)
+                    Toaster.toast(qsTr("Couldn't stop Ollama"), qsTr("Still reachable at %1 -- it may be running as the system service (sudo systemctl stop ollama)").arg(AiConfig.ollamaHost), "error");
+                attempts = 0;
+                root.stoppingOllama = false;
             }
         }
         onRunningChanged: if (running) attempts = 0


### PR DESCRIPTION
## What this changes

Settings > AI > Ollama had a Status row with a Start action but no way to stop it short of a terminal `pkill`. This adds a matching Stop button using Ollama's existing status singleton and start pattern, per #33's harness/provider split — Ollama is a provider, not a harness, so this control belongs in Settings (direct, user-initiated), not the Bar agent popout.

## Scope

- [x] This is scoped to one module/command/fix, not a multi-surface change

## Verification

This project verifies live, not just "it parses" (see `CONTRIBUTING.md`):

- [ ] `pkill -x qs` then a fresh `qs -c aphotic` restart (not relying on hot-reload alone)
- [ ] Checked logs for `Configuration Loaded` and zero new errors
- [ ] Confirmed the shell is still running afterward (`pgrep -f "qs -c aphotic"`)
- [ ] For visual changes: screenshot attached below
- [ ] `bash -n` on any shell script touched
- [ ] Added/updated a test under `tests/` for install/uninstall/CLI behavior changes
- [ ] No debug residue left behind (`git diff` reviewed)

`qmllint` is non-functional in this sandbox (confirmed broken generically — crashes with no output on any input, including a deliberately broken test file, so it's not a signal on this diff specifically) and no display server is reachable here, so none of the above could be run live. **Left for your review** — no shell script touched, no install/uninstall/CLI behavior changed, so those specific items don't apply here.

## Anything the reviewer should know

- Reused `AiProviders.qml`'s existing `ollamaReachable`/`startingOllama` singleton state and `startOllama()`'s established pattern exactly — no second status poller, no systemd (the existing code already documents why: `ollama.service` is a system service needing root this shell deliberately never requests live; `pkill -x ollama` has the same no-privilege boundary as the existing `ollama serve` direct-spawn Start).
- `stopOllama()` confirms success the same way `startOllama()` does — polling `refreshOllamaModels()`'s reachability signal via a retry timer, not trusting the killing process's own exit code.
- Added an honest `Toaster` failure notification on both directions' retry-exhausted path (`pkill` missing, still reachable after stop attempts — likely means it's the root-owned system service instead of a user-spawned one; `ollama` binary missing after several start attempts). Start's retry loop previously gave up silently with zero user-visible signal in that last case — fixed alongside Stop since both are "this control" and the same "no silent no-ops" requirement applies to both.
- No new component: extended the exact existing SettingsRow already there for Ollama Status, matching its StyledRect/StateLayer/MouseArea button shape (used elsewhere in this same file — Reinstall/Uninstall, Create/Refresh, etc.) rather than introducing a bespoke widget.