### PR TITLE
Fix yay not landing on PATH (AUR install ordering bug)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -750,14 +750,28 @@ except Exception:
     fi
   fi
 
+  # Sync pacman DBs first: on a fresh/torn-down system /var/lib/pacman/sync/
+  # is empty, and without it both base-devel and makepkg -si fail with
+  # "database file for ... does not exist". This must precede yay's build.
+  ensure_pacman_db
+
   if ! command -v fakeroot >/dev/null 2>&1; then
     echo -e "$CNT - base-devel not found; installing it now (required to build AUR packages)."
     sudo pacman -S --needed --noconfirm base-devel &>> "$INSTLOG" || { echo -e "$CER - Failed to install base-devel. Install it manually: sudo pacman -S base-devel"; exit 1; }
   fi
 
   echo -e "$CNT - Resolving AUR helper..."
-  AUR_HELPER=$(ensure_aur_helper)
-  echo -e "$COK - Using AUR helper: $AUR_HELPER"
+  # `set -e` is off in the orchestrator, so a non-zero status from the command
+  # substitution must be captured explicitly or a failed yay install (which
+  # returns 1 from ensure_aur_helper) would silently leave AUR_HELPER empty.
+  AUR_HELPER=""
+  AUR_HELPER=$(ensure_aur_helper) || AUR_HELPER=""
+  if [[ -z "$AUR_HELPER" ]]; then
+    echo -e "$CWR - No AUR helper (yay/paru) is available on PATH. AUR packages will fail to resolve."
+    echo -e "$CWR   Fix it manually: sudo pacman -S --needed base-devel git && git clone https://aur.archlinux.org/yay.git /tmp/yay && cd /tmp/yay && makepkg -si"
+  else
+    echo -e "$COK - Using AUR helper: $AUR_HELPER"
+  fi
 
   if [[ "$(any_layer_requires_blackarch "$LAYERS")" == "true" ]]; then
     echo -e "$CNT - Enabling the BlackArch repo for the exploit-* layers that need it..."

--- a/lib/install/aur.sh
+++ b/lib/install/aur.sh
@@ -11,6 +11,26 @@ detect_aur_helper() {
   fi
 }
 
+# makepkg -si resolves build deps and installs the finished package through
+# pacman. Both need populated pacman databases under /var/lib/pacman/sync/;
+# on a fresh or torn-down system those are empty, and makepkg then fails with
+# "database file for 'core'/'extra'/'multilib' does not exist". The sync must
+# happen before any `makepkg -si` (and before `ensure_base_devel`, which
+# shells out to pacman -S) or yay is cloned, built, then silently never lands
+# on PATH. This is the one step that must have actually succeeded to return.
+ensure_pacman_db() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "[dry-run] would run sudo pacman -Sy to sync package databases"
+    return 0
+  fi
+  echo "Syncing pacman databases (required before building/installing AUR packages)..." >&2
+  sudo pacman -Sy --noconfirm || {
+    echo "Failed to sync pacman databases. Installer cannot reliably build AUR packages until this works." >&2
+    echo "Fix it manually: sudo pacman -Sy" >&2
+    return 1
+  }
+}
+
 install_yay() {
   if [[ "${DRY_RUN:-0}" == "1" ]]; then
     echo "[dry-run] would clone and build yay from AUR"
@@ -22,6 +42,17 @@ install_yay() {
     exit 1
   }
   (cd /tmp/yay-bootstrap && makepkg -si --noconfirm)
+  # makepkg -si can fail to actually land the binary (build error, sudo
+  # prompt timeout, a conflicting local package) while still returning a
+  # permissive zero here in some cases -- don't claim success until yay
+  # is actually resolvable again. PATH may cache the old lookup, so
+  # rehash before the check.
+  hash -r 2>/dev/null || true
+  if ! command -v yay >/dev/null 2>&1; then
+    echo "yay was built from AUR but is still not on PATH (looked for 'yay')." >&2
+    echo "Install it manually: sudo pacman -S --needed base-devel git && git clone https://aur.archlinux.org/yay.git /tmp/yay && cd /tmp/yay && makepkg -si" >&2
+    return 1
+  fi
 }
 
 ensure_aur_helper() {
@@ -29,8 +60,15 @@ ensure_aur_helper() {
   helper=$(detect_aur_helper)
   if [[ -z "$helper" ]]; then
     echo "No AUR helper found (yay/paru). Installing yay..." >&2
-    install_yay
-    helper="yay"
+    ensure_pacman_db || return 1
+    install_yay || return 1
+    # Re-detect rather than assume: if the install above failed, yay is
+    # gone too and we must not hand back a name that won't resolve.
+    helper=$(detect_aur_helper)
+    if [[ -z "$helper" ]]; then
+      echo "No AUR helper (yay/paru) is available on PATH after install." >&2
+      return 1
+    fi
   fi
   echo "$helper"
 }

--- a/tests/test_aur.sh
+++ b/tests/test_aur.sh
@@ -31,4 +31,79 @@ result=$(detect_aur_helper)
 [[ "$result" == "yay" ]] || fail "expected yay (priority over paru), got '$result'"
 
 export PATH="$PATH_BACKUP"
+
+# ensure_pacman_db must run before the AUR bootstrap; in dry-run it declares
+# the planned sync and reports success without touching the system.
+DRY_RUN=1
+db_out=$(ensure_pacman_db)
+[[ "$?" == "0" ]] || fail "expected ensure_pacman_db to succeed in dry-run"
+[[ "$db_out" == *"sudo pacman -Sy"* ]] || fail "expected dry-run sync message, got '$db_out'"
+unset DRY_RUN
+
+# ensure_aur_helper must re-detect after a would-be install instead of
+# blindly returning "yay": if the install silently failed, yay is gone and
+# handing back a name that won't resolve just turns one install failure into
+# a cascade of confusing package-install failures later.
+EMPTY_BIN=$(mktemp -d)
+export PATH="$EMPTY_BIN"
+DRY_RUN=1
+# ( ... ) subshell: ensure_aur_helper exits on a failed install, and the
+# exit must not kill the whole test process.
+if ( ensure_aur_helper >/dev/null 2>&1 ); then
+  fail "expected ensure_aur_helper to fail when no helper exists and cannot be installed"
+fi
+unset DRY_RUN
+export PATH="$PATH_BACKUP"
+/bin/rm -rf "$EMPTY_BIN"
+
+# Same guarantee against a *real* (non-dry-run) failed build: fake out git so
+# the clone step fails, fake sudo so ensure_pacman_db's sync no-ops, and fake
+# whatever else install_yay shells to, keeping the test fully self-contained
+# on the real host. ensure_aur_helper must still return non-zero.
+FAIL_BIN=$(mktemp -d)
+export PATH="$FAIL_BIN"
+for fake in rm mkdir sudo git install make; do
+  /bin/cat > "$FAIL_BIN/$fake" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  /bin/chmod +x "$FAIL_BIN/$fake"
+done
+# git must fail so install_yay's clone step returns failure for real
+/bin/cat > "$FAIL_BIN/git" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+/bin/chmod +x "$FAIL_BIN/git"
+if ( ensure_aur_helper >/dev/null 2>&1 ); then
+  fail "expected ensure_aur_helper to fail when the yay build fails"
+fi
+export PATH="$PATH_BACKUP"
+/bin/rm -rf "$FAIL_BIN"
+
+# ensure_pacman_db failing must also make ensure_aur_helper fail (warn-and-
+# continue contract: the orchestrator sees an empty AUR_HELPER, never a stale
+# "yay"). Fake sudo to fail and confirm the DB guard aborts the helper before
+# any build attempt.
+DBFAIL_BIN=$(mktemp -d)
+trap '/bin/rm -rf "$FAKE_BIN" "$FAIL_BIN" "$DBFAIL_BIN"' EXIT
+export PATH="$DBFAIL_BIN"
+for fake in rm; do
+  /bin/cat > "$DBFAIL_BIN/$fake" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  /bin/chmod +x "$DBFAIL_BIN/$fake"
+done
+/bin/cat > "$DBFAIL_BIN/sudo" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+/bin/chmod +x "$DBFAIL_BIN/sudo"
+if ( ensure_aur_helper >/dev/null 2>&1 ); then
+  fail "expected ensure_aur_helper to fail when the pacman DB sync fails"
+fi
+export PATH="$PATH_BACKUP"
+/bin/rm -rf "$DBFAIL_BIN"
+
 echo "PASS: aur helper detection"


### PR DESCRIPTION
## What

Fixes the root cause of "I saw yay get installed during the installer, but `yay` is `command not found` afterward."

### Root cause

`install_yay()` ran `makepkg -si` **before any `pacman -Sy`** in the installer:

- Stage 3 calls `ensure_aur_helper()` (→ `install_yay()` → `makepkg -si --noconfirm`) before `yay` is built.
- The only DB syncs live elsewhere in the flow and run **after** yay (e.g. the Stage 5 `pacman -Syu`, and the blackarch/multilib helpers) and only under certain layer selections.

On a fresh or torn-down system where `/var/lib/pacman/sync/` is empty, `makepkg -si`'s dependency-resolution/install phases fail with exactly:

```
warning: database file for 'core' does not exist (use '-Fy' to download)
warning: database file for 'extra' does not exist ...
```

The git clone + Go build had already happened, so it *looked* like yay was installed, but `/usr/bin/yay` was never written — hence `command not found: yay` afterward.

Additionally, `install.sh:19` disables `set -e` after sourcing the stage modules, so the non-zero status from `AUR_HELPER=$(ensure_aur_helper)` was **silently swallowed**, leaving `AUR_HELPER` empty with no message — masking the whole failure.

## Changes

- **`lib/install/aur.sh`**: add `ensure_pacman_db()` (runs `sudo pacman -Sy --noconfirm`, dry-run aware) and call it before the `base-devel` check and `ensure_aur_helper`.
- **`lib/install/aur.sh`**: `install_yay` re-detects the helper on PATH instead of assuming `"yay"` succeeded; returns non-zero if the binary never lands (cloned but not installed).
- **`install.sh`**: sync pacman DBs at the start of Stage 3; explicitly capture the `ensure_aur_helper` status and emit a visible **warning-and-continue** when no AUR helper resolves (no hard abort).
- **`tests/test_aur.sh`**: cover dry-run DB sync, failed-build, and failed-DB-sync paths using faked binaries so the suite stays self-contained on the host.

## Verification

All bash tests in `tests/test_*.sh` pass and `bash -n` is clean on all three edited files. This targets `main`, so the GitHub Actions Tests + lint workflows will run.