### PR TITLE
Update star history URLs to modern format

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,8 +564,8 @@ Install the <a href="https://addons.mozilla.org/en-US/firefox/addon/pywalfox/">P
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#T-Crypt/Aphotic-Hypr&Date">
-    <img src="https://api.star-history.com/svg?repos=T-Crypt/Aphotic-Hypr&type=Date" width="600">
+  <a href="https://www.star-history.com/?type=date&repos=T-Crypt%2FAphotic-Hypr">
+    <img src="https://api.star-history.com/svg?repos=T-Crypt/Aphotic-Hypr&type=date" width="600">
   </a>
 </p>
 


### PR DESCRIPTION
## Changes

Updates the star history badge URLs in README.md to use the current star-history.com format:

- **Href URL**: Now uses `www.star-history.com` with proper URL encoding (`T-Crypt%2FAphotic-Hypr`)
- **Type parameter**: Changed from `Date` to `date` (lowercase) for consistency with current API
- **Result**: Star history badge now accurately reflects the repository state

## Why

The previous URLs were using a stale format that may not reflect the current repository statistics. This ensures the badge displays accurate data.