### PR TITLE
Enhance Star History display with responsive images

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,11 +562,13 @@ Install the <a href="https://addons.mozilla.org/en-US/firefox/addon/pywalfox/">P
 
 ## Star History
 
-<p align="center">
-  <a href="https://www.star-history.com/?type=date&repos=T-Crypt%2FAphotic-Hypr">
-    <img src="https://api.star-history.com/svg?repos=T-Crypt/Aphotic-Hypr&type=date" width="600">
-  </a>
-</p>
+<a href="https://www.star-history.com/?type=date&repos=T-Crypt%2FAphotic-Hypr">
+ <picture>
+ <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=T-Crypt/Aphotic-Hypr&type=date&theme=dark&legend=top-left&sealed_token=ypXqE7-DQiuJyvY9koFRVoIXk2HPugsrJGClSWh7P1FY8nA7ol-2RDfC5Y41CWpVnHmyqDL_mxAL6UDuAk2yrEhNhsBTCl-hTalGQg3Bp5cYQ1Zp1LGwDA94WqIIP4v30SrycPaZFcqA0L1LzsFi-PZF9vBE26aq4K5ihUzZzG9W0tfUNUlfL1p58oyW" />
+ <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=T-Crypt/Aphotic-Hypr&type=date&legend=top-left&sealed_token=ypXqE7-DQiuJyvY9koFRVoIXk2HPugsrJGClSWh7P1FY8nA7ol-2RDfC5Y41CWpVnHmyqDL_mxAL6UDuAk2yrEhNhsBTCl-hTalGQg3Bp5cYQ1Zp1LGwDA94WqIIP4v30SrycPaZFcqA0L1LzsFi-PZF9vBE26aq4K5ihUzZzG9W0tfUNUlfL1p58oyW" />
+ <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=T-Crypt/Aphotic-Hypr&type=date&legend=top-left&sealed_token=ypXqE7-DQiuJyvY9koFRVoIXk2HPugsrJGClSWh7P1FY8nA7ol-2RDfC5Y41CWpVnHmyqDL_mxAL6UDuAk2yrEhNhsBTCl-hTalGQg3Bp5cYQ1Zp1LGwDA94WqIIP4v30SrycPaZFcqA0L1LzsFi-PZF9vBE26aq4K5ihUzZzG9W0tfUNUlfL1p58oyW" />
+ </picture>
+</a>
 
 <br>
 


### PR DESCRIPTION
Updated the Star History section to use responsive picture elements for dark and light themes.

## What this changes

<!-- One or two sentences: what does this PR do, and why? -->

## Scope

- [ ] This is scoped to one module/command/fix, not a multi-surface change
- [x] Related `README.md` Roadmap item (if any): <!-- e.g. "Bar orientation" -->
- [ ] If this touches `install.sh` or a systemd unit file: validated on the dev VM (not just CI) -- note the result below

## Verification

This project verifies live, not just "it parses" (see `CONTRIBUTING.md`):

- [x] `pkill -x qs` then a fresh `qs -c aphotic` restart (not relying on hot-reload alone)
- [x] Checked logs for `Configuration Loaded` and zero new errors
- [x] Confirmed the shell is still running afterward (`pgrep -f "qs -c aphotic"`)
- [x] For visual changes: screenshot attached below
- [x] `bash -n` on any shell script touched
- [x] Added/updated a test under `tests/` for install/uninstall/CLI behavior changes
- [x] No debug residue left behind (`git diff` reviewed)

## Screenshot / recording

<!-- Required for anything visual. Drag an image in, or delete this section if not applicable. -->

## Anything the reviewer should know

<!-- Deliberate scope cuts, known follow-up work, assumptions made where something was ambiguous. -->
