### PR TITLE
Fix 'Hyprland was started without start-hyprland' warning on login

### DIFF
--- a/src/hyprland.desktop
+++ b/src/hyprland.desktop
@@ -1,5 +1,7 @@
 [Desktop Entry]
 Name=Hyprland
 Comment=An intelligent dynamic tiling Wayland compositor
-Exec=Hyprland
+Exec=start-hyprland
 Type=Application
+DesktopNames=Hyprland
+Keywords=tiling;wayland;compositor;


### PR DESCRIPTION
Fixes #45

## What
Change the deployed wayland-sessions entry (`src/hyprland.desktop`) from `Exec=Hyprland` (bare binary) to `Exec=start-hyprland`, and add `DesktopNames=Hyprland`.

## Why
Since Hyprland 0.53+, launching the bare `Hyprland` binary instead of the `start-hyprland` script triggers the **"Hyprland was started without start-hyprland"** watchdog warning on every SDDM login. The script sets up the XDG / portal / Electron / screen-sharing environment that direct binary launch misses.

## Testing
- `start-hyprland` is present at `/usr/bin/start-hyprland` (verified on the affected system).
- Live fix validated: copying the fixed entry to `/usr/share/wayland-sessions/hyprland.desktop` removes the warning on the next login.