### PR TITLE
Strip conflicting UI packages from a prior rice before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,9 @@ None of this is unique by itself. Together it turns a rice from something you in
 ## Install
 
 > [!IMPORTANT]
-> Aphotic assumes an Arch/AUR base. It hasn't been tested on other distros and no distro branching is planned — see the [FAQ](#faq).
+> Aphotic assumes an Arch/AUR base with systemd as PID 1 (SDDM, bluetooth, and the shell itself all depend on it directly) — install.sh checks for this and refuses to run otherwise. It hasn't been tested on other distros and no distro branching is planned — see the [FAQ](#faq).
+>
+> `install.sh` is built for a fresh Arch install, not a machine already carrying another rice. If waybar, rofi/wofi, dunst/mako/swaync, or another bar/launcher/notifier is already installed, it'll offer to remove it — leaving it in place is what caused [#41](https://github.com/T-Crypt/aphotic-hypr/issues/41)'s duplicate, unstyled bar. See `--strip-conflicts`/`--keep-conflicts` below.
 
 ```
 git clone https://github.com/T-Crypt/Aphotic-Hypr && cd Aphotic-Hypr
@@ -351,6 +353,8 @@ Running with no flags launches a short wizard: profile, optional layers, theme. 
 | `--theme <name>` | Pre-selects a theme. Skips the theme prompt. |
 | `--with-assistant` / `--no-assistant` | Install (or skip) the Aphotic Assistant without being asked. `--with-assistant` implies the `ai` layer and needs an NVIDIA GPU. |
 | `--nvidia-driver <keep\|reinstall>` | Only relevant when an NVIDIA driver is already installed. `keep` leaves it alone, `reinstall` replaces it with Aphotic's recommended `nvidia-open-dkms`. Non-interactive runs default to `keep` — a working driver is never replaced without being told to. |
+| `--strip-conflicts` | Remove already-installed packages Aphotic's shell replaces (waybar, rofi/wofi, dunst/mako/swaync, polybar, eww/ags, hyprpaper/swaybg, swayidle) without asking. Interactive installs are asked either way; non-interactive runs default to leaving them installed unless this is passed. |
+| `--keep-conflicts` | Leave those packages alone without asking, even interactively. |
 | `--config-only` | Config sync only: back up, copy `Configs/` over `~/.config/`, restart the shell. No packages, no system prep, no wizard, no `sudo`, and `aphotic.toml` is left untouched. See [Config sync only](#config-sync-only). |
 | `--dry-run` | Prints the full resolved install plan and exits — nothing is installed, backed up, or written. |
 | `--no-backup` | Skips the pre-install config snapshot. Off by default; use with intent. |

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ source "$ROOT_DIR/lib/install/claude_hooks.sh"
 source "$ROOT_DIR/lib/install/opencode_hooks.sh"
 source "$ROOT_DIR/lib/install/codex_hooks.sh"
 source "$ROOT_DIR/lib/install/assistant.sh"
+source "$ROOT_DIR/lib/install/conflicts.sh"
 # sourced libs each set -euo pipefail, which otherwise leaks into this
 # script's shell options since `set` is not scoped to the sourced file
 set +euo pipefail
@@ -33,6 +34,7 @@ NO_BACKUP=0
 KEEP_BACKUPS=5
 PROFILE=""
 LAYERS=""
+STRIP_CONFLICTS=""
 
 # Layers are carried as a comma-separated string all the way through, so
 # every gate needs the same exact-match test rather than a substring one --
@@ -119,6 +121,14 @@ Usage: ./install.sh [options]
                                 aphotic.toml is left exactly as it is. This
                                 is the "I just want the latest Quickshell/
                                 Hyprland config" path after a git pull.
+  --strip-conflicts              Remove already-installed packages that
+                                Aphotic's shell replaces (waybar, rofi/
+                                wofi, dunst/mako/swaync, etc.) without
+                                asking. Interactive installs are asked;
+                                non-interactive ones default to leaving
+                                them installed.
+  --keep-conflicts                Leave those packages alone without
+                                asking, even interactively.
   --dry-run                     Print planned actions, change nothing
   --no-backup                   Skip backing up existing configs
   --keep-backups <N>             Backups to retain (default: 5)
@@ -136,6 +146,8 @@ while [[ $# -gt 0 ]]; do
     --no-assistant) ASSISTANT="false"; shift ;;
     --accept-exploit-disclaimer) ACCEPT_EXPLOIT_DISCLAIMER=1; shift ;;
     --nvidia-driver) [[ -n "${2:-}" ]] || { echo -e "$CER - Missing value for $1 (keep|reinstall)"; exit 1; }; NVIDIA_DRIVER_ACTION="$2"; shift 2 ;;
+    --strip-conflicts) STRIP_CONFLICTS="1"; shift ;;
+    --keep-conflicts) STRIP_CONFLICTS="0"; shift ;;
     --config-only) CONFIG_ONLY=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     --no-backup) NO_BACKUP=1; shift ;;
@@ -565,6 +577,21 @@ main() {
   print_banner
 
   print_stage 1 "Preflight"
+
+  # Aphotic depends on systemd directly, not just as whatever happens to
+  # be PID 1 on Arch by default: SDDM, bluetooth.service, and the
+  # aphotic-shell.service user unit that runs the actual Quickshell bar
+  # (Configs/systemd/user/aphotic-shell.service) all assume it. A
+  # non-systemd base (e.g. Artix/OpenRC or runit) would get through the
+  # rest of this script and then have no working bar at all, with
+  # nothing pointing back at why -- so this checks and fails fast
+  # instead, for both a full install and --config-only (config-only
+  # still restarts aphotic-shell.service via systemctl --user).
+  if [[ ! -d /run/systemd/system ]]; then
+    echo -e "$CER - systemd isn't running as PID 1 (no /run/systemd/system) -- Aphotic isn't supported on a non-systemd base. Nothing has been changed."
+    exit 1
+  fi
+
   echo -e "$CNT - You are about to execute a script that would attempt to setup Hyprland."
 
   echo -e "$CNT - Checking for Physical or VM..."
@@ -665,6 +692,8 @@ except Exception:
   echo -e "$CNT - This script will run some commands that require sudo. You will be prompted to enter your password."
 
   print_stage 3 "System prep"
+  check_conflicting_packages
+
   read -rep $'[\e[1;33mACTION\e[0m] - Would you like to disable WiFi powersave? (y,n) ' WIFI
   if [[ "$WIFI" == "Y" || "$WIFI" == "y" ]]; then
     if systemctl list-unit-files NetworkManager.service &>/dev/null; then

--- a/lib/install/conflicts.sh
+++ b/lib/install/conflicts.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Packages a previous rice/WM setup commonly leaves behind that fight
+# Aphotic's own Quickshell-based bar/launcher/notification center/
+# wallpaper daemon for the same role. None of Aphotic's own profiles or
+# layers (profiles/base/*.toml, profiles/layers/*.toml) ever install any
+# of these, so anything on this list came from somewhere else -- a prior
+# sway/i3/other-WM setup on the same machine, most commonly. Left in
+# place, they autostart from whatever old config referenced them and end
+# up fighting Aphotic's shell for the same role (a second, unstyled bar;
+# a second app launcher; two daemons racing for the DBus notification
+# name). Issue #41 was exactly this: a leftover waybar produced a raw,
+# unstyled bar and made a working install look broken.
+CONFLICTING_UI_PACKAGES=(
+  waybar waybar-git
+  polybar
+  eww eww-git
+  ags ags-hyprland-git
+  rofi rofi-wayland rofi-lbonn-wayland-git
+  wofi
+  dunst mako swaync
+  hyprpaper swaybg
+  swayidle
+)
+
+conflicting_package_role() {
+  case "$1" in
+    waybar|waybar-git|polybar|eww|eww-git|ags|ags-hyprland-git)
+      echo "status bar -- Aphotic's is Quickshell (aphotic-shell.service)" ;;
+    rofi|rofi-wayland|rofi-lbonn-wayland-git|wofi)
+      echo "app launcher -- Aphotic's is built into the shell (SUPER+space)" ;;
+    dunst|mako|swaync)
+      echo "notifications -- Aphotic's shell runs its own notification center" ;;
+    hyprpaper|swaybg)
+      echo "wallpaper daemon -- Aphotic uses awww-daemon" ;;
+    swayidle)
+      echo "idle handling -- Aphotic uses hypridle" ;;
+    *)
+      echo "a role Aphotic's shell already owns" ;;
+  esac
+}
+
+detect_conflicting_ui_packages() {
+  local installed pkg
+  installed=$(pacman -Qq 2>/dev/null || true)
+  for pkg in "${CONFLICTING_UI_PACKAGES[@]}"; do
+    grep -qxF "$pkg" <<< "$installed" && echo "$pkg"
+  done
+  return 0
+}
+
+# Interactive by default (matches install_nvidia_driver's keep/reinstall
+# gate): asks once, defaults to removing since that's what avoids issue
+# #41's failure mode, but never removes anything without either an
+# explicit y at the prompt or an explicit --strip-conflicts/
+# --keep-conflicts flag. A non-interactive run with neither flag leaves
+# packages alone rather than guessing -- same "never touch what's
+# already there without being told to" rule as the Nvidia driver gate.
+check_conflicting_packages() {
+  local found=() pkg
+  while IFS= read -r pkg; do
+    [[ -n "$pkg" ]] && found+=("$pkg")
+  done < <(detect_conflicting_ui_packages)
+
+  [[ ${#found[@]} -eq 0 ]] && return 0
+
+  echo -e "$CAT - Found packages already installed that Aphotic's shell replaces:"
+  for pkg in "${found[@]}"; do
+    echo -e "    - $pkg  ($(conflicting_package_role "$pkg"))"
+  done
+  echo -e "$CWR - Left running, these commonly autostart from an old WM config and fight Aphotic's shell for the same role -- this is what issue #41 turned out to be."
+
+  local action="${STRIP_CONFLICTS:-}"
+  if [[ -z "$action" ]]; then
+    if [[ -t 0 ]]; then
+      read -rep $'[\e[1;33mACTION\e[0m] - Remove them now? (Y,n) ' STRIP_CHOICE
+      [[ "$STRIP_CHOICE" == "n" || "$STRIP_CHOICE" == "N" ]] && action="0" || action="1"
+    else
+      echo -e "$CWR - Non-interactive install with no --strip-conflicts/--keep-conflicts flag -- leaving them installed. Pass --strip-conflicts to remove them automatically instead."
+      action="0"
+    fi
+  fi
+
+  if [[ "$action" != "1" ]]; then
+    echo -e "$CNT - Leaving ${found[*]} installed. Remove by hand later if you hit duplicate bars/launchers/notifications: sudo pacman -Rns ${found[*]}"
+    return 0
+  fi
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo -e "$CNT - [dry-run] would run: sudo pacman -Rns --noconfirm ${found[*]}"
+    return 0
+  fi
+
+  echo -e "$CNT - Removing ${found[*]}..."
+  sudo pacman -Rns --noconfirm "${found[@]}" &>> "$INSTLOG" || echo -e "$CWR - Failed to remove some of: ${found[*]} -- see $INSTLOG. Something else may depend on them; check with 'pacman -Qi <pkg>' before forcing it with pacman -Rdd."
+}

--- a/tests/test_conflicts.sh
+++ b/tests/test_conflicts.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# tests/test_conflicts.sh
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CNT="[NOTE]"; CWR="[WARNING]"; CAT="[ATTENTION]"; CER="[ERROR]"
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+INSTLOG="$WORKDIR/install.log"
+source "$ROOT/lib/install/conflicts.sh"
+
+# detect_conflicting_ui_packages: only flags what's actually "installed"
+pacman() { [[ "$1" == "-Qq" ]] && printf "bash\nwaybar\nrofi-wayland\ncurl\n"; }
+mapfile -t found < <(detect_conflicting_ui_packages)
+[[ "${found[*]}" == "waybar rofi-wayland" ]] || fail "expected waybar+rofi-wayland detected, got: ${found[*]:-<none>}"
+
+pacman() { [[ "$1" == "-Qq" ]] && printf "bash\ncurl\n"; }
+mapfile -t found < <(detect_conflicting_ui_packages)
+[[ ${#found[@]} -eq 0 ]] || fail "expected no conflicting packages on a clean system, got: ${found[*]}"
+
+# conflicting_package_role: every listed package maps to a real role, not
+# the "a role Aphotic's shell already owns" catch-all
+for pkg in "${CONFLICTING_UI_PACKAGES[@]}"; do
+  role="$(conflicting_package_role "$pkg")"
+  [[ "$role" != "a role Aphotic's shell already owns" ]] || fail "$pkg has no specific role mapping"
+done
+
+# check_conflicting_packages: silent no-op when nothing conflicts
+pacman() { [[ "$1" == "-Qq" ]] && printf "bash\ncurl\n"; }
+sudo() { echo "SUDO_CALLED_UNEXPECTEDLY: $*"; }
+export -f sudo
+out=$(check_conflicting_packages < /dev/null 2>&1)
+[[ -z "$out" ]] || fail "expected no output on a clean system, got: $out"
+
+pacman() { [[ "$1" == "-Qq" ]] && printf "bash\nwaybar\ndunst\n"; }
+
+# non-interactive, no flag -> leaves packages, never calls sudo
+out=$(STRIP_CONFLICTS="" check_conflicting_packages < /dev/null 2>&1)
+echo "$out" | grep -q "Leaving waybar dunst installed" || fail "expected default-keep message, got: $out"
+echo "$out" | grep -q "SUDO_CALLED_UNEXPECTEDLY" && fail "sudo should not run with no flag and no TTY: $out"
+
+# --keep-conflicts (STRIP_CONFLICTS=0) -> leaves packages, never calls sudo
+out=$(STRIP_CONFLICTS="0" check_conflicting_packages < /dev/null 2>&1)
+echo "$out" | grep -q "Leaving waybar dunst installed" || fail "expected --keep-conflicts to leave packages, got: $out"
+echo "$out" | grep -q "SUDO_CALLED_UNEXPECTEDLY" && fail "sudo should not run with --keep-conflicts: $out"
+unset -f sudo
+true
+
+# --strip-conflicts + dry-run -> only prints the plan, no real sudo call
+sudo() { fail "sudo must not run under --dry-run"; }
+export -f sudo
+out=$(DRY_RUN=1 STRIP_CONFLICTS="1" check_conflicting_packages < /dev/null 2>&1)
+echo "$out" | grep -qF "[dry-run] would run: sudo pacman -Rns --noconfirm waybar dunst" || fail "expected dry-run removal plan, got: $out"
+unset -f sudo
+
+# --strip-conflicts, real run -> removes via pacman -Rns, logged to INSTLOG
+sudo() { echo "SUDO_CALLED: $*" >> "$INSTLOG"; }
+export -f sudo
+: > "$INSTLOG"
+DRY_RUN=0 STRIP_CONFLICTS="1" check_conflicting_packages < /dev/null > /dev/null
+grep -qF "SUDO_CALLED: pacman -Rns --noconfirm waybar dunst" "$INSTLOG" || fail "expected sudo pacman -Rns waybar dunst in $INSTLOG, got: $(cat "$INSTLOG")"
+unset -f sudo
+
+echo "PASS: conflicting UI package detection + role mapping + strip/keep gating"


### PR DESCRIPTION
## Summary
- Root-caused issue #41's follow-up report: the reporter's screenshot was upstream waybar's own stock `/etc/xdg/waybar/config.jsonc` fallback config (sway modules and all), not anything Aphotic installs — Aphotic doesn't ship a waybar config; its bar is Quickshell via `aphotic-shell.service`. It surfaced because a prior WM install (waybar, likely more) was already on the machine and `install.sh` had no notion of cleaning that up.
- Adds `lib/install/conflicts.sh`: detects already-installed packages Aphotic's shell replaces (`waybar`, `rofi`/`wofi`, `dunst`/`mako`/`swaync`, `polybar`, `eww`/`ags`, `hyprpaper`/`swaybg`, `swayidle`) and offers to remove them. Interactive installs are asked (default: remove); non-interactive installs default to leaving them alone unless `--strip-conflicts`/`--keep-conflicts` says otherwise — same "never touch what's already there without being told to" convention `install_nvidia_driver` already uses.
- Adds a systemd-as-PID-1 preflight check — SDDM, `bluetooth.service`, and `aphotic-shell.service` all assume it, so a non-systemd base now fails fast with a clear message instead of installing into a broken state.
- README's install callout now states `install.sh` targets a fresh Arch box and documents the new flags.

## Test plan
- [x] `bash tests/test_conflicts.sh` — detection, role mapping, and all four strip/keep gating paths (clean no-op, non-interactive default-keep, `--keep-conflicts`, `--strip-conflicts` dry-run + real removal)
- [x] Full bash suite (`tests/test_*.sh`, 20 files) passes
- [x] `python3 -m pytest tests/` (18 tests) passes
- [x] `./install.sh --help` and `./install.sh --dry-run` sanity-checked manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqFiBSYzTanR7w45mhBMb3