### PR TITLE
Add Live toggle to pause Agent Graph rendering

### DIFF
--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphLayout.qml
@@ -86,9 +86,18 @@ QtObject {
         return Qt.hsla(((hue % 360) + 360) % 360 / 360, 0.5, 0.62, 1);
     }
 
-    onSessionsChanged: root.rebuild()
+    property bool liveEnabled: Settings.agentGraphEnabled
+
+    onSessionsChanged: {
+        if (root.liveEnabled)
+            root.rebuild();
+    }
     onAreaWidthChanged: root.rebuild()
     onAreaHeightChanged: root.rebuild()
+    onLiveEnabledChanged: {
+        if (root.liveEnabled)
+            root.rebuild();
+    }
 
     function rebuild(): void {
         const nodes = [];

--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -109,7 +109,7 @@ Item {
     implicitHeight: 460
 
     NumberAnimation on flowClock {
-        running: root.visible && root.anyFlowing
+        running: root.visible && root.anyFlowing && Settings.agentGraphEnabled
         loops: Animation.Infinite
         from: 0
         to: 1

--- a/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/AgentGraphTab.qml
@@ -55,9 +55,11 @@ StyledRect {
                 Layout.fillWidth: true
                 text: root.replayMode
                     ? (replay.loaded ? qsTr("replaying %1 events").arg(replay.events.length) : qsTr("pick a run"))
-                    : AgentGraphService.liveSessionCount === 0
-                        ? qsTr("idle")
-                        : qsTr("%1 live · %2 nodes").arg(AgentGraphService.liveSessionCount).arg(AgentGraphService.nodeCount)
+                    : !Settings.agentGraphEnabled
+                        ? qsTr("paused · %1 nodes").arg(AgentGraphService.nodeCount)
+                        : AgentGraphService.liveSessionCount === 0
+                            ? qsTr("idle")
+                            : qsTr("%1 live · %2 nodes").arg(AgentGraphService.liveSessionCount).arg(AgentGraphService.nodeCount)
                 font: Tokens.font.label.small
                 color: Colours.palette.m3onSurfaceVariant
             }

--- a/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
@@ -156,6 +156,25 @@ ColumnLayout {
     StyledText {
         Layout.fillWidth: true
         wrapMode: Text.Wrap
+        text: qsTr("The graph tab always stays available. Live keeps it tracking new tool calls and animating in real time; paused freezes it on whatever it last showed -- still browsable, just not doing continuous work in the background.")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.body.small
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+
+        SettingsToggleRow {
+            label: qsTr("Live")
+            description: qsTr("Off pauses layout updates and flow animation -- past sessions stay visible, nothing is lost")
+            checked: Settings.agentGraphEnabled
+            onToggled: state => Settings.agentGraphEnabled = state
+        }
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
         text: qsTr("How much of the agent graph is simulated, not how it looks — every tier draws the same thing. Auto reads your GPU and eases off while Ollama has models loaded, so the graph never competes with a local model for VRAM.")
         color: Colours.palette.m3onSurfaceVariant
         font: Tokens.font.body.small

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -108,6 +108,7 @@ Singleton {
     }
 
     property string agentSelectedProvider: "claude"
+    property bool agentGraphEnabled: true
     // Node budget and layout tick rate for the agent graph surface, never
     // its visual treatment -- every tier renders the same look. "auto"
     // resolves from the detected GPU and demotes a tier while Ollama holds
@@ -272,6 +273,7 @@ Singleton {
             taskbarGrouping: root.taskbarGrouping,
             minimalShowDnd: root.minimalShowDnd,
             agentSelectedProvider: root.agentSelectedProvider,
+            agentGraphEnabled: root.agentGraphEnabled,
             agentGraphQuality: root.agentGraphQuality,
             agentGraphAccent: root.agentGraphAccent,
             ggufModelsDir: root.ggufModelsDir,
@@ -577,6 +579,8 @@ Singleton {
                     root.minimalShowDnd = data.minimalShowDnd;
                 if (typeof data.agentSelectedProvider === "string" && ["claude", "codex", "ollama"].includes(data.agentSelectedProvider))
                     root.agentSelectedProvider = data.agentSelectedProvider;
+                if (typeof data.agentGraphEnabled === "boolean")
+                    root.agentGraphEnabled = data.agentGraphEnabled;
                 if (typeof data.agentGraphQuality === "string" && ["auto", "lite", "standard", "full"].includes(data.agentGraphQuality))
                     root.agentGraphQuality = data.agentGraphQuality;
                 if (typeof data.agentGraphAccent === "string")


### PR DESCRIPTION
## What this changes

Investigated the reported resource cost before implementing anything (findings below), then added a **Live** toggle (Settings > Personalization > Agent graph, default on) that pauses the graph's rendering pipeline specifically -- not the data capture, and not the tab itself.

## Investigation findings

- The "30s restart" isn't QML load time -- `Configuration Loaded` fires ~0.3s after the service starts in every restart I timed.
- There's a real, sustained ~35-40% CPU baseline on the `qs` process that's present *regardless* of whether the Agent Graph tab is open -- not primarily caused by the graph.
- There IS a real, separate, structural cost specific to the graph: `GraphLayout.rebuild()` fires on **every single hook event** via `onSessionsChanged` (dozens/minute during active use), fully recomputing radial layout for the whole node set each time, plus triggering per-node position `Behavior` animations. Isolated `qs`'s own GPU SM% with `nvidia-smi pmon` (not the system-wide number, which is dominated by Hyprland/the wallpaper daemon) and confirmed real bursts to 20-36% tied specifically to graph activity on an RTX 4090.

## Design

Went through a few iterations based on live feedback mid-implementation before landing here: not a full teardown (that would lose history and require restarting to get back), and not just a cosmetic label -- an actual pause of the expensive rendering work while data capture keeps running underneath.

- `Settings.agentGraphEnabled` (default `true`) gates **only** `GraphLayout`'s reactive rebuild and `GraphView`'s flow-particle animation.
- `AgentGraphService`'s event tail, prune timer, and run archive (`agent-runs/`, capped at 25 runs) are **untouched** -- they keep working exactly as before regardless of this toggle. Nothing is lost, nothing goes stale.
- When paused, `GraphLayout`'s `nodes`/`edges`/`positions` simply freeze at their last computed state -- a real frozen snapshot stays visible and browsable, not a blank tab.
- Toggling back on fires one immediate `rebuild()` to catch up, rather than waiting for the next event.
- The tab header now distinguishes "paused" from "N live" so the state is visible, not silently identical-looking.

## A bug I hit and fixed live during verification

My first wiring attempt used a `Connections { target: Settings }` block inside `GraphLayout.qml` -- but `GraphLayout` is a `QtObject`, which has no default property, so that's a fatal `Cannot assign to non-existent default property` at parse time. It crash-looped the actual running shell on this machine until systemd hit its restart limit (`start-limit-hit`). Caught it immediately via `journalctl`, fixed it with a plain mirrored property (`liveEnabled`) + `onLiveEnabledChanged` handler instead (no child object needed), redeployed, and confirmed clean: service active, zero new errors, verified via `nvidia-smi pmon` and the header label that pausing actually freezes rendering while data keeps flowing.

## Unrelated thing worth flagging

Every single `install.sh --config-only` run this session (3 for 3) tripped the known keybinds race into Hyprland emergency mode. Recovered each time with a plain `hyprctl reload` (the symlink was always fine, just a timing race on Hyprland's own config reload), but a 100% reproduction rate across 3 attempts feels worth a second look whenever it's back in scope -- not fixing it here since it's explicitly out of scope for this PR.

## Verification

- [x] Live on this machine: reproduced the crash, fixed it, redeployed, confirmed `Configuration Loaded` + zero new errors in the journal, service `active`
- [x] Confirmed the toggle reaches the render layer: flipped it off via the persisted settings state, confirmed the header label switched from "N live · M nodes" to "paused · M nodes" and the node count stopped climbing with continued activity
- [x] Confirmed GPU cost signal via `nvidia-smi pmon` isolating `qs` specifically (not system-wide, which is dominated by Hyprland/wallpaper)
- [ ] Full off→on visual cycle via mouse click -- no input-automation tool available in this sandbox (`ydotoold` needs `/dev/uinput` access this user doesn't have); verified the mechanism via the persisted-settings-file path instead, which exercises the same property binding