### PR TITLE
Spike: parent-agent grouping in Agent Graph (static, default off)

### DIFF
--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -86,6 +86,19 @@ QtObject {
         return Qt.hsla(((hue % 360) + 360) % 360 / 360, 0.5, 0.62, 1);
     }
 
+    function _hueForKey(key: string): int {
+        let hash = 0;
+        for (let i = 0; i < key.length; i++)
+            hash = (hash * 31 + key.charCodeAt(i)) | 0;
+        return Math.abs(hash) % 360;
+    }
+
+    function groupColorFor(sessionHue: real, agentId: string): color {
+        if (!Settings.agentGraphGroupByParent || !agentId)
+            return root.sessionColor(sessionHue);
+        return root.sessionColor(root._hueForKey(agentId));
+    }
+
     onSessionsChanged: root.rebuild()
     onAreaWidthChanged: root.rebuild()
     onAreaHeightChanged: root.rebuild()
@@ -112,7 +125,8 @@ QtObject {
                 endedAt: session.endedAt ?? 0,
                 cwd: session.cwd ?? "",
                 callCount: session.nodes.length,
-                sessionColor: sessionColor
+                sessionColor: sessionColor,
+                groupColor: sessionColor
             });
 
             const visible = session.nodes.slice(-root.maxNodesPerSession);
@@ -137,7 +151,8 @@ QtObject {
                     durationMs: node.durationMs ?? 0,
                     category: category,
                     categoryColor: root.categoryColor(category),
-                    sessionColor: sessionColor
+                    sessionColor: sessionColor,
+                    groupColor: root.groupColorFor(session.hue ?? 0, node.agentId)
                 });
             }
 

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -356,9 +356,10 @@ Item {
                                 : node.errored
                                     ? Qt.alpha(Colours.palette.m3error, 0.85)
                                     : Qt.alpha(node.modelData.categoryColor ?? Colours.palette.m3surfaceContainerHigh, 0.92)
-                        border.width: 1.5
-                        border.color: Qt.alpha(node.modelData.sessionColor ?? Colours.palette.m3outlineVariant, node.isSession ? 0.85 : 0.55)
+                        border.width: pill.grouped ? 2.5 : 1.5
+                        border.color: Qt.alpha(node.modelData.groupColor ?? Colours.palette.m3outlineVariant, node.isSession ? 0.85 : (pill.grouped ? 0.9 : 0.55))
 
+                        readonly property bool grouped: Settings.agentGraphGroupByParent && node.modelData.kind === "subagent"
                         readonly property color ink: Colours.contrastOn(pill.color)
 
                         Behavior on scale {

--- a/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
@@ -181,6 +181,13 @@ ColumnLayout {
                 onValueChanged: Settings.agentGraphAccent = value
             }
         }
+
+        SettingsToggleRow {
+            label: qsTr("Group by parent agent")
+            description: qsTr("Color-codes a subagent's own tool calls separately from its session — computed once when the graph updates, off by default")
+            checked: Settings.agentGraphGroupByParent
+            onToggled: state => Settings.agentGraphGroupByParent = state
+        }
     }
 
     StyledText {

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -117,6 +117,7 @@ Singleton {
     // machine should pick up load from an upgrade it never opted into.
     property string agentGraphQuality: "auto"
     property string agentGraphAccent: ""
+    property bool agentGraphGroupByParent: false
     property string ggufModelsDir: `${Quickshell.env("HOME")}/Models/gguf`
 
     property bool intelligenceEnabled: true
@@ -274,6 +275,7 @@ Singleton {
             agentSelectedProvider: root.agentSelectedProvider,
             agentGraphQuality: root.agentGraphQuality,
             agentGraphAccent: root.agentGraphAccent,
+            agentGraphGroupByParent: root.agentGraphGroupByParent,
             ggufModelsDir: root.ggufModelsDir,
             assistantWelcomeShown: root.assistantWelcomeShown,
             dndEnabled: root.dndEnabled,
@@ -581,6 +583,8 @@ Singleton {
                     root.agentGraphQuality = data.agentGraphQuality;
                 if (typeof data.agentGraphAccent === "string")
                     root.agentGraphAccent = data.agentGraphAccent;
+                if (typeof data.agentGraphGroupByParent === "boolean")
+                    root.agentGraphGroupByParent = data.agentGraphGroupByParent;
                 if (typeof data.ggufModelsDir === "string" && data.ggufModelsDir.length > 0)
                     root.ggufModelsDir = data.ggufModelsDir;
                 if (typeof data.assistantWelcomeShown === "boolean")


### PR DESCRIPTION
## What this is

An investigation, not a committed feature (per the spike brief) — findings below, plus a lightweight implementation that the findings turned out to justify.

## Findings

**1. What triggers layout/re-layout today.** `GraphLayout.rebuild()` fires only on three bindings: `onSessionsChanged`, `onAreaWidthChanged`, `onAreaHeightChanged`. `sessions` changes once per ingested hook event — `AgentGraphService._apply()` reassigns `_sessions` on every `PreToolUse`/`PostToolUse`/etc. This is event-driven, proportional to actual tool-call activity, never a timer loop. `AgentGraphService.layoutHz`/`shouldSimulate` are declared but **unconsumed anywhere** (verified by grep across the whole graph module) — dead scaffolding, not a hidden continuous-layout path. The only genuinely continuous animation is `flowClock` (a 1600ms `NumberAnimation`), and it only runs `while (root.visible && root.anyFlowing)` — gated on the graph tab being open AND at least one edge actually "running." It animates a few dot positions along already-computed edges, not layout itself. Position *changes* between rebuilds ease via `Behavior on x/y` (a short, self-settling property transition), not a continuous simulation.

**2. Static vs. dynamic feasibility.** Parent-based hierarchical placement **already exists**: `GraphLayout._place()` recursively arcs each node's children around their parent at increasing radius, driven by `node.parentId` (which `AgentGraphService._parentFor()` already resolves from `agentId`/Agent-Task tool tracking). So "nesting tool calls spawned by an invocation under their parent" is already structurally true today via edges + radial position. What's actually missing is a visual cue that makes a subagent's own subtree distinguishable from its session's other direct tool calls *without tracing edges* — that's the real gap this spike closes, and it's a pure function of data already known at `rebuild()` time (`node.agentId`), computable in the same one-shot call that already runs today. No new trigger needed.

**3. Expected cost at 5-15 nodes.** The grouping computation is one hash per node (`_hueForKey`, identical cost/shape to the `_hueForSession` hash `AgentGraphService` already runs once per session) — sub-millisecond even at the "full" tier's 300-node cap. It adds a color/border-width *property* to nodes already being rendered — zero new Shapes, zero new draw calls, zero new Timers. The one actually GPU-relevant piece in this system (unchanged by this spike) is `BioluminescentGlow`'s shader blur on running/hovered/selected nodes and the `Shape.CurveRenderer` edge lines — this feature touches neither.

**4. Decision: lightweight static approach is viable — implemented, not skipped.** Color-coding (the cheaper of the two options the brief allowed), gated behind a new `Settings.agentGraphGroupByParent` toggle, **default off**. Subagent-kind nodes (`agentId` truthy) get a border hue hashed from their `agentId`, distinct from their session's hue, computed once inside the existing `rebuild()`. When the toggle is off — or for any non-subagent node — `groupColor === sessionColor` exactly, so rendered output is pixel-identical to `main` today. No visual containment/blob shape was built; color-coding alone satisfies the ask at lower cost, so I didn't build both.

**5. Not stopped, but not fully cleared either — see caveat below.**

## Hard constraint (20% GPU)

Nothing here should move the needle at all given the "zero new geometry, zero new timers, computed once per event" shape above — but **I could not actually verify this live**. No display server/compositor is reachable in this sandbox (same constraint hit on the last two PRs — `qmllint` itself crashes with no output here on any input). The brief's own gate — "benchmark actual GPU/CPU impact before it's ever considered for default-on" — is genuinely undone. This ships **default off** as instructed; the live benchmark before ever flipping that default is on you, not something I can self-certify.

## Minor known weakness

The hash spreads sequential-looking agent ids (`ag_1`, `ag_2`, `ag_9`) into hues that can land close together (tested: 104°/105°/112°) rather than maximally separated — cosmetic, not a correctness issue, and it reuses the exact same hash formula `AgentGraphService._hueForSession` already uses for consistency. Worth a look if it's not visually distinct enough in practice with 2-3 concurrent subagents.

## Verification

- [ ] `pkill -x qs` then a fresh `qs -c aphotic` restart, toggle "Group by parent agent" on in Settings > Personalization > Agent graph, run something that spawns a subagent (Task/Agent tool), confirm the subtree's border color visibly differs from its session's tool-call nodes
- [ ] Live GPU/CPU check with the toggle on during an active multi-subagent session — this is the actual gate before default-on, not done here
- [ ] Confirm toggle-off renders identically to `main` (should be a no-op diff visually)

Not run — no display server reachable in this sandbox.