### PR TITLE
Phase 0: profile state machine, Resource Engine, event bus, state snapshot/restore

### DIFF
--- a/Configs/quickshell/aphotic/modules/negotiation/NegotiationContent.qml
+++ b/Configs/quickshell/aphotic/modules/negotiation/NegotiationContent.qml
@@ -1,0 +1,205 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
+import qs.config
+import qs.components
+import qs.services
+import qs.services.profile
+
+// The one negotiation prompt every domain pair reuses -- AI vs. Gaming,
+// Security vs. Dev, any future pair -- rendered straight off
+// ResourceEngine.pending, so no domain plugin builds its own conflict UI.
+// The three decisions are the whole contract: nothing here can suspend
+// anything by itself, it only reports the answer back to the engine.
+Item {
+    id: root
+
+    readonly property var negotiation: ResourceEngine.pending
+    readonly property bool open: root.negotiation !== null
+
+    readonly property int cardWidth: 520
+
+    implicitWidth: root.cardWidth
+    implicitHeight: card.implicitHeight
+    width: root.implicitWidth
+    height: root.implicitHeight
+
+    function amountText(claim: var): string {
+        if (!claim || claim.amount <= 0)
+            return "";
+        const unit = root.negotiation?.unit ?? "";
+        return unit ? `${claim.amount} ${unit} of ` : "";
+    }
+
+    StyledRect {
+        id: card
+
+        width: root.width
+        implicitHeight: column.implicitHeight + Tokens.padding.extraLarge * 2
+
+        opacity: root.open ? 1 : 0
+        scale: root.open ? 1 : 0.96
+        transformOrigin: Item.Center
+
+        radius: Tokens.rounding.large
+        color: Colours.palette.m3surfaceContainer
+        border.width: Config.border.thickness
+        border.color: Colours.palette.m3outlineVariant
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.Emphasized
+            }
+        }
+        Behavior on scale {
+            Anim {
+                type: Anim.Emphasized
+            }
+        }
+
+        layer.enabled: true
+        layer.effect: MultiEffect {
+            shadowEnabled: true
+            shadowColor: Colours.palette.m3shadow
+            shadowOpacity: 0.5
+            shadowBlur: 0.5
+            shadowVerticalOffset: 2
+        }
+
+        MouseArea {
+            anchors.fill: parent
+        }
+
+        ColumnLayout {
+            id: column
+
+            anchors.fill: parent
+            anchors.margins: Tokens.padding.extraLarge
+            spacing: Tokens.spacing.large
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.medium
+
+                MaterialIcon {
+                    text: "swap_horiz"
+                    fontStyle: Tokens.font.icon.large
+                    color: Colours.palette.m3primary
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("%1 Resource Conflict").arg(root.negotiation?.requestor.owner ?? "")
+                    font: Tokens.font.title.large
+                    elide: Text.ElideRight
+                }
+
+                StyledText {
+                    visible: ResourceEngine.pendingCount > 1
+                    text: qsTr("+%1 more").arg(ResourceEngine.pendingCount - 1)
+                    color: Colours.palette.m3onSurfaceVariant
+                    font: Tokens.font.label.medium
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("%1 is currently using %2%3.").arg(root.negotiation?.claimant.label ?? "").arg(root.amountText(root.negotiation?.claimant ?? null)).arg(root.negotiation?.resourceLabel ?? "")
+                    font: Tokens.font.body.medium
+                    wrapMode: Text.WordWrap
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("%1 is requesting %2 at %3 priority.").arg(root.negotiation?.requestor.label ?? "").arg(root.negotiation?.resourceLabel ?? "").arg(root.negotiation?.requestor.priority ?? "")
+                    font: Tokens.font.body.medium
+                    wrapMode: Text.WordWrap
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    visible: root.negotiation?.reason === "capacity"
+                    text: qsTr("Combined claims are %1 against a %2 %3 safety budget.").arg(Math.round(root.negotiation?.total ?? 0)).arg(Math.round(root.negotiation?.budget ?? 0)).arg(root.negotiation?.unit ?? "")
+                    color: Colours.palette.m3onSurfaceVariant
+                    font: Tokens.font.label.medium
+                    wrapMode: Text.WordWrap
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                Repeater {
+                    model: [
+                        {
+                            decision: "suspend",
+                            label: qsTr("Suspend %1").arg(root.negotiation?.claimant.label ?? ""),
+                            filled: true,
+                            enabled: root.negotiation?.claimantSuspendable ?? false
+                        },
+                        {
+                            decision: "keep",
+                            label: qsTr("Keep Running"),
+                            filled: false,
+                            enabled: true
+                        },
+                        {
+                            decision: "ignore",
+                            label: qsTr("Ignore"),
+                            filled: false,
+                            enabled: true
+                        }
+                    ]
+
+                    StyledRect {
+                        id: button
+
+                        required property var modelData
+
+                        Layout.preferredWidth: buttonLabel.implicitWidth + Tokens.padding.largeIncreased * 2
+                        Layout.preferredHeight: buttonLabel.implicitHeight + Tokens.padding.small * 2
+                        radius: Tokens.rounding.full
+                        opacity: button.modelData.enabled ? 1 : 0.4
+                        color: button.modelData.filled ? Colours.palette.m3primary : Colours.layer(Colours.tPalette.m3surfaceContainer, 2)
+
+                        StyledText {
+                            id: buttonLabel
+
+                            anchors.centerIn: parent
+                            text: button.modelData.label
+                            color: button.modelData.filled ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurface
+                            font: Tokens.font.label.large
+                        }
+
+                        StateLayer {
+                            anchors.fill: parent
+                            radius: parent.radius
+                            disabled: !button.modelData.enabled
+                            onClicked: ResourceEngine.resolve(button.modelData.decision)
+                        }
+                    }
+                }
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                visible: !(root.negotiation?.claimantSuspendable ?? false)
+                text: qsTr("%1 has no graceful-stop hook, so it can't be suspended from here.").arg(root.negotiation?.claimant.owner ?? "")
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.label.medium
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/negotiation/NegotiationWindow.qml
+++ b/Configs/quickshell/aphotic/modules/negotiation/NegotiationWindow.qml
@@ -1,0 +1,73 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs.config
+import qs.services
+import qs.services.profile
+
+// Same static full-screen PanelWindow + centred animating child as every
+// other modal surface in this shell (see modules/pkginstall) -- the window
+// itself never moves or resizes, NegotiationContent's card does the
+// motion.
+//
+// Instantiated by shell.qml's LazyLoader only while a negotiation is
+// pending, rather than one always-mounted instance per screen: with no
+// opt-in profile installed there is no negotiation, so this surface does
+// not exist at all on a base install. `screen` is latched once on
+// creation instead of bound to the focused monitor, so answering the
+// prompt can't make the window hop screens mid-decision.
+PanelWindow {
+    id: root
+
+    property var latchedScreen: null
+
+    screen: root.latchedScreen
+
+    WlrLayershell.namespace: "aphotic-negotiation"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+    WlrLayershell.exclusionMode: ExclusionMode.Ignore
+    color: "transparent"
+
+    anchors.top: true
+    anchors.bottom: true
+    anchors.left: true
+    anchors.right: true
+
+    // Existence is the gate, not a second condition on ResourceEngine.pending:
+    // shell.qml's loader already holds this window mounted for one animation
+    // duration past the answer, and binding visible to `pending` as well
+    // would unmap the surface on the first frame of that fade-out.
+    visible: root.latchedScreen !== null
+    implicitWidth: root.screen?.width ?? 0
+    implicitHeight: root.screen?.height ?? 0
+
+    Component.onCompleted: {
+        const name = Hypr.focusedMonitor?.name;
+        const screens = Quickshell.screens;
+        for (let i = 0; i < screens.length; i++) {
+            if (screens[i].name === name) {
+                root.latchedScreen = screens[i];
+                return;
+            }
+        }
+        root.latchedScreen = screens[0] ?? null;
+    }
+
+    // Escape and click-outside answer "Keep Running" -- the decision that
+    // stops nothing. A dismissal must never be the one that suspends a
+    // workload.
+    MouseArea {
+        anchors.fill: parent
+        focus: true
+        onClicked: ResourceEngine.resolve("keep")
+
+        Keys.onEscapePressed: ResourceEngine.resolve("keep")
+    }
+
+    NegotiationContent {
+        anchors.centerIn: parent
+    }
+}

--- a/Configs/quickshell/aphotic/modules/negotiation/qmldir
+++ b/Configs/quickshell/aphotic/modules/negotiation/qmldir
@@ -1,0 +1,3 @@
+module qs.modules.negotiation
+NegotiationContent 1.0 NegotiationContent.qml
+NegotiationWindow 1.0 NegotiationWindow.qml

--- a/Configs/quickshell/aphotic/services/Hypr.qml
+++ b/Configs/quickshell/aphotic/services/Hypr.qml
@@ -34,6 +34,12 @@ Singleton {
     property bool numLock: false
 
     signal configReloaded
+    // Re-emitted so anything that needs the compositor's raw stream
+    // (services/profile/ProfileEvents.qml) hangs off this one handler
+    // instead of opening a second Connections on Hyprland itself. Emitted
+    // after the v2 filter below, so subscribers see the same
+    // once-per-event stream this file acts on rather than duplicates.
+    signal rawEvent(name: string, data: string)
 
     function dispatch(request: string): void {
         Hyprland.dispatch(request);
@@ -85,6 +91,8 @@ Singleton {
             const n = event.name;
             if (n.endsWith("v2"))
                 return;
+
+            root.rawEvent(n, event.data ?? "");
 
             if (n === "configreloaded") {
                 root.configReloaded();

--- a/Configs/quickshell/aphotic/services/profile/ProfileEngine.qml
+++ b/Configs/quickshell/aphotic/services/profile/ProfileEngine.qml
@@ -1,0 +1,327 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import qs.services.profile
+
+// The one profile lifecycle every opt-in domain (AI, Gaming, Dev,
+// Security) runs, rather than four near-identical copies of it:
+//
+//   DETECT -> LOAD -> NEGOTIATE -> APPLY -> MONITOR -> ANOMALY
+//                                              \-> EXIT -> RESTORE -> IDLE
+//
+// A domain plugin does not reimplement any of that. It registers a
+// descriptor of hooks (onLoad/onApply/onExit/onRestore/gracefulStop) plus
+// its static claims, and this singleton drives the phases, the claim
+// registration, the snapshot and the restore in the same order for every
+// domain. `phases` and `_allowed` below are the whole contract.
+//
+// ANOMALY is a real phase, not a callback: reportAnomaly() parks the
+// profile there with the anomaly surfaced and *nothing else happens*. The
+// only ways out are acknowledgeAnomaly() (back to MONITOR) or
+// deactivate(). That is the "surface, don't auto-fix" rule expressed as a
+// state machine rather than as a comment nobody has to obey -- there is no
+// transition out of ANOMALY that applies a remedy.
+Singleton {
+    id: root
+
+    readonly property var phases: ["idle", "detect", "load", "negotiate", "apply", "monitor", "anomaly", "exit", "restore"]
+
+    readonly property var profiles: root._profiles
+    readonly property var states: root._states
+    readonly property var activeIds: Object.keys(root._states).filter(id => root._states[id].phase !== "idle")
+    readonly property bool anyActive: root.activeIds.length > 0
+
+    signal profileRegistered(id: string)
+    signal profileUnregistered(id: string)
+    signal phaseChanged(id: string, from: string, to: string)
+    signal anomalySurfaced(id: string, anomaly: var)
+    signal anomalyAcknowledged(id: string)
+
+    property var _profiles: ({})
+    property var _states: ({})
+
+    readonly property var _allowed: ({
+        idle: ["detect"],
+        detect: ["load", "idle"],
+        load: ["negotiate", "exit"],
+        negotiate: ["apply", "exit"],
+        apply: ["monitor", "exit"],
+        monitor: ["anomaly", "exit"],
+        anomaly: ["monitor", "exit"],
+        exit: ["restore"],
+        restore: ["idle"]
+    })
+
+    function register(descriptor: var): bool {
+        if (!descriptor || !descriptor.id) {
+            console.warn("ProfileEngine: descriptor needs an id");
+            return false;
+        }
+        const id = String(descriptor.id);
+
+        const profiles = Object.assign({}, root._profiles);
+        profiles[id] = {
+            id: id,
+            label: descriptor.label ? String(descriptor.label) : id,
+            claims: Array.isArray(descriptor.claims) ? descriptor.claims : [],
+            snapshot: Array.isArray(descriptor.snapshot) ? descriptor.snapshot : StateSnapshot.allParts,
+            onLoad: descriptor.onLoad ?? null,
+            onApply: descriptor.onApply ?? null,
+            onExit: descriptor.onExit ?? null,
+            onRestore: descriptor.onRestore ?? null,
+            gracefulStop: descriptor.gracefulStop ?? null
+        };
+        root._profiles = profiles;
+
+        if (!root._states[id])
+            root._setState(id, { phase: "idle", trigger: "", reason: "", anomalies: [], waitingOn: [], awaitingSnapshot: false, awaitingRestore: false });
+
+        root.profileRegistered(id);
+        return true;
+    }
+
+    function unregister(id: string): void {
+        if (!root._profiles[id])
+            return;
+        if (root.isActive(id))
+            root.deactivate(id, "unregistered");
+
+        const profiles = Object.assign({}, root._profiles);
+        delete profiles[id];
+        root._profiles = profiles;
+
+        const states = Object.assign({}, root._states);
+        delete states[id];
+        root._states = states;
+        StateSnapshot.discard(id);
+
+        root.profileUnregistered(id);
+    }
+
+    function isRegistered(id: string): bool {
+        return !!root._profiles[id];
+    }
+
+    function isActive(id: string): bool {
+        return root.phaseOf(id) !== "idle";
+    }
+
+    function phaseOf(id: string): string {
+        return root._states[id]?.phase ?? "idle";
+    }
+
+    function stateOf(id: string): var {
+        return root._states[id] ?? null;
+    }
+
+    function canSuspend(id: string): bool {
+        return typeof root._profiles[id]?.gracefulStop === "function";
+    }
+
+    function activate(id: string, trigger: string): bool {
+        const profile = root._profiles[id];
+        if (!profile) {
+            console.warn(`ProfileEngine: activate for unregistered profile '${id}'`);
+            return false;
+        }
+        if (root.isActive(id))
+            return false;
+
+        root._patchState(id, { trigger: trigger ?? "", reason: "", anomalies: [], waitingOn: [], awaitingSnapshot: false, awaitingRestore: false });
+
+        if (!root._transition(id, "detect"))
+            return false;
+        if (!root._transition(id, "load"))
+            return false;
+        root._invoke(id, "onLoad");
+
+        if (!root._transition(id, "negotiate"))
+            return false;
+
+        const waiting = [];
+        for (const claim of profile.claims) {
+            const negotiation = ResourceEngine.register(Object.assign({}, claim, { owner: id }));
+            if (negotiation)
+                waiting.push(negotiation.id);
+        }
+
+        if (waiting.length > 0) {
+            root._patchState(id, { waitingOn: waiting });
+            return true;
+        }
+        return root._enterApply(id);
+    }
+
+    function deactivate(id: string, reason: string): bool {
+        if (!root.isActive(id))
+            return false;
+
+        root._patchState(id, { reason: reason ?? "", waitingOn: [] });
+
+        if (!root._transition(id, "exit"))
+            return false;
+        root._invoke(id, "onExit");
+        ResourceEngine.releaseOwner(id);
+
+        if (!root._transition(id, "restore"))
+            return false;
+
+        // Parks in RESTORE until the rollback has actually been issued --
+        // going idle first would report a profile as fully restored while
+        // its monitor read was still in flight.
+        root._patchState(id, { awaitingRestore: true });
+        if (!StateSnapshot.restore(id))
+            return root._finishRestore(id);
+        return true;
+    }
+
+    // Guarded because StateSnapshot's synchronous path emits restored()
+    // from inside restore(), so the Connections below can reach here before
+    // the caller does.
+    function _finishRestore(id: string): bool {
+        if (!root._states[id]?.awaitingRestore)
+            return root.phaseOf(id) === "idle";
+        root._patchState(id, { awaitingRestore: false });
+        root._invoke(id, "onRestore");
+        return root._transition(id, "idle");
+    }
+
+    // Valid only from MONITOR. Records and surfaces; changes nothing else.
+    function reportAnomaly(id: string, anomaly: var): bool {
+        if (root.phaseOf(id) !== "monitor") {
+            console.warn(`ProfileEngine: anomaly for '${id}' ignored in phase '${root.phaseOf(id)}'`);
+            return false;
+        }
+        const entry = {
+            at: Date.now(),
+            kind: anomaly?.kind ? String(anomaly.kind) : "unspecified",
+            detail: anomaly?.detail ? String(anomaly.detail) : ""
+        };
+        const anomalies = (root._states[id]?.anomalies ?? []).concat([entry]);
+        root._patchState(id, { anomalies: anomalies });
+
+        if (!root._transition(id, "anomaly"))
+            return false;
+        root.anomalySurfaced(id, entry);
+        return true;
+    }
+
+    function acknowledgeAnomaly(id: string): bool {
+        if (root.phaseOf(id) !== "anomaly")
+            return false;
+        if (!root._transition(id, "monitor"))
+            return false;
+        root.anomalyAcknowledged(id);
+        return true;
+    }
+
+    function requestSuspend(owner: string, claim: var): void {
+        const hook = root._profiles[owner]?.gracefulStop;
+        if (typeof hook !== "function") {
+            console.warn(`ResourceEngine: '${owner}' has no graceful-stop hook, nothing suspended`);
+            return;
+        }
+        hook(claim);
+    }
+
+    // APPLY is where the profile is allowed to change desktop state, so the
+    // snapshot has to be finished before onApply runs -- otherwise a
+    // profile that reconfigures a monitor gets its own post-change geometry
+    // recorded as the thing to restore to. StateSnapshot's monitors part is
+    // asynchronous (see its header), so this parks until captured().
+    function _enterApply(id: string): bool {
+        const profile = root._profiles[id];
+        if (!root._transition(id, "apply"))
+            return false;
+
+        root._patchState(id, { awaitingSnapshot: true });
+        if (StateSnapshot.capture(id, profile.snapshot).complete)
+            return root._finishApply(id);
+        return true;
+    }
+
+    function _finishApply(id: string): bool {
+        if (!root._states[id]?.awaitingSnapshot)
+            return root.phaseOf(id) === "monitor";
+        root._patchState(id, { awaitingSnapshot: false });
+        root._invoke(id, "onApply");
+        return root._transition(id, "monitor");
+    }
+
+    function _invoke(id: string, hookName: string): void {
+        const hook = root._profiles[id]?.[hookName];
+        if (typeof hook !== "function")
+            return;
+        try {
+            hook();
+        } catch (e) {
+            console.warn(`ProfileEngine: '${id}' ${hookName} threw: ${e}`);
+        }
+    }
+
+    function _transition(id: string, to: string): bool {
+        const from = root.phaseOf(id);
+        if (from === to)
+            return true;
+        if (!(root._allowed[from] ?? []).includes(to)) {
+            console.warn(`ProfileEngine: '${id}' cannot go ${from} -> ${to}`);
+            return false;
+        }
+        root._patchState(id, { phase: to, since: Date.now() });
+        root.phaseChanged(id, from, to);
+        return true;
+    }
+
+    function _setState(id: string, state: var): void {
+        const states = Object.assign({}, root._states);
+        states[id] = state;
+        root._states = states;
+    }
+
+    function _patchState(id: string, patch: var): void {
+        const states = Object.assign({}, root._states);
+        states[id] = Object.assign({}, states[id] ?? { phase: "idle", anomalies: [], waitingOn: [] }, patch);
+        root._states = states;
+    }
+
+    Connections {
+        target: StateSnapshot
+
+        function onCaptured(profileId: string, parts: var): void {
+            if (root._states[profileId]?.awaitingSnapshot && root.phaseOf(profileId) === "apply")
+                root._finishApply(profileId);
+        }
+
+        function onRestored(profileId: string, applied: var): void {
+            if (root._states[profileId]?.awaitingRestore && root.phaseOf(profileId) === "restore")
+                root._finishRestore(profileId);
+        }
+    }
+
+    Connections {
+        target: ResourceEngine
+
+        function onSuspendRequested(owner: string, claim: var): void {
+            root.requestSuspend(owner, claim);
+        }
+
+        // A profile parked in NEGOTIATE proceeds to APPLY once every
+        // conflict its own claims raised has an answer -- including
+        // "keep"/"ignore", which are answers, not blocks. Nothing is
+        // suspended on its behalf here; that only ever happens through
+        // the suspend decision above, against the claim's own owner.
+        function onNegotiationResolved(negotiation: var, decision: string): void {
+            for (const id of Object.keys(root._states)) {
+                const waiting = root._states[id].waitingOn ?? [];
+                if (!waiting.includes(negotiation.id))
+                    continue;
+                const remaining = waiting.filter(n => n !== negotiation.id);
+                root._patchState(id, { waitingOn: remaining });
+                if (remaining.length === 0 && root.phaseOf(id) === "negotiate")
+                    root._enterApply(id);
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/profile/ProfileEvents.qml
+++ b/Configs/quickshell/aphotic/services/profile/ProfileEvents.qml
@@ -1,0 +1,143 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import qs.services
+import qs.services.profile
+
+// The fan-out point between event sources the shell already has and
+// whatever wants to react to them. Not a new event mechanism: the
+// compositor half is fed by Hypr.qml's existing Connections on Hyprland's
+// raw event stream (Hypr re-emits as `rawEvent`), and the substrate half
+// is fed by ProfileEngine's and ResourceEngine's own signals. Nothing here
+// opens a socket, spawns a process or runs a timer.
+//
+// A domain plugin that watches something core has no business knowing
+// about (a game launcher, a container runtime, a harness hook's event log)
+// owns that watcher itself and publish()es into this bus, so subscribers
+// see one stream regardless of where an event came from.
+//
+// Zero-cost when unused is structural, not a promise: every Connections
+// below is disabled while there are no subscribers, so with no opt-in
+// profile installed this singleton is not connected to anything and the
+// compositor's event stream reaches nothing.
+Singleton {
+    id: root
+
+    readonly property var kinds: ["compositor.raw", "window.open", "window.close", "window.focus", "workspace.focus", "monitor.change", "profile.phase", "profile.anomaly", "resource.claim", "resource.negotiation"]
+
+    readonly property int subscriberCount: root._subs.length
+    readonly property bool idle: root._subs.length === 0
+    readonly property var lastEvent: root._lastEvent
+
+    signal event(kind: string, payload: var)
+
+    property var _subs: []
+    property var _lastEvent: null
+    property int _nextToken: 1
+
+    // wanted: array of kind strings, or [] / "*" for everything.
+    function subscribe(owner: string, wanted: var, callback: var): int {
+        if (typeof callback !== "function") {
+            console.warn(`ProfileEvents: subscribe('${owner}') needs a callback`);
+            return 0;
+        }
+        const token = root._nextToken;
+        root._nextToken = token + 1;
+        const selected = (wanted === "*" || !Array.isArray(wanted)) ? [] : wanted.slice();
+        root._subs = root._subs.concat([{
+            token: token,
+            owner: String(owner),
+            kinds: selected,
+            callback: callback
+        }]);
+        return token;
+    }
+
+    function unsubscribe(token: int): void {
+        root._subs = root._subs.filter(s => s.token !== token);
+    }
+
+    function unsubscribeOwner(owner: string): void {
+        root._subs = root._subs.filter(s => s.owner !== owner);
+    }
+
+    function publish(kind: string, payload: var): void {
+        if (root._subs.length === 0)
+            return;
+
+        const record = {
+            kind: kind,
+            at: Date.now(),
+            payload: payload ?? ({})
+        };
+        root._lastEvent = record;
+
+        for (const sub of root._subs) {
+            if (sub.kinds.length > 0 && !sub.kinds.includes(kind))
+                continue;
+            try {
+                sub.callback(record);
+            } catch (e) {
+                console.warn(`ProfileEvents: subscriber '${sub.owner}' threw on '${kind}': ${e}`);
+            }
+        }
+    }
+
+    readonly property var _rawEventKinds: ({
+        openwindow: "window.open",
+        closewindow: "window.close",
+        activewindow: "window.focus",
+        workspace: "workspace.focus",
+        monitoradded: "monitor.change",
+        monitorremoved: "monitor.change",
+        focusedmon: "monitor.change"
+    })
+
+    Connections {
+        target: Hypr
+        enabled: !root.idle
+
+        function onRawEvent(name: string, data: string): void {
+            root.publish("compositor.raw", { name: name, data: data });
+            const mapped = root._rawEventKinds[name];
+            if (mapped)
+                root.publish(mapped, { name: name, data: data });
+        }
+    }
+
+    Connections {
+        target: ProfileEngine
+        enabled: !root.idle
+
+        function onPhaseChanged(id: string, from: string, to: string): void {
+            root.publish("profile.phase", { profile: id, from: from, to: to });
+        }
+
+        function onAnomalySurfaced(id: string, anomaly: var): void {
+            root.publish("profile.anomaly", { profile: id, anomaly: anomaly });
+        }
+    }
+
+    Connections {
+        target: ResourceEngine
+        enabled: !root.idle
+
+        function onClaimRegistered(claim: var): void {
+            root.publish("resource.claim", { action: "register", claim: claim });
+        }
+
+        function onClaimReleased(claim: var): void {
+            root.publish("resource.claim", { action: "release", claim: claim });
+        }
+
+        function onNegotiationRaised(negotiation: var): void {
+            root.publish("resource.negotiation", { action: "raised", negotiation: negotiation });
+        }
+
+        function onNegotiationResolved(negotiation: var, decision: string): void {
+            root.publish("resource.negotiation", { action: "resolved", decision: decision, negotiation: negotiation });
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
+++ b/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
@@ -1,0 +1,287 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import qs.services.profile
+
+// Cross-domain claim arbitration (docs/archive/OPT-IN-FEATURES.md section
+// 2). Tracks *claims*, never continuous usage: every state change here is
+// driven by a register/release call, so this singleton owns no timer, no
+// process and no file watch, and does exactly nothing until a profile
+// registers something. `dormant` is that guarantee made observable.
+//
+// Three boundaries this file must never cross, in order of importance:
+//   1. It never terminates anything. The only stop path is
+//      suspendRequested -> the owning profile's own gracefulStop hook
+//      (ProfileEngine.requestSuspend), and a claim stays registered until
+//      that owner releases it, so the claim table keeps telling the truth
+//      even if the owner's stop is slow or declines.
+//   2. It never touches kernel/sysctl, and never probes hardware. Capacity
+//      is *declared* by whoever knows how to measure it, via
+//      declareResource(); an undeclared resource is tracked but never
+//      arbitrated. Core declares no resources at all, which is why a base
+//      install can never raise a negotiation.
+//   3. It never resolves a conflict on its own. Contention only ever
+//      produces a negotiation the user answers.
+Singleton {
+    id: root
+
+    readonly property var claims: root._claims
+    readonly property var resources: root._resources
+
+    // Head of the negotiation queue -- the one the prompt is showing.
+    // Queued rather than concurrent so two simultaneous conflicts can't
+    // stack two modal prompts on top of each other.
+    readonly property var pending: root._queue.length > 0 ? root._queue[0] : null
+    readonly property int pendingCount: root._queue.length
+
+    readonly property bool dormant: root._claims.length === 0 && root._queue.length === 0
+
+    readonly property real defaultSafetyMargin: 0.1
+
+    signal claimRegistered(claim: var)
+    signal claimReleased(claim: var)
+    signal negotiationRaised(negotiation: var)
+    signal negotiationResolved(negotiation: var, decision: string)
+    signal suspendRequested(owner: string, claim: var)
+
+    property var _claims: []
+    property var _resources: ({})
+    property var _queue: []
+    property var _ignoredPairs: ({})
+    property int _nextId: 1
+
+    function declareResource(key: string, spec: var): bool {
+        if (!key)
+            return false;
+        const next = Object.assign({}, root._resources);
+        next[key] = {
+            key: key,
+            label: spec?.label ?? key,
+            unit: spec?.unit ?? "",
+            capacity: (typeof spec?.capacity === "number" && spec.capacity > 0) ? spec.capacity : 0,
+            safetyMargin: (typeof spec?.safetyMargin === "number") ? spec.safetyMargin : root.defaultSafetyMargin,
+            exclusive: !!spec?.exclusive
+        };
+        root._resources = next;
+        return true;
+    }
+
+    function undeclareResource(key: string): void {
+        if (!Object.prototype.hasOwnProperty.call(root._resources, key))
+            return;
+        const next = Object.assign({}, root._resources);
+        delete next[key];
+        root._resources = next;
+    }
+
+    function resourceSpec(key: string): var {
+        return root._resources[key] ?? null;
+    }
+
+    // The Phase 1 claim shape. `origin` is the seam that keeps dynamic
+    // claims an additive change rather than a breaking one: Phase 1
+    // consumers declare their claims in profile config and register them
+    // verbatim ("static"), a later runtime-declared claim registers
+    // through this same call with origin "dynamic", and nothing else about
+    // the struct or the arbitration path differs. register() upserts on
+    // id for the same reason -- re-registering an existing id is already
+    // the update path a dynamic claim needs.
+    function normalizeClaim(input: var): var {
+        if (!input || !input.id || !input.owner || !input.resource)
+            return null;
+        return {
+            id: String(input.id),
+            owner: String(input.owner),
+            resource: String(input.resource),
+            amount: (typeof input.amount === "number" && isFinite(input.amount)) ? input.amount : 0,
+            priority: input.priority === "foreground" ? "foreground" : "background",
+            label: input.label ? String(input.label) : String(input.id),
+            origin: input.origin === "dynamic" ? "dynamic" : "static"
+        };
+    }
+
+    function claimById(id: string): var {
+        return root._claims.find(c => c.id === id) ?? null;
+    }
+
+    function claimsFor(resource: string): var {
+        return root._claims.filter(c => c.resource === resource);
+    }
+
+    function claimsOf(owner: string): var {
+        return root._claims.filter(c => c.owner === owner);
+    }
+
+    // Returns the negotiation this registration raised, or null. A caller
+    // that has to wait for an answer (ProfileEngine's NEGOTIATE phase)
+    // uses that return value; a caller that doesn't care can ignore it.
+    function register(input: var): var {
+        const claim = root.normalizeClaim(input);
+        if (!claim) {
+            console.warn(`ResourceEngine: rejected malformed claim ${JSON.stringify(input)}`);
+            return null;
+        }
+
+        const next = root._claims.filter(c => c.id !== claim.id);
+        next.push(claim);
+        root._claims = next;
+        root.claimRegistered(claim);
+
+        const contention = root._contentionFor(claim);
+        if (!contention)
+            return null;
+        return root._raise(contention);
+    }
+
+    function release(id: string): void {
+        const claim = root.claimById(id);
+        if (!claim)
+            return;
+        root._claims = root._claims.filter(c => c.id !== id);
+        root._dropNegotiationsInvolving(id);
+        root.claimReleased(claim);
+    }
+
+    function releaseOwner(owner: string): void {
+        for (const claim of root.claimsOf(owner))
+            root.release(claim.id);
+    }
+
+    // "suspend" -> ask the claimant's owner to stop (never a kill, and
+    // never a release from here -- the owner releases when it has actually
+    // stopped). "keep" -> both claims stand, this conflict is answered but
+    // an identical one can be raised again after the claims change.
+    // "ignore" -> like keep, and this owner pair stops asking about this
+    // resource for the rest of the session.
+    readonly property var decisions: ["suspend", "keep", "ignore"]
+
+    function resolve(decision: string): bool {
+        const negotiation = root.pending;
+        if (!negotiation)
+            return false;
+        if (!root.decisions.includes(decision)) {
+            console.warn(`ResourceEngine: '${decision}' is not one of ${root.decisions.join("/")}`);
+            return false;
+        }
+
+        root._queue = root._queue.slice(1);
+
+        if (decision === "ignore") {
+            const next = Object.assign({}, root._ignoredPairs);
+            next[negotiation.pairKey] = true;
+            root._ignoredPairs = next;
+        } else if (decision === "suspend") {
+            if (negotiation.claimantSuspendable)
+                root.suspendRequested(negotiation.claimant.owner, negotiation.claimant);
+            else
+                console.warn(`ResourceEngine: no graceful-stop hook for '${negotiation.claimant.owner}', suspend declined`);
+        }
+
+        root.negotiationResolved(negotiation, decision);
+        return true;
+    }
+
+    function isIgnored(a: string, b: string, resource: string): bool {
+        return !!root._ignoredPairs[root._pairKey(a, b, resource)];
+    }
+
+    function clearIgnored(): void {
+        root._ignoredPairs = ({});
+    }
+
+    function reset(): void {
+        root._claims = [];
+        root._queue = [];
+        root._ignoredPairs = ({});
+        root._resources = ({});
+    }
+
+    function _pairKey(a: string, b: string, resource: string): string {
+        return [a, b].sort().join("|") + "@" + resource;
+    }
+
+    // Only ever compares claims on one resource, and only when that
+    // resource has been declared -- an undeclared resource has no capacity
+    // and no exclusivity to reason about, so treating it as contended
+    // would be a guess, and guessing here means prompting the user about
+    // nothing.
+    function _contentionFor(claim: var): var {
+        const spec = root.resourceSpec(claim.resource);
+        if (!spec)
+            return null;
+
+        const others = root.claimsFor(claim.resource).filter(c => c.id !== claim.id);
+        if (others.length === 0)
+            return null;
+
+        const claimant = root._incumbent(others);
+        if (!claimant)
+            return null;
+
+        if (root.isIgnored(claim.owner, claimant.owner, claim.resource))
+            return null;
+
+        if (spec.exclusive)
+            return root._negotiation(spec, claimant, claim, "exclusive", 0, 0);
+
+        if (spec.capacity <= 0)
+            return null;
+
+        const total = root.claimsFor(claim.resource).reduce((sum, c) => sum + c.amount, 0);
+        const budget = spec.capacity * (1 - spec.safetyMargin);
+        if (total <= budget)
+            return null;
+
+        return root._negotiation(spec, claimant, claim, "capacity", total, budget);
+    }
+
+    // Whoever the prompt will offer to suspend: the cheapest thing to give
+    // up first (background before foreground), then the largest claim,
+    // so the offer is deterministic rather than registration-order luck.
+    function _incumbent(others: var): var {
+        const ranked = others.slice().sort((a, b) => {
+            if (a.priority !== b.priority)
+                return a.priority === "background" ? -1 : 1;
+            return b.amount - a.amount;
+        });
+        return ranked[0] ?? null;
+    }
+
+    function _negotiation(spec: var, claimant: var, requestor: var, reason: string, total: real, budget: real): var {
+        return {
+            id: root._nextId,
+            resource: spec.key,
+            resourceLabel: spec.label,
+            unit: spec.unit,
+            reason: reason,
+            total: total,
+            budget: budget,
+            claimant: claimant,
+            requestor: requestor,
+            claimantSuspendable: ProfileEngine.canSuspend(claimant.owner),
+            pairKey: root._pairKey(requestor.owner, claimant.owner, spec.key)
+        };
+    }
+
+    function _raise(negotiation: var): var {
+        root._nextId = root._nextId + 1;
+        root._queue = root._queue.concat([negotiation]);
+        root.negotiationRaised(negotiation);
+        return negotiation;
+    }
+
+    // A claim going away takes its unanswered conflicts with it -- asking
+    // the user to arbitrate between something that has already stopped and
+    // something else is worse than not asking at all.
+    function _dropNegotiationsInvolving(claimId: string): void {
+        const kept = root._queue.filter(n => n.claimant.id !== claimId && n.requestor.id !== claimId);
+        if (kept.length === root._queue.length)
+            return;
+        const dropped = root._queue.filter(n => n.claimant.id === claimId || n.requestor.id === claimId);
+        root._queue = kept;
+        for (const n of dropped)
+            root.negotiationResolved(n, "withdrawn");
+    }
+}

--- a/Configs/quickshell/aphotic/services/profile/RingBuffer.qml
+++ b/Configs/quickshell/aphotic/services/profile/RingBuffer.qml
@@ -1,0 +1,69 @@
+import QtQuick
+
+// Fixed-capacity record-the-last-N primitive, built once here because
+// Gaming, Dev and Security all want the same "keep the last N of {stream},
+// dump on {trigger}" shape (docs/APHOTIC_UNIFIED_VISION.md section 3.5).
+// Not a singleton: a consumer instantiates one per stream it records.
+//
+// Preallocated slots plus a moving head, so push() is O(1) with no
+// allocation and no array shift at capacity -- the difference matters
+// because the intended consumers push on every frame/event of a stream,
+// not once a second like a sparkline.
+//
+// Kept deliberately behind a narrow surface (push/dump/clear/at) so the
+// decision to keep it in QML rather than a compiled core component stays
+// reversible -- see the PR for this branch.
+QtObject {
+    id: root
+
+    property int capacity: 256
+
+    readonly property int count: root._count
+    readonly property int dropped: root._dropped
+    readonly property bool full: root._count >= root.capacity
+    readonly property var newest: root._count > 0 ? root._slots[(root._head - 1 + root.capacity) % root.capacity] : null
+    readonly property var oldest: root._count > 0 ? root._slots[(root._head - root._count + root.capacity) % root.capacity] : null
+
+    property var _slots: new Array(root.capacity)
+    property int _head: 0
+    property int _count: 0
+    property int _dropped: 0
+
+    onCapacityChanged: root.clear()
+
+    function push(value: var): void {
+        if (root.capacity <= 0)
+            return;
+        root._slots[root._head] = value;
+        root._head = (root._head + 1) % root.capacity;
+        if (root._count < root.capacity)
+            root._count = root._count + 1;
+        else
+            root._dropped = root._dropped + 1;
+    }
+
+    // Oldest to newest. Allocates -- a dump is the trigger-time operation,
+    // not the hot path.
+    function dump(): var {
+        const out = [];
+        const start = (root._head - root._count + root.capacity) % root.capacity;
+        for (let i = 0; i < root._count; i++)
+            out.push(root._slots[(start + i) % root.capacity]);
+        return out;
+    }
+
+    // 0 is the oldest retained entry.
+    function at(index: int): var {
+        if (index < 0 || index >= root._count)
+            return null;
+        const start = (root._head - root._count + root.capacity) % root.capacity;
+        return root._slots[(start + index) % root.capacity];
+    }
+
+    function clear(): void {
+        root._slots = new Array(root.capacity);
+        root._head = 0;
+        root._count = 0;
+        root._dropped = 0;
+    }
+}

--- a/Configs/quickshell/aphotic/services/profile/StateSnapshot.qml
+++ b/Configs/quickshell/aphotic/services/profile/StateSnapshot.qml
@@ -1,0 +1,340 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+
+// One capture/restore path for desktop state, shared by every profile
+// regardless of which domain triggered the transition -- a gaming profile
+// and a security profile restore through the exact same code, so "did it
+// come back" is one behaviour to get right instead of four.
+//
+// Restore is the only automatic action anywhere in this substrate, and it
+// is a rollback: every part is diffed against live state first and skipped
+// when it already matches, so restoring never writes back something the
+// user changed themselves and never re-applies a monitor mode that is
+// already correct.
+//
+// The monitors part is asynchronous, and has to be. Quickshell's cached
+// Hyprland monitor data (HyprlandMonitor.lastIpcObject) is only refreshed
+// on monitor add/remove/focus events, and a runtime monitor
+// reconfiguration emits none of those -- verified live: after
+// `hl.monitor({... scale = 1.25})`, hyprctl reports the new scale and
+// Quickshell still reports the old one indefinitely. Capturing from that
+// cache silently records stale geometry and the restore diff then compares
+// stale against stale and skips, so both sides read `hyprctl -j monitors`
+// directly instead. That is one process spawn per capture and per restore
+// of a profile that asked for monitors, and none at all otherwise.
+//
+// Deliberately in-memory only. Persisting snapshots across a shell restart
+// would mean deciding whether to auto-roll-back state captured by a
+// profile that died with the shell, which is a real design question with
+// no consumer yet -- see the PR for this branch.
+Singleton {
+    id: root
+
+    readonly property var allParts: ["theme", "workspace", "monitors", "notifications"]
+
+    readonly property var snapshots: root._snapshots
+    readonly property var capturedIds: Object.keys(root._snapshots)
+    readonly property int queuedJobs: root._jobs.length
+
+    // What the last rollback actually wrote back. restore() is
+    // asynchronous, so this is how a caller (or `qs ipc call profile
+    // state`) sees which parts genuinely differed.
+    readonly property var lastRestore: root._lastRestore
+
+    signal captured(profileId: string, parts: var)
+    signal restored(profileId: string, applied: var)
+
+    property var _snapshots: ({})
+    property var _jobs: []
+    property bool _reading: false
+    property var _lastRestore: null
+
+    // Returns the snapshot. `complete` is false until the monitors read
+    // lands; callers that must not mutate state before the capture is
+    // finished wait for captured() (ProfileEngine parks in APPLY).
+    function capture(profileId: string, parts: var): var {
+        const wanted = (Array.isArray(parts) && parts.length > 0 ? parts : root.allParts).filter(p => root.allParts.includes(p));
+        const snapshot = {
+            profileId: profileId,
+            at: Date.now(),
+            parts: wanted,
+            complete: !wanted.includes("monitors")
+        };
+
+        if (wanted.includes("theme"))
+            snapshot.theme = root._captureTheme();
+        if (wanted.includes("workspace"))
+            snapshot.workspace = root._captureWorkspace();
+        if (wanted.includes("notifications"))
+            snapshot.notifications = root._captureNotifications();
+
+        root._store(profileId, snapshot);
+
+        if (snapshot.complete)
+            root.captured(profileId, wanted);
+        else
+            root._enqueue({ kind: "capture", profileId: profileId });
+
+        return snapshot;
+    }
+
+    function snapshotOf(profileId: string): var {
+        return root._snapshots[profileId] ?? null;
+    }
+
+    function isComplete(profileId: string): bool {
+        return !!root._snapshots[profileId]?.complete;
+    }
+
+    function discard(profileId: string): void {
+        if (!root._snapshots[profileId])
+            return;
+        const next = Object.assign({}, root._snapshots);
+        delete next[profileId];
+        root._snapshots = next;
+    }
+
+    // Emits restored(profileId, appliedParts) when the rollback has been
+    // issued; appliedParts holds only the parts that actually differed.
+    function restore(profileId: string): bool {
+        const snapshot = root._snapshots[profileId];
+        if (!snapshot) {
+            root.restored(profileId, []);
+            return false;
+        }
+        if (!snapshot.monitors) {
+            root._finishRestore(profileId, []);
+            return true;
+        }
+        root._enqueue({ kind: "restore", profileId: profileId });
+        return true;
+    }
+
+    function _store(profileId: string, snapshot: var): void {
+        const next = Object.assign({}, root._snapshots);
+        next[profileId] = snapshot;
+        root._snapshots = next;
+    }
+
+    function _finishRestore(profileId: string, applied: var): void {
+        const snapshot = root._snapshots[profileId];
+        if (!snapshot)
+            return;
+
+        if (snapshot.theme && root._restoreTheme(snapshot.theme))
+            applied.push("theme");
+        if (snapshot.notifications && root._restoreNotifications(snapshot.notifications))
+            applied.push("notifications");
+        if (snapshot.workspace && root._restoreWorkspace(snapshot.workspace))
+            applied.push("workspace");
+
+        root.discard(profileId);
+        root._lastRestore = { profileId: profileId, applied: applied, at: Date.now() };
+        root.restored(profileId, applied);
+    }
+
+    function _captureTheme(): var {
+        return {
+            theme: Themes.activeTheme,
+            wallpaper: Themes.activeWallpaper
+        };
+    }
+
+    function _restoreTheme(snap: var): bool {
+        if (!snap.theme)
+            return false;
+        if (snap.theme === Themes.activeTheme && snap.wallpaper === Themes.activeWallpaper)
+            return false;
+        Themes.setTheme(snap.theme, snap.wallpaper);
+        return true;
+    }
+
+    // Window-to-workspace placement is recorded but never replayed:
+    // dragging the user's windows back where a profile found them is a
+    // destructive action dressed up as a rollback. What restores is focus.
+    function _captureWorkspace(): var {
+        return {
+            focusedMonitor: Hypr.focusedMonitor?.name ?? "",
+            focusedWorkspace: Hypr.activeWsId,
+            monitors: Hypr.monitors.values.map(m => ({
+                name: m.name,
+                activeWorkspace: m.lastIpcObject?.activeWorkspace?.id ?? -1,
+                specialWorkspace: m.lastIpcObject?.specialWorkspace?.name ?? ""
+            })),
+            toplevels: Hypr.toplevels.values.map(t => ({
+                address: t.address,
+                workspace: t.workspace?.id ?? -1,
+                title: t.title ?? ""
+            }))
+        };
+    }
+
+    // The originally-focused monitor's workspace goes last so focus ends up
+    // where it started -- a workspace focus follows that workspace to
+    // whichever monitor owns it, which is also why no focusmonitor dispatch
+    // is needed. Special workspaces are recorded but not replayed: the only
+    // way to set one is a toggle, and a toggle is not a rollback.
+    function _restoreWorkspace(snap: var): bool {
+        const focusLast = snap.monitors.find(m => m.name === snap.focusedMonitor);
+        const others = snap.monitors.filter(m => m.name !== snap.focusedMonitor);
+        let changed = false;
+
+        for (const entry of others.concat(focusLast ? [focusLast] : [])) {
+            const live = Hypr.monitors.values.find(m => m.name === entry.name);
+            if (!live || entry.activeWorkspace < 0)
+                continue;
+
+            const wsDiffers = (live.lastIpcObject?.activeWorkspace?.id ?? -1) !== entry.activeWorkspace;
+            const focusDiffers = entry.name === snap.focusedMonitor && Hypr.focusedMonitor?.name !== entry.name;
+            if (!wsDiffers && !focusDiffers)
+                continue;
+
+            Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ workspace = ${entry.activeWorkspace} })` : `workspace ${entry.activeWorkspace}`);
+            changed = true;
+        }
+        return changed;
+    }
+
+    function monitorState(ipc: var): var {
+        return {
+            name: ipc.name ?? "",
+            disabled: !!ipc.disabled,
+            width: ipc.width ?? 0,
+            height: ipc.height ?? 0,
+            refresh: typeof ipc.refreshRate === "number" ? ipc.refreshRate.toFixed(2) : "preferred",
+            x: ipc.x ?? 0,
+            y: ipc.y ?? 0,
+            scale: ipc.scale ?? 1,
+            transform: ipc.transform ?? 0
+        };
+    }
+
+    function monitorKey(state: var): string {
+        return `${state.disabled}|${state.width}x${state.height}@${state.refresh}|${state.x}x${state.y}|${state.scale}|${state.transform}`;
+    }
+
+    // Monitor layout is config, not an action, so this is `hyprctl` rather
+    // than a dispatch -- and the two config parsers take it differently:
+    // `hyprctl keyword` is refused outright under the Lua parser ("keyword
+    // can't work with non-legacy parsers"), where the runtime equivalent is
+    // hl.monitor() through `hyprctl eval`. Both forms verified live; the
+    // disabled branch is the one case not exercised (single-output rig).
+    function monitorCommand(state: var): string {
+        const mode = `${state.width}x${state.height}@${state.refresh}`;
+        if (Hypr.usingLua) {
+            if (state.disabled)
+                return `hyprctl eval 'hl.monitor({ output = "${state.name}", disabled = true })'`;
+            const fields = [`output = "${state.name}"`, `mode = "${mode}"`, `position = "${state.x}x${state.y}"`, `scale = ${state.scale}`];
+            if (state.transform)
+                fields.push(`transform = ${state.transform}`);
+            return `hyprctl eval 'hl.monitor({ ${fields.join(", ")} })'`;
+        }
+        if (state.disabled)
+            return `hyprctl keyword monitor '${state.name},disable'`;
+        const spec = `${state.name},${mode},${state.x}x${state.y},${state.scale}`;
+        return `hyprctl keyword monitor '${state.transform ? `${spec},transform,${state.transform}` : spec}'`;
+    }
+
+    function _captureNotifications(): var {
+        return {
+            dnd: Settings.dndEnabled
+        };
+    }
+
+    function _restoreNotifications(snap: var): bool {
+        if (Settings.dndEnabled === snap.dnd)
+            return false;
+        Settings.dndEnabled = snap.dnd;
+        return true;
+    }
+
+    // One reader, one job at a time. The _reading guard is load-bearing, not
+    // defensive: completing a capture emits captured(), which runs the
+    // profile's onApply, which may itself capture -- that re-entrant
+    // _enqueue lands while this handler is still unwinding, so without the
+    // flag both it and the tail of _completeJob would start a read.
+    function _enqueue(job: var): void {
+        root._jobs = root._jobs.concat([job]);
+        root._pump();
+    }
+
+    function _pump(): void {
+        if (root._reading || root._jobs.length === 0)
+            return;
+        root._reading = true;
+        monitorRead.exec(["hyprctl", "-j", "monitors"]);
+    }
+
+    function _completeJob(live: var): void {
+        root._reading = false;
+        const job = root._jobs[0];
+        root._jobs = root._jobs.slice(1);
+
+        if (job) {
+            if (job.kind === "capture")
+                root._completeCapture(job.profileId, live);
+            else
+                root._completeRestore(job.profileId, live);
+        }
+
+        root._pump();
+    }
+
+    function _completeCapture(profileId: string, live: var): void {
+        const snapshot = root._snapshots[profileId];
+        if (!snapshot)
+            return;
+        snapshot.monitors = live.map(m => root.monitorState(m));
+        snapshot.complete = true;
+        root._store(profileId, snapshot);
+        root.captured(profileId, snapshot.parts);
+    }
+
+    function _completeRestore(profileId: string, live: var): void {
+        const snapshot = root._snapshots[profileId];
+        if (!snapshot)
+            return;
+
+        const commands = [];
+        for (const entry of snapshot.monitors) {
+            const current = live.find(m => m.name === entry.name);
+            if (!current)
+                continue;
+            if (root.monitorKey(root.monitorState(current)) === root.monitorKey(entry))
+                continue;
+            commands.push(root.monitorCommand(entry));
+        }
+
+        const applied = [];
+        if (commands.length > 0) {
+            monitorConfig.exec(["sh", "-c", commands.join("; ")]);
+            applied.push("monitors");
+        }
+        root._finishRestore(profileId, applied);
+    }
+
+    Process {
+        id: monitorRead
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let live = [];
+                try {
+                    live = JSON.parse(text);
+                } catch (e) {
+                    console.warn(`StateSnapshot: could not read monitors: ${e}`);
+                }
+                root._completeJob(Array.isArray(live) ? live : []);
+            }
+        }
+    }
+
+    Process {
+        id: monitorConfig
+    }
+}

--- a/Configs/quickshell/aphotic/services/profile/qmldir
+++ b/Configs/quickshell/aphotic/services/profile/qmldir
@@ -1,0 +1,6 @@
+module qs.services.profile
+singleton ProfileEngine 1.0 ProfileEngine.qml
+singleton ProfileEvents 1.0 ProfileEvents.qml
+singleton ResourceEngine 1.0 ResourceEngine.qml
+singleton StateSnapshot 1.0 StateSnapshot.qml
+RingBuffer 1.0 RingBuffer.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.components
+import qs.config
 import qs.modules.bar
 import qs.modules.launcher
 import qs.modules.notifications
@@ -18,7 +19,9 @@ import qs.modules.notificationcenter
 import qs.modules.pkginstall
 import qs.modules.wallpaperpicker
 import qs.modules.keybinds
+import qs.modules.negotiation
 import qs.services
+import qs.services.profile
 
 ShellRoot {
     id: root
@@ -242,6 +245,112 @@ ShellRoot {
                 fn();
             else
                 console.warn(`aphotic toggle: unknown name '${name}'`);
+        }
+    }
+
+    // Mounted only while the Resource Engine actually has a conflict to
+    // ask about, so a base install with no opt-in profile carries no
+    // negotiation surface at all rather than a hidden one per screen.
+    // Unmount is held for one animation duration (same closeTimer shape as
+    // PkgInstallWindow) so answering the prompt plays the card's fade-out
+    // instead of the window vanishing under it.
+    readonly property bool negotiationOpen: ResourceEngine.pending !== null
+    property bool negotiationMounted: false
+
+    onNegotiationOpenChanged: {
+        if (root.negotiationOpen) {
+            negotiationCloseTimer.stop();
+            root.negotiationMounted = true;
+        } else {
+            negotiationCloseTimer.restart();
+        }
+    }
+
+    Timer {
+        id: negotiationCloseTimer
+        interval: Tokens.anim.durations.normal
+        onTriggered: root.negotiationMounted = false
+    }
+
+    LazyLoader {
+        active: root.negotiationMounted
+
+        NegotiationWindow {}
+    }
+
+    // The profile substrate's inspection/drive surface (Phase 0 --
+    // docs/APHOTIC_UNIFIED_VISION.md section 3.5). Lives here rather than
+    // inside the singletons so declaring the IPC target doesn't
+    // instantiate them: ProfileEngine, ProfileEvents and StateSnapshot
+    // stay uncreated until a plugin (or one of these calls) first touches
+    // them. Profile *registration* is deliberately not here -- a
+    // descriptor carries hooks, which don't cross an IPC boundary.
+    IpcHandler {
+        target: "profile"
+
+        function state(): string {
+            return JSON.stringify({
+                profiles: Object.keys(ProfileEngine.profiles),
+                active: ProfileEngine.activeIds,
+                phases: ProfileEngine.states,
+                resources: ResourceEngine.resources,
+                claims: ResourceEngine.claims,
+                pending: ResourceEngine.pending,
+                pendingCount: ResourceEngine.pendingCount,
+                dormant: ResourceEngine.dormant,
+                snapshots: StateSnapshot.capturedIds,
+                lastRestore: StateSnapshot.lastRestore,
+                subscribers: ProfileEvents.subscriberCount
+            }, null, 2);
+        }
+
+        function declare(resource: string, spec: string): string {
+            try {
+                return ResourceEngine.declareResource(resource, JSON.parse(spec || "{}")) ? "ok" : "rejected";
+            } catch (e) {
+                return `bad spec: ${e}`;
+            }
+        }
+
+        function claim(json: string): string {
+            try {
+                const negotiation = ResourceEngine.register(JSON.parse(json));
+                return negotiation ? `negotiation ${negotiation.id}` : "ok";
+            } catch (e) {
+                return `bad claim: ${e}`;
+            }
+        }
+
+        function release(id: string): string {
+            ResourceEngine.release(id);
+            return "ok";
+        }
+
+        function resolve(decision: string): string {
+            if (!ResourceEngine.pending)
+                return "nothing pending";
+            return ResourceEngine.resolve(decision) ? "ok" : `expected one of ${ResourceEngine.decisions.join("/")}`;
+        }
+
+        function activate(id: string, trigger: string): string {
+            return ProfileEngine.activate(id, trigger) ? ProfileEngine.phaseOf(id) : "refused";
+        }
+
+        function deactivate(id: string, reason: string): string {
+            return ProfileEngine.deactivate(id, reason) ? ProfileEngine.phaseOf(id) : "refused";
+        }
+
+        function snapshot(id: string, parts: string): string {
+            return JSON.stringify(StateSnapshot.capture(id, parts ? parts.split(",") : []), null, 2);
+        }
+
+        function restore(id: string): string {
+            return StateSnapshot.restore(id) ? "started" : "no snapshot";
+        }
+
+        function reset(): string {
+            ResourceEngine.reset();
+            return "ok";
         }
     }
 

--- a/tests/test_profile_substrate.sh
+++ b/tests/test_profile_substrate.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# tests/test_profile_substrate.sh
+#
+# Structural guards for the Phase 0 profile substrate
+# (docs/APHOTIC_UNIFIED_VISION.md section 3.5). These are the invariants
+# that can regress silently -- a Timer added "just for now", a kill call
+# added to make a suspend actually stick, a resource declared in core so a
+# base install starts arbitrating. None of them show up as a broken shell,
+# which is exactly why they need a test.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+QS="Configs/quickshell/aphotic"
+SUB="$QS/services/profile"
+UI="$QS/modules/negotiation"
+
+for f in "$SUB/ProfileEngine.qml" "$SUB/ResourceEngine.qml" "$SUB/ProfileEvents.qml" \
+         "$SUB/StateSnapshot.qml" "$SUB/RingBuffer.qml" "$SUB/qmldir" \
+         "$UI/NegotiationWindow.qml" "$UI/NegotiationContent.qml" "$UI/qmldir"; do
+  [[ -f "$f" ]] || fail "missing $f"
+done
+
+# Every substrate type is reachable through its module, not an ad hoc import.
+for s in ProfileEngine ProfileEvents ResourceEngine StateSnapshot; do
+  grep -q "^singleton $s 1.0 $s.qml\$" "$SUB/qmldir" || fail "$s not registered as a singleton in $SUB/qmldir"
+done
+grep -q "^RingBuffer 1.0 RingBuffer.qml\$" "$SUB/qmldir" || fail "RingBuffer not registered in $SUB/qmldir"
+grep -q "^module qs.services.profile\$" "$SUB/qmldir" || fail "$SUB/qmldir has the wrong module name"
+
+# Single-sourced: exactly one definition of each engine, no per-domain copy.
+for s in ProfileEngine ResourceEngine; do
+  n=$(find "$QS" -name "$s.qml" | wc -l)
+  [[ "$n" -eq 1 ]] || fail "found $n copies of $s.qml -- the engines are single-sourced singletons"
+done
+
+# Zero cost when no profile is active: the substrate owns no timer and
+# watches no file. StateSnapshot's two Process objects are on-demand only.
+for f in "$SUB"/*.qml "$UI"/*.qml; do
+  grep -qE '^\s*Timer\s*\{' "$f" && fail "$f declares a Timer -- the substrate must add no polling"
+  grep -q 'FileView' "$f" && fail "$f uses a FileView -- the substrate must add no always-on file watch"
+  grep -qE '^\s*Timer\s*\{|triggeredOnStart' "$f" && fail "$f looks like it polls"
+done
+
+# Comments in these files legitimately name the things the code must never
+# do ("never touches kernel/sysctl"), so the safety greps below read code
+# only.
+code() { grep -vE "^\s*(//|\*|/\*)" "$1"; }
+
+# Never terminates a process directly -- suspension only ever goes through
+# the owning profile's own gracefulStop hook.
+for f in "$SUB"/*.qml "$UI"/*.qml; do
+  code "$f" | grep -qE '"(kill|pkill|killall|systemctl)"|\bkill -|SIGKILL|SIGTERM' \
+    && fail "$f can terminate a process -- the Resource Engine only asks the owning plugin to stop"
+done
+
+# Never touches kernel/sysctl.
+for f in "$SUB"/*.qml; do
+  code "$f" | grep -qE 'sysctl|/proc/sys/|/sys/kernel' && fail "$f touches kernel tunables"
+done
+
+# Core declares no resources, so a base install has nothing to arbitrate
+# and can never raise a negotiation prompt.
+# A literal resource key is the tell: shell.qml's IPC handler forwards a
+# caller-supplied one, which is fine; a hardcoded "gpu.vram" in core is not.
+for f in "$SUB"/*.qml "$UI"/*.qml "$QS/shell.qml"; do
+  code "$f" | grep -qE 'declareResource\("' \
+    && fail "$f declares a resource with a literal key -- capacity is declared by whoever can measure it, never by core"
+done
+
+# Static PanelWindow geometry: the prompt animates its content, never the
+# window (docs/APHOTIC_UNIFIED_VISION.md section 1.3).
+grep -qE '^\s*Behavior on (implicitWidth|implicitHeight|width|height|x|y)\b' "$UI/NegotiationWindow.qml" \
+  && fail "NegotiationWindow animates its own geometry -- PanelWindow geometry stays static"
+grep -q 'PanelWindow' "$UI/NegotiationWindow.qml" || fail "NegotiationWindow is not a PanelWindow"
+
+# Every binary the substrate can spawn -- the first element of any exec()
+# or `command:` array -- must already be declared in BOTH base profiles,
+# since the shell always loads in full regardless of install profile.
+for b in $(grep -ohE '(exec\(\[|command:\s*\[)"[^"]+"' "$SUB"/*.qml "$UI"/*.qml | grep -oE '"[^"]+"$' | tr -d '"' | sort -u); do
+  case "$b" in
+    sh) ;;
+    hyprctl) ;;
+    *) fail "substrate spawns '$b', which this test does not know to be a declared base dependency" ;;
+  esac
+done
+# The substrate introduces no new binary dependency: hyprctl is already
+# spawned by the base shell (services/Hypr.qml's keyboard-state read), so
+# nothing new needs declaring in profiles/base/{full,minimal}.toml. If a
+# future change adds a binary the base shell does not already use, that
+# rule kicks in and this guard is where it gets noticed.
+grep -q 'hyprctl' "$QS/services/Hypr.qml" \
+  || fail "hyprctl is no longer spawned by the base shell -- the substrate now adds it as a new dependency and it must be declared in both profiles/base/*.toml"
+
+echo "PASS: profile substrate"


### PR DESCRIPTION
Phase 0 of the shared substrate every opt-in domain profile (AI, Gaming, Dev, Security) sits on — `docs/APHOTIC_UNIFIED_VISION.md` §3.5, `docs/archive/OPT-IN-FEATURES.md` §§1–2, 9–10. Core infrastructure only: **no plugin consumes any of this yet, and that is the intended end state of this branch.** Gaming/Dev/Security Phase 1 stop being blocked on core; each becomes a plugin that registers a descriptor against the contract below.

## What's here

| Piece | File | Shape |
|---|---|---|
| Profile state machine | `services/profile/ProfileEngine.qml` | Singleton. One enforced transition table, described below. |
| Resource Engine | `services/profile/ResourceEngine.qml` | Singleton. Claims-based, contention-only, never kills. |
| Event bus | `services/profile/ProfileEvents.qml` | Singleton. Fan-out over event sources the shell already has. |
| State snapshot/restore | `services/profile/StateSnapshot.qml` | Singleton. Theme, workspace, monitors, notification state. |
| Ring-buffer primitive | `services/profile/RingBuffer.qml` | Component, one per recorded stream. |
| Negotiation prompt | `modules/negotiation/` | The one conflict surface, shared by every domain pair. |
| Inspection/drive surface | `shell.qml`, IPC target `profile` | `state / declare / claim / release / resolve / activate / deactivate / snapshot / restore / reset`. |

### The state machine is a table, not a convention

```
idle → detect → load → negotiate → apply → monitor ⇄ anomaly
                                              ↘ exit → restore → idle
```

A plugin registers `{ id, label, claims, snapshot, onLoad, onApply, onExit, onRestore, gracefulStop }` and implements no phase logic of its own — `ProfileEngine` drives the phases, the claim registration, the snapshot and the restore in the same order for every domain. Illegal transitions are refused and logged rather than silently allowed.

`anomaly` is a **real phase**, not a callback. `reportAnomaly()` parks the profile there with the anomaly surfaced and *nothing else happening*; the only exits are `acknowledgeAnomaly()` (back to `monitor`) or `deactivate()`. That makes "surface, don't auto-fix" a property of the machine — there is no transition out of `anomaly` that applies a remedy — rather than a comment somebody has to remember to obey.

### The Resource Engine's three hard boundaries

1. **It never terminates anything.** The only stop path is `suspendRequested` → the owning profile's own `gracefulStop` hook. The claim stays registered until that owner releases it, so the claim table keeps telling the truth even if the owner's stop is slow or declines. `[Suspend]` is only offered when the claimant's owner actually has a hook; without one the button is disabled and says why.
2. **It never probes hardware and never touches kernel/sysctl.** Capacity is *declared* by whoever knows how to measure it (`declareResource`), and an undeclared resource is tracked but never arbitrated. **Core declares no resources at all**, which is why a base install cannot raise a prompt — guarded by a test.
3. **It never resolves a conflict itself.** Contention only ever produces a negotiation the user answers: `[Suspend {claimant}] [Keep Running] [Ignore]`, one contract for every domain pair. `keep` answers this conflict; `ignore` also suppresses that owner-pair-on-that-resource for the session. Escape and click-outside both answer `keep` — a dismissal must never be the decision that suspends a workload.

### The event bus extends, it doesn't duplicate

`Hypr.qml` already owns the one `Connections` that understands Hyprland's raw event stream; this adds a `rawEvent` re-emit inside that existing handler (after the v2 filter, so no duplicates) and `ProfileEvents` hangs off it. The substrate half comes from the two engines' own signals. `publish()` lets a plugin inject events core has no business knowing about — a game launcher, a container runtime, the harness hooks' event log — so subscribers see one stream regardless of origin. Every `Connections` is `enabled: !idle`, so with zero subscribers the singleton is connected to nothing.

## Resolved open questions

### 1. Static vs. dynamic resource claims → static now, dynamic additive later

Phase 1 consumers declare claims in their profile descriptor and the engine registers them verbatim, per the doc's recommendation. The seam that keeps dynamic a non-breaking addition:

```js
{ id, owner, resource, amount, priority, label, origin }   // origin: "static" | "dynamic"
```

`register()` **upserts on `id`**, which is already the update path a runtime-declared claim needs, and `origin` distinguishes the two without any other field changing meaning. So dynamic claims already work through the same call — turning them on is a plugin-side decision, not a core migration. Verified: re-registering an existing id with `origin: "dynamic"` and a new amount replaces the claim and re-arbitrates.

### 2. Ring-buffer primitive → QML (`services/profile/RingBuffer.qml`), not a Go-core component

The doc leaned Go-core "for consistency with the installer core's role as source of truth". Checking that premise: **there is no Go core in this repo.** `core/` does not exist; the installer is bash (`lib/install/*.sh`) plus a little Python (`lib/toml/merge.py`). Choosing Go would mean introducing a compiler toolchain, an `install.sh` build step, and a packaging story — for a primitive with zero consumers today. `CONTRIBUTING.md` separately rules out vendoring a native plugin and asks for a real QML/JS substitute instead.

Beyond precedent: every prospective consumer (the three flight recorders) records a stream the *shell itself* observes — Hyprland events, `Process` output — so a separate process would have to be fed over IPC it doesn't otherwise need. The one genuine Go advantage is a recorder that survives a shell crash and flushes post-mortem, and that is a Phase 2 requirement with no consumer now. So: QML, with the surface (`push` / `dump` / `at` / `clear` / `dropped` / `newest` / `oldest`) kept deliberately narrow so re-implementing behind it later doesn't touch callers.

Being honest about the trade: this is the *simpler* option, and it is the right one only while nothing needs crash-survival. When a flight recorder does, that's the trigger to revisit — not a reason to build the harder thing now.

### 3. Engagement-mode visual signal → untouched, per the brief

Out of scope for this branch. It is a Security-domain design pass, not core substrate, and it stays open in §3.5.

## Zero-cost verification

Measured on the same box, branch vs. `main`, both run from a clean start as a transient user unit and left idle:

| | `main` | this branch, zero claims |
|---|---|---|
| CPU ticks / 60 s idle | 830 | **813** |
| RSS | 568 MB | 570 MB |
| child processes | `nmcli`, `tail` | `nmcli`, `tail` (identical) |
| substrate lines in the journal over 90 s idle | — | **0** |

Structurally: the substrate declares **no `Timer` and no `FileView` anywhere**. `StateSnapshot`'s two `Process` objects only ever run inside a capture or a restore. The negotiation surface does not exist at all until a conflict is pending (`LazyLoader`), rather than being a hidden `PanelWindow` per screen. `ProfileEngine`, `ProfileEvents` and `StateSnapshot` are not even instantiated at startup — the IPC handler lives in `shell.qml` specifically so declaring the target doesn't touch them. `tests/test_profile_substrate.sh` pins each of these.

## How this was tested

No plugin consumes the substrate, so verification drove it two ways: a **synthetic-profile harness** injected into a scratchpad copy of the shell (three profiles, one with a `gracefulStop` hook, one without, plus declared `gpu.vram` / `gpu.compute` resources), and the **pristine branch config with no test code in it at all**, driven purely through the `profile` IPC. Both ran against a live Hyprland session. Test scripts and the harness block are in the session scratchpad, not the repo.

22 assertions pass on the final source:

```
PASS  dormant with no claims                    PASS  ai gracefulStop invoked
PASS  activate ai reaches monitor               PASS  gaming proceeded to monitor
PASS  ai claim registered                       PASS  ai still in monitor (suspend != deactivate)
PASS  ai snapshot captured                      PASS  prompt surface torn down
PASS  gaming parks in negotiate                 PASS  anomaly parks in anomaly
PASS  one negotiation pending                   PASS  anomaly changes nothing else
PASS  prompt surface mapped                     PASS  acknowledge returns to monitor
PASS  claimant is the background claim           PASS  gaming back to idle
PASS  suspend offered (ai has a hook)            PASS  ai back to idle
PASS  ring wraps to capacity                    PASS  dormant again
PASS  ring counts drops                         PASS  no snapshots left
```

**Negotiation prompt, fired from the pristine config via two IPC claims** (17800 + 9000 MB against a 24576 MB declared capacity at a 10% margin → 22118 MB budget). `aphotic-negotiation` appears in `hyprctl layers` on raise and is gone after resolve; the rendered strings, read back off the live negotiation object:

```
Gaming Resource Conflict
Ollama (llama3:70b) is currently using 17800 MB of GPU VRAM.
Cyberpunk 2077 is requesting GPU VRAM at foreground priority.
Combined claims are 26800 against a 22118 MB safety budget.
[Suspend Ollama (llama3:70b)]  [Keep Running]  [Ignore]
```

Resolving `suspend` on the harness instance invoked `ai`'s own `gracefulStop("ai/ollama-vram")`, which released the claim; `gaming` then un-parked from `negotiate` through `apply` to `monitor`. Resolving on an owner with no hook logged `no graceful-stop hook for 'gaming', suspend declined` and stopped nothing. Also verified: `ignore` suppresses that pair on that resource but not on a different one; releasing a claim withdraws its unanswered negotiation; an undeclared resource is tracked and never arbitrated; a garbage decision is rejected rather than silently treated as `keep`.

**Snapshot/restore round-trip**, all four parts mutated then rolled back:

| Part | captured | mutated to | after restore |
|---|---|---|---|
| theme | `tokyonight` / `neon-skyline.jpg` | `…penguin-…png` | `neon-skyline.jpg` ✓ |
| notifications | `dnd: false` | `dnd: true` | `false` ✓ |
| workspace | ws 1 on `Virtual-1` | ws 4 | ws 1 ✓ |
| monitors | `1280x800@74.99 0x0 scale 1` | `100x0 scale 1.25` | `0x0 scale 1` ✓ |

And the negative cases, which matter more: restoring with nothing changed reports `applied: []` and writes nothing; a snapshot of only `monitors,notifications` with only those two mutated reports exactly `['monitors','notifications']` and leaves theme and workspace alone. The desktop was returned to its pre-test state.

**No screenshot.** Hyprland on the test box is stuck in its crashed-lockscreen fallback (a locker engaged the session and died before this work started, unrelated), which renders above every layer surface, so `grim` only captures Hyprland's own fallback text. Clearing it means unlocking the session, which the maintainer declined for now. The functional evidence above stands in: the surface is confirmed mapped at 1280x800 while pending and unmapped after resolve, and the rendered strings are dumped from the live object. A `grim` capture is still owed from a session where the compositor isn't lock-blocked.

## Bugs found by testing, not by reading

Both were real and both would have shipped broken:

1. **`hyprctl keyword` is refused under Hyprland's Lua config parser** — *"keyword can't work with non-legacy parsers. Use eval."* The monitor restore path now branches: `hyprctl eval 'hl.monitor({…})'` under Lua, `hyprctl keyword monitor …` under the legacy parser. Both forms verified live. (The `disabled` branch is the one case not exercised — the rig has a single output and disabling it isn't a safe test.)

2. **Quickshell's cached Hyprland monitor data is stale after a runtime reconfiguration.** `HyprlandMonitor.lastIpcObject` is only refreshed on monitor add/remove/focus events, and `hl.monitor()` emits none of those — after changing scale to 1.25, `hyprctl` reported the new value and Quickshell kept reporting the old one indefinitely. Capturing from that cache silently records stale geometry, and the restore diff then compares stale against stale and skips. Both sides now read `hyprctl -j monitors` directly, which makes the monitors part asynchronous, which in turn is why `ProfileEngine` parks in `APPLY` until `captured()` fires — a profile must not be allowed to change state before the snapshot of that state is finished.

A third, caught in self-review before testing: the snapshot reader's job queue could start two concurrent reads, because completing a capture emits `captured()` → runs the profile's `onApply` → which may itself capture, re-entering `_enqueue` while the completion handler is still unwinding. Guarded with an explicit `_reading` flag.

## Constraints checklist

- **Zero cost to base install** — table above; no new `Timer`, no new polling, no new always-on watcher, negotiation surface not instantiated until needed.
- **Static `PanelWindow` geometry** — `NegotiationWindow` is a static full-screen panel; all motion is the centred child card's opacity/scale, same as `modules/pkginstall`. Tested for by `test_profile_substrate.sh`.
- **Single-sourced singletons** — exactly one `ProfileEngine.qml` and one `ResourceEngine.qml` under the shell; the test pins it.
- **No comments beyond non-obvious reasoning** — each file carries a header stating its contract and boundaries (matching every existing service); inline comments only where the code can't carry it, e.g. why the monitors read is async and why the `_reading` guard is load-bearing.
- **No new binary dependency** — `hyprctl` only, already spawned by the base shell (`Hypr.qml`'s keyboard-state read), so nothing new to declare in `profiles/base/{full,minimal}.toml`.
- **No destructive automatic action** — the only automatic behaviour anywhere is restore, which is a diffed rollback that skips anything already matching.
- **YAGNI** — deliberate cuts below, rather than speculative hooks.

## Deliberate cuts

Each because nothing consumes them yet, and each is a decision rather than an omission:

- **Snapshots are in-memory only.** Persisting across a shell restart means deciding whether to auto-roll-back state captured by a profile that died with the shell — a real design question with no consumer.
- **Window→workspace placement is recorded but never replayed.** Dragging a user's windows back where a profile found them is a destructive action dressed up as a rollback. Focus restores; placement is data a plugin can offer later.
- **Special workspaces: recorded, not replayed.** The only way to set one is a toggle, and a toggle is not a rollback.
- **`services/CircularBuffer.qml` left alone.** It's the bar's sparkline history buffer, read by `NetworkSpeedPopout` and `Dashboard`. Folding it onto `RingBuffer` would change bar behaviour (its in-place `values` mutation doesn't currently notify bindings), so it belongs in its own change, not smuggled into a core-infrastructure PR.
- **No gaming/dev/security-shaped hooks.** §7's plugin directory tree is aspirational; nothing here is built to its shape.

## Notes for review

- Branched off `main` as instructed, not `modular`. §1.5 routes plugin-architecture work to `modular`; this is Phase 0 core substrate with no plugin-system coupling, and the branch name `feature/resource-engine-core` is the one §8 names for it. Worth a call on where it lands.
- `docs/APHOTIC_UNIFIED_VISION.md` §3.5 and `CLAUDE.md` are updated locally with the same resolutions, and stay gitignored.
- The `profile` IPC target is a real surface, not test scaffolding — it's the substrate's inspection path and the natural place for a future `aphotic profile` CLI verb — but it is also, with no plugin present, the only way to exercise any of this. Reasonable to want it narrowed once a plugin exists.
