### PR TITLE
AGP-14: Agent Graph session root detail (call count + elapsed)

### DIFF
--- a/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
+++ b/Configs/quickshell/aphotic/modules/agentgraph/GraphView.qml
@@ -82,6 +82,18 @@ Item {
             WindowList.focus(match.address);
     }
 
+    function _sessionElapsedText(node): string {
+        if (!node.startedAt)
+            return "";
+        const end = node.endedAt || root.nowMs;
+        const ms = Math.max(0, end - node.startedAt);
+        if (ms < 60000)
+            return qsTr("%1s").arg(Math.round(ms / 1000));
+        if (ms < 3600000)
+            return qsTr("%1m").arg(Math.floor(ms / 60000));
+        return qsTr("%1h %2m").arg(Math.floor(ms / 3600000)).arg(Math.floor((ms % 3600000) / 60000));
+    }
+
     function _durationText(node): string {
         const ms = node.status === "running"
             ? Math.max(0, root.nowMs - (node.startedAt ?? 0))
@@ -426,6 +438,26 @@ Item {
 
                                     anchors.centerIn: parent
                                     text: [node.modelData.locality, node.modelData.quant].filter(Boolean).join(" · ")
+                                    font: Tokens.font.label.small
+                                    color: pill.ink
+                                }
+                            }
+
+                            StyledRect {
+                                id: detailBadge
+
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: node.isSession && root.showLabels && node.modelData.callCount > 0
+                                radius: Tokens.rounding.small
+                                color: Qt.alpha(pill.ink, 0.16)
+                                implicitWidth: detailText.implicitWidth + Tokens.padding.small
+                                implicitHeight: detailText.implicitHeight + Tokens.padding.extraSmall
+
+                                StyledText {
+                                    id: detailText
+
+                                    anchors.centerIn: parent
+                                    text: [qsTr("%1 calls").arg(node.modelData.callCount), root._sessionElapsedText(node.modelData)].filter(Boolean).join(" · ")
                                     font: Tokens.font.label.small
                                     color: pill.ink
                                 }


### PR DESCRIPTION
## What this changes

`BACKLOG.md`'s `AGP-14`: session pills in the Agent Graph now show a second compact badge with call count and elapsed time, alongside the existing model badge (locality/quant).

## Design

- New `_sessionElapsedText(node)` in `GraphView.qml` — live while the session hasn't ended (reads `root.nowMs`, already ticking every 1s for the existing tool-node duration display), frozen at the final duration once it has.
- Call count was already tracked on the node (`callCount: session.nodes.length` in `GraphLayout.rebuild()`) but only ever surfaced in the hover tooltip — now also on the pill itself.
- Same `StyledRect`/`StyledText` pattern as the existing model badge, same zoom gate (`root.showLabels`).

## Scoped out, on purpose

`AGP-14` also asked for token/cost "if the usage data can be joined to it" — deliberately not attempted. `agent_usage.py`'s usage tracking is a daily aggregate per provider (today's total tokens), not scoped to an individual session. There's no clean join between one session in the graph and some slice of today's aggregate without fabricating an attribution that isn't real. This matches `FEATURES.md`'s own stated principle against forcing a data shape that doesn't fit rather than building a second adapter for it.

## Verified live

Deployed directly and screenshotted: both a long-running Claude Code session and a (stale, pre-fix) OpenCode session correctly show `<N> calls · <elapsed>` on their pills — `100 calls · 36m` and `71 calls · 24m` respectively, cross-checked against real wall-clock elapsed time since each session actually started.

## Note

There's unrelated, in-progress Codex-hook work sitting uncommitted in this checkout (`codex_hook.py`/`.sh`, `README.md`/`install.sh` edits) from a separate concurrent session — not touched, not included in this diff.