### PR TITLE
Remove the WiFi powersave prompt from install.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ subcommand.
 - `install.sh` must stay **idempotent** after partial application — if a
   contribution adds an install stage, guard repeated appends (`tee -a`,
   `>>`) with a grep check first, matching the existing PATH-export/
-  wifi-powersave/nvidia-modprobe pattern.
+  nvidia-modprobe pattern.
 - If your change adds a binary dependency the shell shells out to (bar,
   OSD, area-picker, session menu, etc.), add it to **both**
   `profiles/base/full.toml` and `profiles/base/minimal.toml` — the

--- a/install.sh
+++ b/install.sh
@@ -736,20 +736,6 @@ except Exception:
   print_stage 3 "System prep"
   check_conflicting_packages
 
-  read -rep $'[\e[1;33mACTION\e[0m] - Would you like to disable WiFi powersave? (y,n) ' WIFI
-  if [[ "$WIFI" == "Y" || "$WIFI" == "y" ]]; then
-    if systemctl list-unit-files NetworkManager.service &>/dev/null; then
-      echo -e "$CNT - Disabling WiFi powersave..."
-      LOC="/etc/NetworkManager/conf.d/wifi-powersave.conf"
-      if ! sudo grep -qF "wifi.powersave = 2" "$LOC" 2>/dev/null; then
-        echo -e "[connection]\nwifi.powersave = 2" | sudo tee -a "$LOC" &>> "$INSTLOG"
-      fi
-      sudo systemctl restart NetworkManager &>> "$INSTLOG"
-    else
-      echo -e "$CWR - NetworkManager isn't installed; skipping WiFi powersave config."
-    fi
-  fi
-
   # Sync pacman DBs first: on a fresh/torn-down system /var/lib/pacman/sync/
   # is empty, and without it both base-devel and makepkg -si fail with
   # "database file for ... does not exist". This must precede yay's build.


### PR DESCRIPTION
## Summary

Drops the "Would you like to disable WiFi powersave? (y,n)" interactive prompt (and the NetworkManager conf.d write / service restart behind it) from `install.sh` entirely. It interrupted the install for a system tweak with no real bearing on whether the desktop actually works, and both an outside reporter and the maintainer flagged it as unnecessary noise.

Related to (not fixing) #45 — one of that issue's threads was this exact request ("is it possible to remove 'disable powersaver for wifi' prompt during install process? i think it is unnecessary & annoying"). **#45 itself stays open** — its other, unresolved thread (`yay` still not landing on PATH after the AUR fix in #49) hasn't been root-caused yet; see my comment on the issue for the diagnostic questions I've asked the reporter. This PR doesn't touch that.

## Why removed outright, not defaulted-on or flag-gated

Nothing else in the installer reads or depends on this step, and a user who genuinely wants WiFi powersave disabled can still do it by hand (`wifi.powersave = 2` in `/etc/NetworkManager/conf.d/`). Silently defaulting it to "always disable" would be a real behavior change for anyone relying on default powersave for battery life; adding a new flag for something this minor felt like solving a problem nobody asked for.

## Test plan

- [x] `bash -n install.sh`
- [x] `tests/test_install_cli.sh`, `tests/test_install_dry_run.sh`, `tests/test_install_assistant.sh`, `tests/test_wizard.sh` all pass
- [x] Grepped for any other reference to `wifi-powersave`/`wifi.powersave` in scripts, tests, and docs — only one, an illustrative example in `CONTRIBUTING.md`, trimmed to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)