### PR TITLE
Wire OpenCode into the agent hook system

### DIFF
--- a/Configs/.local/lib/aphotic/agent_hook.py
+++ b/Configs/.local/lib/aphotic/agent_hook.py
@@ -97,10 +97,12 @@ for key, field in (("tool_name", "tool"), ("tool_use_id", "toolId"),
                    ("agent_id", "agentId"), ("agent_type", "agentType"),
                    ("duration_ms", "durationMs"), ("notification_type", "notificationType"),
                    ("source", "source"), ("end_reason", "endReason"),
-                   ("model", "model"), ("cwd", "cwd")):
+                   ("model", "model"), ("cwd", "cwd"), ("harness", "harness")):
     value = payload.get(key)
     if value not in (None, ""):
         record[field] = value
+
+harness = payload.get("harness") or "claude"
 
 # The Agent tool's own PostToolUse response is the only place Claude Code
 # states which agent id a Task/Agent call spawned. Capturing it here is what
@@ -156,6 +158,7 @@ try:
             "event": raw_event,
             "tool": record.get("tool", ""),
             "updatedAt": stamp,
+            "harness": harness,
         }, separators=(",", ":")) + "\n")
 except OSError:
     pass

--- a/Configs/.local/lib/aphotic/opencode_hook.js
+++ b/Configs/.local/lib/aphotic/opencode_hook.js
@@ -1,0 +1,108 @@
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+const HOOK_PATH = path.join(os.homedir(), "Aphotic-Hypr", "Configs", ".local", "lib", "aphotic", "agent_hook.py");
+
+const TOOL_NAMES = {
+  bash: "Bash",
+  read: "Read",
+  write: "Write",
+  edit: "Edit",
+  grep: "Grep",
+  glob: "Glob",
+  webfetch: "WebFetch",
+  websearch: "WebSearch",
+  task: "Task",
+  todowrite: "TodoWrite",
+  todoread: "TodoRead",
+  patch: "Edit",
+};
+
+function normalizeTool(name) {
+  if (!name)
+    return name;
+  const lower = name.toLowerCase();
+  if (TOOL_NAMES[lower])
+    return TOOL_NAMES[lower];
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+function send(payload) {
+  const child = spawn("python3", [HOOK_PATH], { stdio: ["pipe", "ignore", "ignore"] });
+  child.on("error", () => {});
+  child.stdin.on("error", () => {});
+  child.stdin.write(JSON.stringify({ harness: "opencode", ...payload }));
+  child.stdin.end();
+}
+
+export const AphoticAgentTracking = async ({ directory }) => {
+  const models = new Map();
+  const toolStarts = new Map();
+  const known = new Set();
+
+  return {
+    event: async ({ event }) => {
+      switch (event.type) {
+        case "session.created": {
+          const info = event.properties.info;
+          known.add(info.id);
+          send({
+            session_id: info.id,
+            hook_event_name: "SessionStart",
+            cwd: info.directory || directory,
+            model: models.get(info.id) || "",
+          });
+          break;
+        }
+        case "session.idle": {
+          const id = event.properties.sessionID;
+          if (!known.has(id))
+            break;
+          send({ session_id: id, hook_event_name: "Stop" });
+          break;
+        }
+        case "session.deleted": {
+          const id = event.properties.info.id;
+          if (!known.has(id))
+            break;
+          send({ session_id: id, hook_event_name: "SessionEnd" });
+          known.delete(id);
+          models.delete(id);
+          break;
+        }
+      }
+    },
+    "chat.params": async input => {
+      if (input.sessionID && input.model)
+        models.set(input.sessionID, `${input.model.providerID}/${input.model.modelID}`);
+    },
+    "tool.execute.before": async input => {
+      toolStarts.set(input.callID, Date.now());
+      send({
+        session_id: input.sessionID,
+        hook_event_name: "PreToolUse",
+        tool_name: normalizeTool(input.tool),
+        tool_use_id: input.callID,
+      });
+    },
+    "tool.execute.after": async input => {
+      const startedAt = toolStarts.get(input.callID);
+      toolStarts.delete(input.callID);
+      send({
+        session_id: input.sessionID,
+        hook_event_name: "PostToolUse",
+        tool_name: normalizeTool(input.tool),
+        tool_use_id: input.callID,
+        duration_ms: startedAt ? Date.now() - startedAt : undefined,
+      });
+    },
+    dispose: async () => {
+      for (const id of known)
+        send({ session_id: id, hook_event_name: "SessionEnd" });
+      known.clear();
+      models.clear();
+      toolStarts.clear();
+    },
+  };
+};

--- a/Configs/.local/lib/aphotic/opencode_hook.js
+++ b/Configs/.local/lib/aphotic/opencode_hook.js
@@ -74,8 +74,18 @@ export const AphoticAgentTracking = async ({ directory }) => {
       }
     },
     "chat.params": async input => {
-      if (input.sessionID && input.model)
-        models.set(input.sessionID, `${input.model.providerID}/${input.model.modelID}`);
+      if (!input.sessionID || !input.model)
+        return;
+      const resolved = `${input.model.providerID}/${input.model.id}`;
+      const isNew = models.get(input.sessionID) !== resolved;
+      models.set(input.sessionID, resolved);
+      // session.created fires before the first chat.params call, so the
+      // model is always unknown at that point -- send a follow-up
+      // SessionStart-shaped update the first time it resolves (or changes
+      // mid-session) so the graph label picks it up instead of staying on
+      // the session id fallback.
+      if (isNew && known.has(input.sessionID))
+        send({ session_id: input.sessionID, hook_event_name: "SessionStart", model: resolved });
     },
     "tool.execute.before": async input => {
       toolStarts.set(input.callID, Date.now());

--- a/Configs/quickshell/aphotic/services/AgentProviders.qml
+++ b/Configs/quickshell/aphotic/services/AgentProviders.qml
@@ -183,32 +183,39 @@ Singleton {
     // folder-watch API exists for "list of files in a directory that
     // changes", so this still re-lists on the same 5s cadence as
     // presence polling above rather than reacting to individual file
-    // writes. Claude Code is currently the only harness with a hook
-    // system that populates this directory -- Codex/OpenCode stay
-    // presence-only (see docs/AGENT_TRACKING.md) until they ship an
-    // equivalent.
+    // writes. Each session file now carries which harness produced it
+    // (agent_hook.py's "harness" field, added when OpenCode's hook shipped
+    // -- absent/older files default to "claude"), so sessions route to
+    // their own provider's tab instead of assuming everything is Claude's.
+    // Codex has no hook system yet and stays presence-only (see
+    // docs/AGENT_TRACKING.md) until it ships an equivalent.
     Process {
         id: sessionLister
         stdout: StdioCollector {
             onStreamFinished: {
-                const sessions = text.split("\n").filter(l => l.length > 0).map(line => {
+                const byHarness = ({});
+                for (const line of text.split("\n")) {
+                    if (line.length === 0)
+                        continue;
                     const tab = line.indexOf("\t");
                     if (tab === -1)
-                        return null;
+                        continue;
                     const id = line.slice(0, tab);
                     try {
                         const data = JSON.parse(line.slice(tab + 1));
-                        return {
+                        const harness = data.harness || "claude";
+                        (byHarness[harness] = byHarness[harness] ?? []).push({
                             id: id,
                             event: data.event ?? "",
                             tool: data.tool ?? "",
                             updatedAt: data.updatedAt ?? ""
-                        };
+                        });
                     } catch (e) {
-                        return null;
+                        continue;
                     }
-                }).filter(s => s !== null);
-                root._setStat(root._findIndex("claude"), { liveSessions: sessions });
+                }
+                for (const p of root.providers)
+                    root._setStat(root._findIndex(p.id), { liveSessions: byHarness[p.id] ?? [] });
             }
         }
     }

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ source "$ROOT_DIR/lib/install/wizard.sh"
 source "$ROOT_DIR/lib/install/blackarch.sh"
 source "$ROOT_DIR/lib/install/exploit_disclaimer.sh"
 source "$ROOT_DIR/lib/install/claude_hooks.sh"
+source "$ROOT_DIR/lib/install/opencode_hooks.sh"
 source "$ROOT_DIR/lib/install/assistant.sh"
 # sourced libs each set -euo pipefail, which otherwise leaks into this
 # script's shell options since `set` is not scoped to the sourced file
@@ -459,6 +460,20 @@ deploy_user_configs() {
   elif command -v jq >/dev/null 2>&1; then
     echo -e "$CNT - AI layer not selected; removing any Aphotic Claude Code hook entries..."
     remove_claude_code_hooks "$ROOT_DIR/Configs/.local/lib/aphotic/agent_hook.sh" &>> "$INSTLOG" || echo -e "$CWR - Could not clean ~/.claude/settings.json; remove the aphotic agent_hook.sh entries by hand if they are still there."
+  fi
+
+  # Same `ai`-layer opt-in as the Claude Code hook above, same
+  # add-on-select/remove-on-deselect symmetry -- see lib/install/
+  # opencode_hooks.sh for why this is a symlink into OpenCode's own plugin
+  # auto-discovery directory rather than a settings.json merge.
+  if [[ "$CONFIG_ONLY" == "1" && "$LAYERS_KNOWN" != "1" ]]; then
+    :
+  elif layer_selected "ai"; then
+    echo -e "$CNT - Configuring the OpenCode hook for live agent session tracking..."
+    configure_opencode_hook "$ROOT_DIR/Configs/.local/lib/aphotic/opencode_hook.js" &>> "$INSTLOG" || echo -e "$CWR - Could not symlink into ~/.config/opencode/plugins/; the bar's agent popout will only show session presence/count for OpenCode, not live per-session status. Wire it manually — see docs/AGENT_TRACKING.md."
+  else
+    echo -e "$CNT - AI layer not selected; removing the Aphotic OpenCode hook plugin..."
+    remove_opencode_hook &>> "$INSTLOG" || echo -e "$CWR - Could not remove ~/.config/opencode/plugins/opencode_hook.js; remove it by hand if it's still there."
   fi
 
   # Make sure `aphotic` (and anything else under ~/.local/bin) resolves on

--- a/lib/install/opencode_hooks.sh
+++ b/lib/install/opencode_hooks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# lib/install/opencode_hooks.sh
+set -euo pipefail
+
+# Symlinks Configs/.local/lib/aphotic/opencode_hook.js into OpenCode's own
+# global plugin auto-discovery directory (~/.config/opencode/plugins/ --
+# any .js/.ts file dropped there loads at startup, no config.json entry
+# needed) so the bar's agent popout and the agent graph get live
+# per-session state for OpenCode the same way they already do for Claude
+# Code, instead of presence/count only. A symlink (not a copy) so the repo
+# is the only place the plugin's actual logic ever needs editing, same
+# reasoning as configure_claude_code_hooks pointing straight at
+# agent_hook.sh rather than a copied version.
+configure_opencode_hook() {
+  local plugin_script="$1"
+  local plugin_dir="$HOME/.config/opencode/plugins"
+
+  if [[ ! -f "$plugin_script" ]]; then
+    echo "opencode_hook.js not found at $plugin_script" >&2
+    return 1
+  fi
+
+  mkdir -p "$plugin_dir"
+  ln -sfn "$plugin_script" "$plugin_dir/opencode_hook.js"
+}
+
+# The inverse, for a re-run where the user de-selected the `ai` layer --
+# only removes the symlink this function itself would have created, never
+# touches any other plugin the user has in that directory.
+remove_opencode_hook() {
+  local plugin_dir="$HOME/.config/opencode/plugins"
+  local link="$plugin_dir/opencode_hook.js"
+
+  [[ -L "$link" ]] && rm -f "$link"
+  return 0
+}


### PR DESCRIPTION
## What this changes

OpenCode is now wired into the same event pipeline as Claude Code — live per-session state in the bar popout, and OpenCode sessions now appear in the Agent Graph, not just presence/token-count as before.

## Research done first

OpenCode ships a real plugin system (`@opencode-ai/plugin`) — verified directly against its bundled type definitions on this machine (`~/.opencode/node_modules/@opencode-ai/plugin/dist/index.d.ts`), not guessed. It has a generic `event` hook plus `tool.execute.before`/`tool.execute.after`, rich enough to mirror Claude Code's hook coverage. Codex still has nothing comparable, so it stays out of scope here. Plugin loading: `~/.config/opencode/plugins/*.js` auto-discovers, no `opencode.jsonc` entry needed (confirmed via OpenCode's own docs).

## Design

Doesn't reimplement the three-sink write logic — `opencode_hook.js` translates OpenCode's own event vocabulary into the *exact same* stdin JSON shape `agent_hook.py` already expects from Claude Code, then spawns that same script per event:

| OpenCode | → | Claude Code shape |
|---|---|---|
| `session.created` | → | `SessionStart` |
| `tool.execute.before` | → | `PreToolUse` |
| `tool.execute.after` | → | `PostToolUse` |
| `session.idle` | → | `Stop` |
| `session.deleted` / plugin `dispose()` | → | `SessionEnd` |

Model info comes from `chat.params`'s `model.providerID`/`modelID` (OpenCode's `Session` type carries no model field itself). Tool names get normalized from OpenCode's lowercase convention (`bash`) to Claude Code's PascalCase (`Bash`) at the plugin boundary, so `agent_hook.py` and every QML consumer (icon lookups, category colors) stay completely unaware there's more than one harness feeding them.

`agent_hook.py` gains one backward-compatible field: every record now carries `harness` (default `"claude"` when absent). `AgentProviders.qml`'s `sessionLister` groups session snapshots by that field and routes each harness's `liveSessions` to its own bar tab — replacing the hardcoded `_findIndex("claude")` that assumed only Claude Code could ever produce a live session file. `AgentGraphService` needed **zero changes** — it already keys everything off `sessionId`, harness-agnostic by construction, so OpenCode sessions just started showing up in the graph the moment the plugin began writing real events.

`lib/install/opencode_hooks.sh` mirrors `claude_hooks.sh`'s shape exactly — same `ai`-layer opt-in, same add-on-select/remove-on-deselect symmetry — wired into `install.sh` right next to the Claude Code block. It's a symlink (`configure_opencode_hook`), not a copy, so the repo stays the only place the plugin's logic ever needs editing, same reasoning as Claude Code's hook pointing straight at `agent_hook.sh`.

## Verified live against the real binary

- Confirmed this machine has an actual OpenCode install (`~/.opencode/bin/opencode`, v1.18.25) and used it directly for every test below
- `opencode run "reply with just the word hi"` (no tool call): `session_start` → `stop` → `session_end` all landed with `harness:"opencode"`
- `opencode run "run 'ls' in the shell..."` (forces a tool call): full `session_start` → `pre_tool_use` → `post_tool_use` (correct `durationMs`) → `stop` → `session_end`, tool name correctly normalized to `"Bash"` (was lowercase `"bash"` before the normalization fix, caught and fixed in the same pass)
- Confirmed OpenCode's events land in the *same* `agent-events.jsonl` alongside this very Claude Code session's own events, correctly tagged, zero collision
- Confirmed the run archive (`agent-runs/*.jsonl`) captured all 3 test sessions for Replay, and `agent-sessions/*.json` cleanly deleted each snapshot on `session_end` — nothing left dangling
- Symlink deployment: this machine has no `aphotic.toml`, so `install.sh --config-only`'s layer-detection gate skips the hook-reconfigure block entirely (same as it already does for Claude Code's own hook on this exact machine) — created the symlink manually to match exactly what `configure_opencode_hook` would do, and verified the plugin loads and fires correctly through it

## Known gaps (documented in `docs/AGENT_TRACKING.md`, local/gitignored, not part of this diff)

- No `PostToolUseFailure` equivalent — `tool.execute.after`'s input type carries no error signal, so every completed tool call reports `status: "completed"` even if it actually failed underneath
- No `Notification` equivalent
- Subagent sessions (OpenCode nests via `Session.parentID`, not an in-session `agentId` the way Claude Code's Task/Agent tool calls work) render as independent top-level sessions in the graph, not nested under their parent — would need `AgentGraphService._parentFor`'s model extended for `parentID`-linked sessions, a separate change
- Token usage tracking (§2, `agent_usage.py`) is untouched — OpenCode stores sessions in a local sqlite db (`~/.local/share/opencode/opencode.db`), not the JSONL transcripts already globbed for Claude/Codex, so it still reports `unavailable` for OpenCode until something queries that db instead

## Verification

- [x] `bash -n` on `install.sh` and `lib/install/opencode_hooks.sh`
- [x] `python3 -m py_compile` on `agent_hook.py`
- [x] `node --check` on `opencode_hook.js`
- [x] Live end-to-end test against the real `opencode` binary (see above) — not simulated