### PR TITLE
Gate AiProviders' claude/codex/ollama auto-probe behind InstallProfile.aiEnabled

### DIFF
--- a/Configs/quickshell/aphotic/services/ai/AiProviders.qml
+++ b/Configs/quickshell/aphotic/services/ai/AiProviders.qml
@@ -345,10 +345,20 @@ Singleton {
         }
     }
 
+    // Gated on the same install-time signal AgentProviders.qml's presence
+    // poll already uses -- without the `ai` layer, `claude`/`codex` aren't
+    // installed and probing for them on every shell start just produces
+    // "Process failed to start" log noise (see issue #43). Ollama is
+    // included too since it ships with the same layer; refreshOllamaModels()
+    // stays callable on demand (Settings -> AI's refresh action, the
+    // ollamaHostChanged handler above) for anyone pointing at a host that
+    // wasn't set up through this layer at all.
     Component.onCompleted: {
-        root.refreshOllamaModels();
-        root.refreshClaudeAuth();
-        root.refreshCodexAuth();
+        if (InstallProfile.aiEnabled) {
+            root.refreshOllamaModels();
+            root.refreshClaudeAuth();
+            root.refreshCodexAuth();
+        }
     }
 
     function isAvailable(providerId: string): bool {


### PR DESCRIPTION
## Summary
- `AiProviders.qml`'s `Component.onCompleted` ran `claude auth status`, `codex login status`, and an Ollama model probe unconditionally on every shell start, unlike `AgentProviders.qml`'s identical presence poll, which already gates on `InstallProfile.aiEnabled`.
- Fixes #43: without the `ai` layer installed, users got `WARN: Process failed to start ... Command: QList("codex", "login", "status")` log noise for CLIs the installer never set up.
- Manual refresh (Settings → AI's refresh action) still works regardless, for anyone using these tools outside the installer's layer system.

## Test plan
- [x] `qmllint` clean on the changed file (confirmed locally)
- [ ] Fresh install without the `ai` layer: confirm no `claude`/`codex`/ollama probe warnings in `journalctl --user -u aphotic-shell.service`
- [ ] Fresh install with the `ai` layer: confirm probing still runs and AI providers still populate as available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqFiBSYzTanR7w45mhBMb3