### PR TITLE
resource engine: name a claimant that can actually stop, and stop blaming the shell

### DIFF
--- a/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
+++ b/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
@@ -237,16 +237,33 @@ Singleton {
         return root._negotiation(spec, claimant, claim, "capacity", total, budget);
     }
 
-    // Whoever the prompt will offer to suspend: the cheapest thing to give
-    // up first (background before foreground), then the largest claim,
-    // so the offer is deterministic rather than registration-order luck.
+    // Whoever the prompt will name: something that can actually stop,
+    // ahead of anything that can't. Only claims whose owner has a
+    // graceful-stop hook are real candidates, and among those the
+    // cheapest to give up goes first (background before foreground, then
+    // largest), so the offer is deterministic rather than
+    // registration-order luck.
+    //
+    // When nothing on the resource can stop, the prompt is informational
+    // rather than actionable (NegotiationContent disables Suspend and
+    // says why), so ranking by "cheapest to give up" stops meaning
+    // anything -- and picking the largest *background* claim actively
+    // misleads: with a game and a local model both on the GPU, the
+    // largest remaining background claim is the shell itself, so a
+    // multi-gigabyte overage was being reported against ~225 MB of
+    // compositor. Falling back to the largest claim outright names the
+    // thing actually holding the memory. It does not make that thing
+    // stoppable -- canSuspend still gates the button.
     function _incumbent(others: var): var {
-        const ranked = others.slice().sort((a, b) => {
+        const stoppable = others.filter(c => ProfileEngine.canSuspend(c.owner));
+        if (stoppable.length === 0)
+            return others.slice().sort((a, b) => b.amount - a.amount)[0] ?? null;
+
+        return stoppable.sort((a, b) => {
             if (a.priority !== b.priority)
                 return a.priority === "background" ? -1 : 1;
             return b.amount - a.amount;
-        });
-        return ranked[0] ?? null;
+        })[0] ?? null;
     }
 
     function _negotiation(spec: var, claimant: var, requestor: var, reason: string, total: real, budget: real): var {


### PR DESCRIPTION
### The bug

`ResourceEngine._incumbent()` ranked background claims before foreground ones and then by size, on the reasoning that the cheapest thing to give up should be offered first. That reasoning only holds when something can actually be given up.

With a game and a local model both on the GPU it does not. If Ollama loads **while a game is already running**, Ollama is the requestor, and the largest remaining *background* claim is the shell itself — so a 24 GB GPU carrying a 13 GB game reported its overage against ~235 MB of compositor, with Suspend disabled because `qs` has no graceful-stop hook. Nothing about that prompt was actionable, or even true to what was happening.

This is pre-existing, and only became reachable once Gaming shipped a real foreground claimant (#71/#72).

### The change

Claims whose owner has a graceful-stop hook are considered first, ranked among themselves by the same cheapest-first rule as before.

When none of them can stop, the prompt is informational rather than actionable — `NegotiationContent` already disables Suspend and explains why — so ranking by "cheapest to give up" stops meaning anything, and picking the largest *background* claim actively misleads. The fallback is now the largest claim outright, which names the thing actually holding the memory.

**This does not make anything newly stoppable.** `ProfileEngine.canSuspend` still gates the button, so Gaming can be *named* but never asked to stop — §3.2's guarantee holds where it matters, at the action.

### Verified live, both sides real

RTX 4090. A `gamemoderun`-registered CUDA process holding **13386 MB** (adopted through `GpuVramSource`'s PID seam, registered foreground under owner `gaming`) against `llama3.1:8b`'s real **8226 MB** claim from `/api/ps` — 22376 MB against a 22108 MB safety budget.

Same live workload, same machine, only the engine swapped:

| | claimant named | amount | suspendable |
|---|---|---|---|
| `main` | `qs` | 235 MB | false |
| this PR | `gaming` | 13386 MB | false |

The live prompt now reads: *"vramhog is currently using 13386 MB of GPU VRAM. llama3.1:8b is requesting GPU VRAM at background priority. Combined claims are 22376 against a 22108 MB safety budget."* with Suspend disabled and *"gaming has no graceful-stop hook, so it can't be suspended from here."*

The other branch was checked too — with the game as requestor, a stoppable claimant exists, and Ollama is still selected with **Suspend enabled**. No regression where the prompt was already actionable.

After both workloads exited, `ResourceEngine.dormant` returned to `true` with zero claims.

### Separate bug found while testing, not fixed here

`qs -c aphotic ipc call profile reset` calls `ResourceEngine.reset()`, which clears `_resources` alongside claims. `GpuVramSource._declared` stays `true`, so `_probe()` returns early and **never re-declares `gpu-vram`** — arbitration is silently dead for the rest of the session with no visible symptom. It produced a false negative in this very test run before I spotted it. Debug-surface only, so it is recorded rather than folded in here.

### Testing

All 23 `tests/test_*.sh` pass (including `test_profile_substrate.sh`), `pytest tests/ -q` 48 passed.