### PR TITLE
Fix install.sh --config-only leaving a duplicate qs -c aphotic running

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_reload.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_reload.sh
@@ -50,6 +50,21 @@ EOF
     # falls back to the manual pkill+relaunch for a dev/debug session
     # where `qs -c aphotic` was started bypassing the service entirely.
     if systemctl --user list-unit-files aphotic-shell.service >/dev/null 2>&1; then
+        # `systemctl restart` only manages whatever's already in the
+        # unit's own cgroup -- a `qs -c aphotic` process that predates the
+        # service's current Main PID (a prior crash, a manual launch, the
+        # deploy_user_configs symlink race) survives the restart
+        # untouched and duplicates the bar. Kill anything matching that
+        # isn't the current Main PID first, same fix as config_sync's
+        # --config-only restart step (lib/install/config_deploy.sh).
+        local service_pid pid
+        service_pid=$(systemctl --user show -p MainPID --value aphotic-shell.service 2>/dev/null || echo 0)
+        while IFS= read -r pid; do
+            [[ -z "$pid" || "$pid" == "$service_pid" ]] && continue
+            aphotic_warn "found an orphaned qs -c aphotic process (PID $pid, not owned by aphotic-shell.service) -- killing it before restart"
+            kill "$pid" 2>/dev/null || true
+        done < <(pgrep -f "qs -c aphotic" 2>/dev/null)
+
         aphotic_log "restarting quickshell daemon (aphotic-shell.service)..."
         systemctl --user restart aphotic-shell.service
         aphotic_ok "quickshell daemon restarted"

--- a/lib/install/config_deploy.sh
+++ b/lib/install/config_deploy.sh
@@ -80,13 +80,23 @@ deploy_user_configs() {
   #     (since cp -R can no longer "reset" a symlinked target the way it
   #     resets a plain file) re-running install.sh would keep appending
   #     duplicate require lines with nothing ever clearing them.
+  # Real bug, reproduced live: `rm -rf` immediately followed by `ln -sfn`
+  # leaves the destination briefly absent. If Hyprland reloads its config
+  # in that exact gap for keybinds.lua, it sees the module missing and
+  # trips emergency mode. `ln -sfn` alone (no preceding rm) already
+  # replaces an existing file or symlink atomically -- rm -rf is only
+  # needed for the one-time case where the destination is still a real
+  # directory (never true after the first successful deploy, since
+  # everything here becomes a symlink), so it's now conditional instead
+  # of unconditional.
   for entry in "$ROOT_DIR/Configs/hypr/"*; do
     name="$(basename "$entry")"
     case "$name" in
       custom.lua|monitors.lua|hyprland.lua) continue ;;
     esac
-    rm -rf "$HOME/.config/hypr/$name"
-    ln -sfn "$entry" "$HOME/.config/hypr/$name"
+    dest="$HOME/.config/hypr/$name"
+    [[ -d "$dest" && ! -L "$dest" ]] && rm -rf "$dest"
+    ln -sfn "$entry" "$dest"
   done
   chmod +x "$HOME/.config/hypr/scripts/"*
 
@@ -214,6 +224,24 @@ install_vscode_extensions() {
   tar -xf "$ROOT_DIR/src/extensions.tar.gz" -C "$HOME/.vscode/"
 }
 
+# Real bug, reproduced live: `systemctl --user restart aphotic-shell
+# .service` only manages whatever's already in the unit's own cgroup --
+# a `qs -c aphotic` process from before a symlink race (see
+# deploy_user_configs above), a crash, or a manual launch predates the
+# service's current Main PID and isn't touched by the restart at all, so
+# it survives alongside the fresh instance and duplicates the bar. Kill
+# anything matching that isn't the service's current Main PID before
+# restarting, so the restart always converges on exactly one process.
+kill_orphan_qs_processes() {
+  local service_pid pid
+  service_pid=$(systemctl --user show -p MainPID --value aphotic-shell.service 2>/dev/null || echo 0)
+  while IFS= read -r pid; do
+    [[ -z "$pid" || "$pid" == "$service_pid" ]] && continue
+    echo -e "$CWR - Found an orphaned qs -c aphotic process (PID $pid, not owned by aphotic-shell.service) -- killing it before restart." | tee -a "$INSTLOG"
+    kill "$pid" 2>/dev/null || true
+  done < <(pgrep -f "qs -c aphotic" 2>/dev/null)
+}
+
 config_sync() {
   TOTAL_STAGES=3
   print_stage 1 "Backup"
@@ -233,6 +261,7 @@ config_sync() {
 
   print_stage 3 "Restarting the shell"
   if systemctl --user is-enabled aphotic-shell.service &>/dev/null; then
+    kill_orphan_qs_processes
     systemctl --user restart aphotic-shell.service &>> "$INSTLOG" && echo -e "$COK - Restarted aphotic-shell.service." || echo -e "$CWR - Could not restart aphotic-shell.service; restart Quickshell manually (SUPER+B)."
   else
     echo -e "$CNT - aphotic-shell.service isn't enabled; restart Quickshell manually (SUPER+B) to pick up the new config."

--- a/tests/test_config_sync_orphan_kill.sh
+++ b/tests/test_config_sync_orphan_kill.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# tests/test_config_sync_orphan_kill.sh
+# Reproduces the live bug (--config-only leaving a duplicate `qs -c
+# aphotic` process running): `systemctl --user restart` only manages
+# whatever's already in the unit's own cgroup, so a process that predates
+# the service's current Main PID survives a restart untouched and
+# duplicates the bar. kill_orphan_qs_processes (lib/install/
+# config_deploy.sh) must kill exactly that PID and leave the current
+# Main PID alone.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+CWR="[WARNING]"
+INSTLOG="$WORKDIR/install.log"
+: > "$INSTLOG"
+
+mkdir -p "$WORKDIR/bin"
+export PATH="$WORKDIR/bin:$PATH"
+
+KILL_LOG="$WORKDIR/killed.log"
+
+# `kill` is a shell builtin -- a function of the same name shadows it in
+# bash's lookup order (functions before regular builtins), so this is
+# enough to intercept it without needing a PATH stub.
+kill() { echo "$*" >> "$KILL_LOG"; }
+
+source "$ROOT/lib/install/config_deploy.sh"
+
+# --- fake systemctl reporting a known current Main PID ---
+cat > "$WORKDIR/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"show"* ]]; then
+    echo "42424"
+fi
+EOF
+chmod +x "$WORKDIR/bin/systemctl"
+
+# --- fake pgrep reporting the real service PID plus two orphans ---
+cat > "$WORKDIR/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+printf '11111\n42424\n33333\n'
+EOF
+chmod +x "$WORKDIR/bin/pgrep"
+
+: > "$KILL_LOG"
+kill_orphan_qs_processes
+
+grep -qx "11111" "$KILL_LOG" || fail "expected orphan PID 11111 to be killed, log: $(cat "$KILL_LOG")"
+grep -qx "33333" "$KILL_LOG" || fail "expected orphan PID 33333 to be killed, log: $(cat "$KILL_LOG")"
+grep -qx "42424" "$KILL_LOG" && fail "expected the service's own current Main PID (42424) NOT to be killed"
+[[ "$(wc -l < "$KILL_LOG")" -eq 2 ]] || fail "expected exactly 2 kill calls (the two orphans only), got: $(cat "$KILL_LOG")"
+
+# --- no orphans (pgrep reports only the service's own PID) -> no kills ---
+cat > "$WORKDIR/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+printf '42424\n'
+EOF
+: > "$KILL_LOG"
+kill_orphan_qs_processes
+[[ -s "$KILL_LOG" ]] && fail "expected no kill calls when pgrep reports only the service's own PID, got: $(cat "$KILL_LOG")"
+
+# --- service not running (MainPID empty/0) -> everything found is an orphan ---
+cat > "$WORKDIR/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+[[ "$*" == *"show"* ]] && echo "0"
+EOF
+cat > "$WORKDIR/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+printf '55555\n'
+EOF
+: > "$KILL_LOG"
+kill_orphan_qs_processes
+grep -qx "55555" "$KILL_LOG" || fail "expected the lone stray PID to be killed when the service reports no Main PID, log: $(cat "$KILL_LOG")"
+
+echo "PASS: kill_orphan_qs_processes kills only PIDs not owned by aphotic-shell.service's current Main PID"


### PR DESCRIPTION
## Summary

Reported live: `./install.sh --config-only` left two `qs -c aphotic` processes running — confirmed directly (`pgrep -af "qs -c aphotic"` showed one as `aphotic-shell.service`'s tracked Main PID, one orphan outside its cgroup), duplicating the bar. This is a previously-diagnosed-but-deferred issue; fixing it now that it came up live again.

Two independent causes, both fixed:

1. **`deploy_user_configs`'s `Configs/hypr/*` symlink loop** did `rm -rf` immediately followed by `ln -sfn` per file — a real window where the destination doesn't exist at all. If Hyprland reloads config for `keybinds.lua` in that exact gap, it trips emergency mode. Fix: `ln -sfn` alone already atomically replaces an existing file/symlink; `rm -rf` now only runs for the one-time case where the destination is still a real directory (never true after the first successful deploy).
2. **`systemctl --user restart aphotic-shell.service`** only manages whatever's already in the unit's own cgroup. A `qs -c aphotic` process from before the race above (or a crash, or a manual launch) predates the service's current Main PID and survives the restart completely untouched. Fix: both `config_sync` (`--config-only`) and `aphotic reload --full` (`SUPER+B`) now kill any `qs -c aphotic` PID that isn't the service's current Main PID before restarting.

The live orphan on the reporting machine was killed manually as an immediate fix; this PR is the actual root-cause fix so it doesn't recur.

## Test plan

- [x] `tests/test_config_sync_orphan_kill.sh` (new): faked `systemctl`/`pgrep`/`kill` — current Main PID is spared, orphans are killed, and the "service not running" (MainPID 0) case kills everything found
- [x] Full existing suite passes
- [ ] Not re-verified against a live `--config-only` run on real hardware this pass (the original report already confirms the symptom; recommend a real run before/after to confirm the fix end to end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)