### PR TITLE
profile: make gpu-vram capacity vendor-aware, add a generic claim source

### DIFF
--- a/Configs/quickshell/aphotic/services/ai/OllamaClaims.qml
+++ b/Configs/quickshell/aphotic/services/ai/OllamaClaims.qml
@@ -9,12 +9,10 @@ import qs.services.profile
 // first foreground claimant to arrive (Gaming, once it exists) negotiates
 // against a measured number instead of a placeholder.
 //
-// Capacity is declared here rather than in ResourceEngine because the
-// engine never probes hardware (see its header). nvidia-smi is the only
-// total-VRAM source this repo can currently trust; on an AMD/Intel
-// machine nothing is declared at all, which leaves "gpu-vram" undeclared
-// and therefore never arbitrated -- the correct degrade, not a gap to
-// paper over with a guessed capacity.
+// Capacity for "gpu-vram" belongs to GpuVramSource, not here -- one place
+// declares the resource, everything else only claims against it. Claims
+// registered before it is declared are tracked and simply never
+// arbitrated, so there is no ordering requirement between the two.
 //
 // Everything is driven off the runningModels the parent hands in, so this
 // owns no poll of its own; AiProviders' single background /api/ps timer is
@@ -29,19 +27,23 @@ QtObject {
     readonly property string owner: "ollama"
     readonly property string resource: "gpu-vram"
 
-    property bool _probed: false
-    property bool _declared: false
+    property bool _registered: false
 
-    onEnabledChanged: root._probe()
+    onEnabledChanged: root._register()
     onRunningModelsChanged: root._sync()
 
-    Component.onCompleted: root._probe()
+    Component.onCompleted: root._register()
 
-    function _probe(): void {
-        if (root._probed || !root.enabled)
+    function _register(): void {
+        if (root._registered || !root.enabled)
             return;
-        root._probed = true;
-        root._probeProc.running = true;
+        root._registered = true;
+        ProfileEngine.register({
+            id: root.owner,
+            label: qsTr("Ollama"),
+            gracefulStop: claim => root._unload(claim?.id ?? "")
+        });
+        root._sync();
     }
 
     // Re-registers only what actually changed: register() is an upsert
@@ -57,7 +59,7 @@ QtObject {
     // suspend -- offering to stop a CPU-resident model to free VRAM it was
     // never holding.
     function _sync(): void {
-        if (!root._declared)
+        if (!root._registered)
             return;
 
         const resident = {};
@@ -99,38 +101,6 @@ QtObject {
             model: id,
             keep_alive: 0
         })]);
-    }
-
-    // `sh -c` with a command -v guard rather than execing nvidia-smi
-    // directly: the binary is absent on most machines and a missing
-    // command is a Process-failed-to-start log line on every shell start
-    // (issue #43), where this just prints nothing.
-    property Process _probeProc: Process {
-        command: ["sh", "-c", "command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits"]
-        stdout: StdioCollector {
-            onStreamFinished: {
-                // Summed across cards because size_vram from /api/ps is
-                // itself a total across every GPU Ollama loaded onto --
-                // capacity has to be the same aggregate the claims are.
-                const total = text.trim().split("\n").map(line => parseInt(line.trim(), 10)).filter(v => !isNaN(v) && v > 0).reduce((a, b) => a + b, 0);
-                if (total <= 0)
-                    return;
-
-                ResourceEngine.declareResource(root.resource, {
-                    label: qsTr("GPU VRAM"),
-                    unit: "MB",
-                    capacity: total,
-                    safetyMargin: 0.1
-                });
-                ProfileEngine.register({
-                    id: root.owner,
-                    label: qsTr("Ollama"),
-                    gracefulStop: claim => root._unload(claim?.id ?? "")
-                });
-                root._declared = true;
-                root._sync();
-            }
-        }
     }
 
     property Process _unloadProc: Process {}

--- a/Configs/quickshell/aphotic/services/profile/GpuVramSource.qml
+++ b/Configs/quickshell/aphotic/services/profile/GpuVramSource.qml
@@ -1,0 +1,172 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell.Io
+import qs.services
+import qs.services.profile
+
+// The one place "gpu-vram" is ever declared, and the catch-all claim
+// source for GPU memory held by anything that isn't a domain plugin.
+//
+// Capacity is vendor-routed off SystemUsage.selectedGpu.vendor rather
+// than re-detected here -- that singleton already enumerates every
+// controller via lspci at startup and is the repo's single source of GPU
+// vendor truth.
+//
+// The per-process half exists because building an integration per
+// inference framework is unbounded and always one tool behind:
+// nvidia-smi reports every process holding GPU memory by PID, whatever
+// it happens to be. Those claims carry the real process name as owner,
+// so the negotiation prompt's "no graceful-stop hook" line names the
+// actual thing holding the memory.
+QtObject {
+    id: root
+
+    readonly property string resource: "gpu-vram"
+    readonly property string claimPrefix: "gpu-proc-"
+    readonly property string vendor: SystemUsage.selectedGpu?.vendor ?? ""
+
+    readonly property bool declared: root._declared
+
+    property bool _declared: false
+    property string _probeVendor: ""
+
+    onVendorChanged: root._probe()
+
+    Component.onCompleted: root._probe()
+
+    function _probe(): void {
+        if (root._declared || !root.vendor)
+            return;
+
+        switch (root.vendor) {
+        case "nvidia":
+            root._capacityProc.command = ["sh", "-c", "command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits"];
+            break;
+        case "amd":
+            // Connector entries (card0-DP-1) glob alongside the card
+            // itself and their `device` link resolves to the DRM node
+            // rather than the PCI device, so the same card can appear
+            // more than once -- resolve and dedupe before summing.
+            root._capacityProc.command = ["sh", "-c", "for f in /sys/class/drm/card*/device/mem_info_vram_total; do [ -r \"$f\" ] && readlink -f \"$f\"; done | sort -u | while read -r p; do cat \"$p\"; done"];
+            break;
+        default:
+            // Intel is integrated and carves its framebuffer out of
+            // system RAM, so there is no dedicated-VRAM total to
+            // declare. Leaving the resource undeclared is the whole
+            // answer: ResourceEngine never arbitrates a resource it has
+            // no capacity for, so nothing else needs a special case.
+            return;
+        }
+
+        root._probeVendor = root.vendor;
+        root._capacityProc.running = true;
+    }
+
+    // amdgpu reports bytes (kernel docs, "Misc AMDGPU driver
+    // information"); nvidia-smi reports MiB. Both are summed across
+    // cards to match the aggregate Ollama's own claims sum against.
+    function _declareFrom(text: string): void {
+        const values = text.trim().split("\n").map(line => parseInt(line.trim(), 10)).filter(v => !isNaN(v) && v > 0);
+        if (values.length === 0)
+            return;
+
+        const total = values.reduce((a, b) => a + b, 0);
+        const mb = root._probeVendor === "amd" ? Math.round(total / (1024 * 1024)) : total;
+        if (mb <= 0)
+            return;
+
+        ResourceEngine.declareResource(root.resource, {
+            label: qsTr("GPU VRAM"),
+            unit: "MB",
+            capacity: mb,
+            safetyMargin: 0.1
+        });
+        root._declared = true;
+    }
+
+    // Ollama is excluded because OllamaClaims registers a precise
+    // per-model claim from /api/ps already, and nvidia-smi's figure for
+    // the same runner is both larger (it includes CUDA context
+    // overhead) and coarser (one row for all loaded models).
+    //
+    // Matched on the path, not the bare basename: current Ollama runs
+    // /usr/lib/ollama/llama-server, and excluding every "llama-server"
+    // by name would also hide a user's own llama.cpp server -- exactly
+    // the process this catch-all exists to notice.
+    function _isOllama(path: string): bool {
+        const name = path.split("/").pop() ?? "";
+        return name === "ollama" || name === "ollama_llama_server" || path.indexOf("/ollama/") !== -1;
+    }
+
+    function _syncProcesses(text: string): void {
+        const seen = ({});
+
+        for (const line of text.trim().split("\n")) {
+            if (line.length === 0)
+                continue;
+            const parts = line.split(",").map(s => s.trim());
+            if (parts.length < 3)
+                continue;
+
+            const pid = parts[0];
+            const amount = parseInt(parts[1], 10);
+            const path = parts.slice(2).join(",");
+            if (!pid || isNaN(amount) || amount <= 0 || root._isOllama(path))
+                continue;
+
+            const name = path.split("/").pop() || path;
+            const id = `${root.claimPrefix}${pid}`;
+            seen[id] = true;
+
+            const known = ResourceEngine.claimById(id);
+            if (known && known.amount === amount && known.owner === name)
+                continue;
+
+            ResourceEngine.register({
+                id: id,
+                owner: name,
+                resource: root.resource,
+                amount: amount,
+                priority: "background",
+                label: name,
+                origin: "dynamic"
+            });
+        }
+
+        for (const claim of ResourceEngine.claims) {
+            if (claim.id.startsWith(root.claimPrefix) && !seen[claim.id])
+                ResourceEngine.release(claim.id);
+        }
+    }
+
+    property Process _capacityProc: Process {
+        stdout: StdioCollector {
+            onStreamFinished: root._declareFrom(text)
+        }
+    }
+
+    // NVIDIA only: this is the sole structured per-process GPU *memory*
+    // source nvidia-smi offers. `pmon` lists graphics processes too but
+    // reports no framebuffer figure (verified live -- its columns are
+    // utilisation percentages), and AMD exposes per-process VRAM only
+    // through DRM fdinfo (drm-resident-vram in /proc/<pid>/fdinfo/<fd>,
+    // kernel 5.14+), which needs a real parser and real hardware to
+    // verify before it can be trusted here.
+    property Process _processProc: Process {
+        command: ["sh", "-c", "command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi --query-compute-apps=pid,used_memory,process_name --format=csv,noheader,nounits"]
+        stdout: StdioCollector {
+            onStreamFinished: root._syncProcesses(text)
+        }
+    }
+
+    // Catch-all background accounting, deliberately slower than the 5s
+    // cadence Ollama's own /api/ps poll runs at.
+    property Timer _processPoll: Timer {
+        interval: 12000
+        repeat: true
+        triggeredOnStart: true
+        running: root._declared && root.vendor === "nvidia"
+        onTriggered: root._processProc.running = true
+    }
+}

--- a/Configs/quickshell/aphotic/services/profile/qmldir
+++ b/Configs/quickshell/aphotic/services/profile/qmldir
@@ -3,4 +3,5 @@ singleton ProfileEngine 1.0 ProfileEngine.qml
 singleton ProfileEvents 1.0 ProfileEvents.qml
 singleton ResourceEngine 1.0 ResourceEngine.qml
 singleton StateSnapshot 1.0 StateSnapshot.qml
+GpuVramSource 1.0 GpuVramSource.qml
 RingBuffer 1.0 RingBuffer.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -278,6 +278,14 @@ ShellRoot {
         NegotiationWindow {}
     }
 
+    // Declares "gpu-vram" (vendor-routed off SystemUsage's existing
+    // detection) and keeps the catch-all per-process claims for GPU
+    // memory held by anything that isn't a domain plugin. Mounted here
+    // rather than under services/ai because it is core resource
+    // accounting, not an AI surface -- Ollama only ever claims against
+    // the resource this declares.
+    GpuVramSource {}
+
     // The profile substrate's inspection/drive surface (Phase 0 --
     // docs/APHOTIC_UNIFIED_VISION.md section 3.5). Lives here rather than
     // inside the singletons so declaring the IPC target doesn't


### PR DESCRIPTION
Stacked on #69 (base is `feature/resource-engine-ollama-claimant`, since that hasn't merged yet — retarget to `main` once it does).

Fixes two real gaps in the Ollama claimant as merged.

## 1. Capacity was NVIDIA-hardcoded, in the wrong place

`OllamaClaims.qml` shelled straight to `nvidia-smi --query-gpu=memory.total`. That duplicated vendor knowledge `SystemUsage.qml` already owns — it enumerates every controller via `lspci` at startup and already branches `nvidia-smi`/`radeontop`/`intel_gpu_top` for stats — and it put resource *declaration* inside a domain consumer.

New `services/profile/GpuVramSource.qml` owns that declaration **exclusively**, routed off `SystemUsage.selectedGpu.vendor`. `OllamaClaims.qml` keeps registering its own claims exactly as before; it just no longer declares the resource. (Ordering doesn't matter: claims against an undeclared resource are tracked and simply never arbitrated.)

It lives in `services/profile/` next to `ResourceEngine.qml`, not under `services/ai/`, because it's core resource accounting, and it's mounted once from `shell.qml`.

## 2. Only Ollama's claims existed

Anything else holding VRAM was invisible to arbitration. Building an integration per inference framework is unbounded and always one tool behind, so `GpuVramSource` polls `nvidia-smi --query-compute-apps=pid,used_memory,process_name` — every process holding GPU memory by PID, whatever it is — on its own **12s** cadence, deliberately slower than Ollama's 5s poll since this is background accounting.

Claims register as `gpu-proc-<pid>` with the **real process name** as owner, which is what makes `NegotiationContent.qml`'s existing no-hook line informative.

**Ollama is excluded by path, not basename.** It runs `/usr/lib/ollama/llama-server`; excluding every `llama-server` by name would also hide a user's own llama.cpp server — precisely what this catch-all exists to notice. Excluding it matters: nvidia-smi reports 9218 MB for the runner vs the precise 8780 MB per-model claim from `/api/ps`, so without this they'd double-count.

## Verified live (RTX 4090)

| check | result |
|---|---|
| capacity via new routed path | **24564 MB** — same number as before |
| reactive re-check | `UNDECLARED` at T+0.02s → `24564` at T+0.64s once `lspci` returned |
| Ollama claim after refactor | **8780 MB**, unchanged — no regression |
| real non-Ollama CUDA process (12 GB) | `gpu-proc-30414`, owner `vram-hog`, **12386 MB** — matches nvidia-smi exactly |
| Ollama double-count | none — no `gpu-proc-` claim for the runner |
| triggered negotiation | `claimantSuspendable: false`, Suspend button disabled, and *"vram-hog has no graceful-stop hook, so it can't be suspended from here"* |
| release on exit | claim cleared on the next poll at T+8.9s |

Screenshot of the real prompt naming `vram-hog` is in the thread.

## What is NOT verified — read this before trusting the AMD path

I have an NVIDIA 4090. **I have no AMD and no Intel hardware.** Being specific about which half is which:

**NVIDIA — live-tested.** Everything in the table above.

**AMD capacity — written to spec, never run on AMD hardware.** It sums `/sys/class/drm/card*/device/mem_info_vram_total`. What I *could* verify: the attribute name and its **bytes** unit are confirmed against the kernel's ["Misc AMDGPU driver information"](https://docs.kernel.org/gpu/amdgpu/driver-misc.html) docs; the shell pipeline (glob, `readlink -f`, dedupe, sum) and the bytes→MB conversion are verified against a synthetic sysfs tree mirroring the real layout (16 GiB + 24 GiB → 40960 MB); and the command degrades silently to exit 0 with no output on this NVIDIA box, so a wrong guess declares nothing rather than something false.

What I could **not** verify: that a real amdgpu card actually exposes that file at that path, and that the number is what a user would call the card's VRAM.

*An AMD user should check:* `cat /sys/class/drm/card*/device/mem_info_vram_total` returns a plausible byte count per card, then confirm the declared `capacity` in `qs -c aphotic ipc call profile state` matches the card's real VRAM in MB. If it's wrong, the resource should not be declared at all rather than declared wrongly.

The dedupe is defensive, not load-bearing: I confirmed on real hardware that connector entries (`card0-DP-4/device`) resolve to the DRM node rather than the PCI device and so don't expose the attribute. It guards against that layout changing.

**AMD per-process claims — deliberately not implemented.** DRM fdinfo (`drm-resident-vram` in `/proc/<pid>/fdinfo/<fd>`, kernel 5.14+) is the only interface; there is no per-device sysfs listing. It needs walking every PID's fds, unit parsing, and shared-buffer handling — not something to ship unverified. Skipping it is the honest choice over shipping a parser I can't test.

**Intel — declares nothing, on purpose.** An integrated GPU carves its framebuffer out of system RAM, so there is no coherent dedicated-VRAM number. Undeclared is inert by design, which is the existing convention for exactly this situation.

## One more real limit, worth a reviewer's attention

`--query-compute-apps` returns **compute** processes only. Verified on this machine: the `G` (graphics) rows — Hyprland 162 MiB, `qs` 220 MiB, kitty, Xorg — are not returned. Excluding the desktop (and the shell itself) from claiming against its own arbiter is desirable, but it means **a game will not appear here**. A future Gaming domain will need a different source: `nvidia-smi pmon` does list graphics processes but reports no per-process memory figure at all (verified live — its columns are utilisation percentages), so this is a real open problem, not an oversight.

Sources: [Misc AMDGPU driver information](https://docs.kernel.org/gpu/amdgpu/driver-misc.html), [DRM client usage stats](https://docs.kernel.org/gpu/drm-usage-stats.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jd3d4KozRZVrzYiK7nKobG