### PR TITLE
Fix #41: sync/upgrade pacman db before installing packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -714,6 +714,22 @@ except Exception:
   fi
 
   print_stage 5 "Installing packages"
+  # Sync + upgrade before installing anything new (issue #41): Arch mirrors
+  # only ever carry the current package build, not the version that was
+  # current when the local db was last refreshed -- installing against a
+  # stale db can request a filename that's already been rotated off every
+  # mirror, which pacman reports as a plain 404 per-mirror rather than
+  # "your db is stale". `-Sy` alone is deliberately not used here: syncing
+  # the db without upgrading already-installed packages is a partial
+  # upgrade, which the Arch wiki calls out as unsupported and a real
+  # source of broken dependencies for whatever gets installed next.
+  echo -e "$CNT - Syncing package databases and upgrading the system..."
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo -e "$CNT - [dry-run] would run: sudo pacman -Syu --noconfirm"
+  else
+    sudo pacman -Syu --noconfirm &>> "$INSTLOG" || { echo -e "$CER - Failed to sync/upgrade the system package database. Re-run 'sudo pacman -Syu' by hand, resolve whatever it reports, then re-run install.sh."; exit 1; }
+  fi
+
   while IFS= read -r pkg; do
     [[ -n "$pkg" ]] && install_software "$pkg"
   done <<< "$prep_pkgs"


### PR DESCRIPTION
## Summary
- `install_software()` installed packages against whatever local pacman db was on disk, with no refresh first. Arch mirrors only keep the current build of a package, not whatever version was current when the db was last synced — installing against a stale db can resolve to a filename already rotated off every mirror, which pacman surfaces as a plain per-mirror 404 rather than any hint the db is stale. That's exactly what #41 hit on `firefox-154.0-1`.
- Adds a `sudo pacman -Syu --noconfirm` (sync **and** upgrade, not a bare `-Sy` — the Arch wiki calls a sync-without-upgrade an unsupported partial upgrade and a real source of broken deps) at the start of Stage 5 ("Installing packages"), before the first package install.

## Test plan
- [ ] `bash -n install.sh` (syntax check — done, passes)
- [ ] Reporter (or another affected user) re-runs `install.sh` on the same machine and confirms the firefox 404 no longer occurs
- [ ] Spot-check a normal (non-stale-db) install still completes cleanly with the extra sync/upgrade step

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqFiBSYzTanR7w45mhBMb3