### PR TITLE
Fix fresh-install wallpaper never applying on first boot

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_theme.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_theme.sh
@@ -3,9 +3,10 @@
 # @cmd: theme
 # @cmd.desc: List, set, or cycle themes
 # @cmd.group: CONFIG
-# @cmd.opt: list        | List installed themes
-# @cmd.opt: set <name>  | Apply a theme by name
-# @cmd.opt: next|prev   | Cycle to the next/previous theme
+# @cmd.opt: list           | List installed themes
+# @cmd.opt: set <name>     | Apply a theme by name
+# @cmd.opt: next|prev      | Cycle to the next/previous theme
+# @cmd.opt: ensure-default | Apply the install-time theme if none is set yet (startup.lua only)
 #
 # Themes live as directories under APHOTIC_AWWW_DIR, each with a
 # theme.toml manifest (see Aphotic-Hypr/themes/THEME_SPEC.md) — this is
@@ -206,10 +207,56 @@ _aphotic_theme_apply() {
     return 0
 }
 
+# Applies the install-time-configured theme (aphotic.toml's [theme].name)
+# if no theme has ever been set on this machine yet (no theme.json) --
+# called once from Hyprland's startup.lua so a fresh install actually
+# shows a wallpaper on first boot instead of "No wallpaper set" until
+# SUPER+SHIFT+W is used manually. A no-op once theme.json exists, so a
+# later Hyprland restart never clobbers a theme the user already
+# switched to.
+_aphotic_theme_ensure_default() {
+    [[ -f "$APHOTIC_THEME_STATE_FILE" ]] && return 0
+
+    # `awww img` needs the daemon's socket up; poll instead of assuming a
+    # fixed startup.lua sleep was long enough on this machine.
+    local waited=0
+    while ! awww query -j &>/dev/null; do
+        sleep 0.5
+        waited=$((waited + 1))
+        if [[ $waited -ge 20 ]]; then
+            aphotic_warn "awww-daemon never came up after 10s, skipping first-boot theme apply"
+            return 1
+        fi
+    done
+
+    # Same fixed clone-path convention InstallProfile.qml uses for
+    # aphotic.toml -- see that file's comment for why it's not derived
+    # from the running script's own location.
+    local toml="${HOME}/Aphotic-Hypr/aphotic.toml"
+    local theme_name; theme_name="$(_aphotic_toml_get "$toml" theme name || true)"
+
+    if [[ -z "$theme_name" ]] || [[ ! -d "$(_aphotic_theme_dir "$theme_name")" ]]; then
+        local dir
+        for dir in "$APHOTIC_AWWW_DIR"/*/; do
+            [[ -d "$dir" ]] || continue
+            theme_name="$(basename "$dir")"
+            break
+        done
+    fi
+
+    if [[ -z "$theme_name" ]]; then
+        aphotic_err "no theme folders found in ${APHOTIC_AWWW_DIR}, nothing to apply"
+        return 1
+    fi
+
+    _aphotic_theme_apply "$theme_name"
+}
+
 aphotic_cmd_theme() {
     local sub="${1:-}"; shift || true
     case "$sub" in
         list) _aphotic_theme_list ;;
+        ensure-default) _aphotic_theme_ensure_default ;;
         set)
             local name="${1:-}"
             [[ -z "$name" ]] && { aphotic_err "usage: aphotic theme set <name>"; return 1; }
@@ -268,11 +315,14 @@ aphotic_cmd_theme() {
             ;;
         ""|-h|--help)
             cat <<HELP
-Usage: aphotic theme <list|set|next|prev> [name]
+Usage: aphotic theme <list|set|next|prev|ensure-default> [name]
 
-  list         List theme folders (${APHOTIC_AWWW_DIR})
-  set <name>   Apply a theme (its declared default wallpaper)
-  next / prev  Cycle themes
+  list            List theme folders (${APHOTIC_AWWW_DIR})
+  set <name>      Apply a theme (its declared default wallpaper)
+  next / prev     Cycle themes
+  ensure-default  Apply the install-time theme if none is set yet (no-op
+                  once a theme has ever been applied); called once from
+                  Hyprland's startup.lua, not meant for everyday use
 HELP
             ;;
         *)

--- a/Configs/hypr/startup.lua
+++ b/Configs/hypr/startup.lua
@@ -15,6 +15,12 @@ hl.on("hyprland.start", function()
     hl.exec_cmd("blueman-applet")
     hl.exec_cmd("nm-applet --indicator")
     hl.exec_cmd("sleep 1 && awww-daemon")
+    -- No-op once a theme has ever been applied (checks for theme.json) --
+    -- a fresh install has neither, so nothing in this file previously
+    -- ever told awww-daemon what to show, leaving "No wallpaper set"
+    -- until SUPER+SHIFT+W was used manually. Polls for the daemon's
+    -- socket itself rather than assuming the sleep above was long enough.
+    hl.exec_cmd("aphotic theme ensure-default")
     -- Connects only if Settings.vpnAutoConnect is true (checked inside
     -- the command itself, see cmd_vpn.sh's `autostart` subcommand) --
     -- warns and no-ops without passwordless sudo, same as everything

--- a/lib/install/wizard.sh
+++ b/lib/install/wizard.sh
@@ -94,10 +94,71 @@ prompt_layers() {
   echo "${layers[*]}"
 }
 
+# Reads [theme].display_name out of a theme.toml -- deliberately a
+# purpose-built grep/awk pass rather than pulling in aphotic_toml_get
+# from globalcontrol.sh (not sourced here, and this install-time-only
+# read doesn't need the shared shell's full TOML helper).
+_wizard_theme_display_name() {
+  local toml="$1"
+  [[ -f "$toml" ]] || return 0
+  awk '
+    /^\[theme\]/ { insec=1; next }
+    /^\[/ { insec=0 }
+    insec && /^display_name[[:space:]]*=/ {
+      sub(/^[^=]*=[[:space:]]*/, "");
+      gsub(/^"|"$/, "");
+      print;
+      exit
+    }
+  ' "$toml"
+}
+
+# Themes live as directories under Configs/awww/ (see
+# themes/THEME_SPEC.md) -- computed from this script's own path rather
+# than a global like ROOT_DIR so this stays callable in isolation (tests
+# source wizard.sh directly without setting ROOT_DIR).
+_wizard_repo_dir() {
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+}
+
 prompt_theme() {
-  local answer
-  read -rp "Theme? (default): " answer
-  echo "${answer:-default}"
+  local repo_dir names=() labels=() dir name label answer default_idx=1 i
+
+  repo_dir="$(_wizard_repo_dir)"
+  for dir in "$repo_dir"/Configs/awww/*/; do
+    [[ -d "$dir" ]] || continue
+    name="$(basename "$dir")"
+    label="$(_wizard_theme_display_name "${dir}theme.toml")"
+    names+=("$name")
+    labels+=("${label:-$name}")
+  done
+
+  if [[ ${#names[@]} -eq 0 ]]; then
+    # No theme folders found (shouldn't happen in a real clone) -- fall
+    # back to a name rather than leaving THEME empty, since downstream
+    # `aphotic theme set` treats an unresolvable name as an error, not a
+    # silent no-op.
+    echo "tokyonight"
+    return 0
+  fi
+
+  for i in "${!names[@]}"; do
+    [[ "${names[$i]}" == "tokyonight" ]] && default_idx=$((i + 1))
+  done
+
+  echo "Available themes:" >&2
+  for i in "${!names[@]}"; do
+    printf '  %d) %-12s %s\n' "$((i + 1))" "${names[$i]}" "${labels[$i]}" >&2
+  done
+  read -rp "Theme? [1-${#names[@]}] (default ${default_idx} - ${names[$((default_idx - 1))]}): " answer
+  answer="${answer:-$default_idx}"
+
+  if [[ "$answer" =~ ^[0-9]+$ ]] && (( answer >= 1 && answer <= ${#names[@]} )); then
+    echo "${names[$((answer - 1))]}"
+  else
+    echo -e "$CWR - Invalid selection, using ${names[$((default_idx - 1))]}." >&2
+    echo "${names[$((default_idx - 1))]}"
+  fi
 }
 
 # Reads aphotic.toml's [install].layers as a CSV, or "" if the file/key is
@@ -185,7 +246,7 @@ resolve_config() {
     echo -e "$CNT - Run with --opt-in for the interactive layer picker, or --with gaming,dev,ai,exploit to pick layers directly. Layers can always be added later by re-running install.sh."
     PROFILE="full"
     LAYERS=""
-    [[ -z "$THEME" ]] && THEME="default"
+    [[ -z "$THEME" ]] && THEME="tokyonight"
     # Return here, not just fall through -- LAYERS="" is this branch's real
     # answer (no optional layers), and the -z checks below can't tell that
     # apart from "not resolved yet," which would otherwise re-trigger

--- a/tests/test_theme_ensure_default.sh
+++ b/tests/test_theme_ensure_default.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# tests/test_theme_ensure_default.sh
+# `aphotic theme ensure-default` is the fix for a fresh install showing
+# "No wallpaper set" until SUPER+SHIFT+W is used manually: install.sh
+# writes aphotic.toml's [theme].name but never actually ran `aphotic
+# theme set` (couldn't -- no Wayland session/awww-daemon exists yet at
+# install time), so theme.json (the file Wallpaper.qml/Themes.qml read)
+# never got written. This is now called once from Hyprland's
+# startup.lua instead, after awww-daemon is up.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+# Point away from the real system SDDM theme dir -- this test must never
+# touch /usr/share/sddm on the machine running it.
+export APHOTIC_SDDM_THEME_DIR="$TESTHOME/no-such-sddm-theme"
+
+# Fake `awww`/`jq` on PATH ahead of the real ones -- `jq` stays real
+# (should already be installed; only awww needs stubbing since nothing
+# in this test has a real Wayland session/daemon to talk to).
+FAKEBIN="$TESTHOME/fakebin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/awww" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    query) echo '{}' ;;
+    img) exit 0 ;;
+    *) exit 0 ;;
+esac
+EOF
+chmod +x "$FAKEBIN/awww"
+cat > "$FAKEBIN/wallust" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKEBIN/wallust"
+export PATH="$FAKEBIN:$PATH"
+
+LIB_DIR="$ROOT/Configs/.local/lib/aphotic"
+COMMANDS_DIR="$LIB_DIR/commands"
+source "$LIB_DIR/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_theme.sh"
+
+# --- scratch theme folders (mirrors the real Configs/awww layout --
+# every shipped theme ships a theme.toml, so these do too) ---
+mkdir -p "$APHOTIC_AWWW_DIR/alpha" "$APHOTIC_AWWW_DIR/beta"
+: > "$APHOTIC_AWWW_DIR/alpha/one.jpg"
+: > "$APHOTIC_AWWW_DIR/beta/two.jpg"
+cat > "$APHOTIC_AWWW_DIR/alpha/theme.toml" <<'EOF'
+[theme]
+display_name = "Alpha"
+
+[wallpaper]
+default = "one.jpg"
+EOF
+cat > "$APHOTIC_AWWW_DIR/beta/theme.toml" <<'EOF'
+[theme]
+display_name = "Beta"
+
+[wallpaper]
+default = "two.jpg"
+EOF
+
+# --- case 1: aphotic.toml names a real theme -> that theme gets applied ---
+mkdir -p "$HOME/Aphotic-Hypr"
+cat > "$HOME/Aphotic-Hypr/aphotic.toml" <<'EOF'
+[install]
+profile = "full"
+layers = []
+
+[theme]
+name = "beta"
+EOF
+
+_aphotic_theme_ensure_default
+
+[[ -f "$APHOTIC_THEME_STATE_FILE" ]] || fail "theme.json was not written"
+applied="$(jq -r '.theme' "$APHOTIC_THEME_STATE_FILE")"
+[[ "$applied" == "beta" ]] || fail "expected 'beta' applied from aphotic.toml, got '$applied'"
+
+# --- case 2: already-set theme.json is left alone (no clobbering a switch) ---
+jq -n '{theme: "alpha", wallpaper: "one.jpg"}' > "$APHOTIC_THEME_STATE_FILE"
+_aphotic_theme_ensure_default
+still="$(jq -r '.theme' "$APHOTIC_THEME_STATE_FILE")"
+[[ "$still" == "alpha" ]] || fail "ensure-default clobbered an existing theme.json, got '$still'"
+
+# --- case 3: no aphotic.toml at all -> falls back to first theme folder ---
+rm -f "$APHOTIC_THEME_STATE_FILE" "$HOME/Aphotic-Hypr/aphotic.toml"
+_aphotic_theme_ensure_default
+fallback="$(jq -r '.theme' "$APHOTIC_THEME_STATE_FILE")"
+[[ "$fallback" == "alpha" ]] || fail "expected fallback to first theme folder 'alpha', got '$fallback'"
+
+echo "PASS: aphotic theme ensure-default"

--- a/tests/test_wizard.sh
+++ b/tests/test_wizard.sh
@@ -35,8 +35,16 @@ result=$(printf "3\nn\nn\nn\ny\nn\ny\ny\nn\nn\nn\nn\nn\n" | prompt_layers)
 result=$(printf "3\nn\nn\nn\ny\ny\ny\ny\nn\nn\nn\n" | prompt_layers)
 [[ "$result" == "exploit,exploit-passwords,exploit-wordlists" ]] || fail "expected 'exploit,exploit-passwords,exploit-wordlists', got '$result'"
 
-result=$(echo "" | prompt_theme)
-[[ "$result" == "default" ]] || fail "expected 'default', got '$result'"
+CWR="[WARNING]"
+
+result=$(echo "" | prompt_theme 2>/dev/null)
+[[ "$result" == "tokyonight" ]] || fail "expected default 'tokyonight', got '$result'"
+
+result=$(echo "1" | prompt_theme 2>/dev/null)
+[[ "$result" == "gruvbox" ]] || fail "expected 'gruvbox' for selection 1, got '$result'"
+
+result=$(echo "99" | prompt_theme 2>/dev/null)
+[[ "$result" == "tokyonight" ]] || fail "expected fallback to 'tokyonight' for out-of-range selection, got '$result'"
 
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT


### PR DESCRIPTION
## Summary
- Root cause: `install.sh` writes `aphotic.toml`'s `[theme].name` but never applies it — it can't, since there's no Wayland session/`awww-daemon` yet at install time. Nothing else ever called `aphotic theme set` either, so `theme.json` (what `Wallpaper.qml`/`Themes.qml` read) never got written, leaving a fresh install on "No wallpaper set" until `SUPER+SHIFT+W` is used manually.
- Adds `aphotic theme ensure-default`, called once from Hyprland's `startup.lua` after `awww-daemon` comes up (polls for its socket rather than trusting a fixed sleep): applies the install-time theme if `theme.json` doesn't exist yet, no-ops otherwise so it never clobbers a theme the user already switched to.
- Fixes the wizard's theme prompt: `"Theme? (default):"` fell back to a literal theme named `"default"`, which doesn't exist — none of the eight shipped themes are named that, so `aphotic theme set` would have failed outright had anything ever called it. Replaced with a numbered menu of the real theme folders (`Configs/awww/*`), defaulting to Tokyo Night.

## Test plan
- [x] `tests/test_theme_ensure_default.sh` (new): applies the aphotic.toml-configured theme, no-ops when `theme.json` already exists, falls back to the first available theme when `aphotic.toml` is missing/invalid
- [x] `tests/test_wizard.sh`: updated for the numbered theme menu (default selection, numeric selection, out-of-range fallback)
- [x] Full existing test suite (`tests/test_*.sh`) still passes
- [ ] Live dev-VM verification: fresh `install.sh` run, reboot into Hyprland, confirm a wallpaper shows without manual selection

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_019aemwNnBthgme6XHGVyjvA