### PR TITLE
system usage: stop polling GPU and temperature readings nothing is displaying

### DIFF
--- a/Configs/quickshell/aphotic/components/SystemUsageWatch.qml
+++ b/Configs/quickshell/aphotic/components/SystemUsageWatch.qml
@@ -1,0 +1,11 @@
+import QtQuick
+import qs.services
+
+// Mount this for as long as a surface showing SystemUsage's detailed
+// stats (CPU temperature, GPU utilisation/temperature) is on screen.
+// Object lifetime is the registration, so a surface behind a Loader
+// cannot leak a watch by missing an unpaired call.
+QtObject {
+    Component.onCompleted: SystemUsage.beginDetailedMonitoring()
+    Component.onDestruction: SystemUsage.endDetailedMonitoring()
+}

--- a/Configs/quickshell/aphotic/components/qmldir
+++ b/Configs/quickshell/aphotic/components/qmldir
@@ -17,3 +17,4 @@ StateLayer 1.0 StateLayer.qml
 StyledClippingRect 1.0 StyledClippingRect.qml
 StyledRect 1.0 StyledRect.qml
 StyledText 1.0 StyledText.qml
+SystemUsageWatch 1.0 SystemUsageWatch.qml

--- a/Configs/quickshell/aphotic/modules/bar/popouts/ResourcesPopout.qml
+++ b/Configs/quickshell/aphotic/modules/bar/popouts/ResourcesPopout.qml
@@ -7,6 +7,12 @@ import qs.services
 ColumnLayout {
     id: root
 
+    // This popout is built and destroyed with the hover that shows it
+    // (popouts/Wrapper.qml's Loader), so its own lifetime is the gate --
+    // no surrounding LazyLoader needed the way the dashboard and settings
+    // windows need one.
+    SystemUsageWatch {}
+
     // Fixed implicitWidth (not width!) so Layout.fillWidth + elide on the
     // CPU/disk secondary lines actually constrain their text instead of
     // reporting their full unelided implicitWidth upward. This has to be

--- a/Configs/quickshell/aphotic/modules/dashboard/DashboardWindow.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/DashboardWindow.qml
@@ -40,4 +40,14 @@ PanelWindow {
         anchors.centerIn: parent
         screenState: root.screenState
     }
+
+    // Gated on the state rather than this window's own `visible`: the
+    // loader evaluates `active` during its own completion, before the
+    // window's visible binding has settled, and would latch a watch open
+    // for the whole session.
+    LazyLoader {
+        active: root.screenState.dashboard
+
+        SystemUsageWatch {}
+    }
 }

--- a/Configs/quickshell/aphotic/modules/settings/SettingsWindow.qml
+++ b/Configs/quickshell/aphotic/modules/settings/SettingsWindow.qml
@@ -53,4 +53,14 @@ PanelWindow {
         anchors.centerIn: parent
         screenState: root.screenState
     }
+
+    // Gated on the state rather than this window's own `visible`: the
+    // loader evaluates `active` during its own completion, before the
+    // window's visible binding has settled, and would latch a watch open
+    // for the whole session.
+    LazyLoader {
+        active: root.screenState.settings
+
+        SystemUsageWatch {}
+    }
 }

--- a/Configs/quickshell/aphotic/services/SystemUsage.qml
+++ b/Configs/quickshell/aphotic/services/SystemUsage.qml
@@ -36,8 +36,40 @@ Singleton {
     readonly property real gpuTemp: selectedGpu?.temp ?? 0
 
     function selectGpu(index: int): void {
-        if (index >= 0 && index < _gpus.length)
-            _selectedGpuIndex = index;
+        if (index < 0 || index >= _gpus.length || index === _selectedGpuIndex)
+            return;
+        _selectedGpuIndex = index;
+        root._pollGpu();
+    }
+
+    // CPU temperature and GPU utilisation/temperature have no
+    // always-visible consumer: the bar reads cpuPerc and memPerc and
+    // nothing else. Everything that shows the rest -- the Command
+    // Center's performance tab, Settings' System pane, the bar's
+    // resources popout -- is a surface the user opens, so each mounts a
+    // SystemUsageWatch while it is on screen and nothing polls in
+    // between. Same "sleeping until seen" shape as GpuVramSource's
+    // `scanning` gate.
+    readonly property bool detailedMonitoring: root._watchers > 0
+
+    function beginDetailedMonitoring(): void {
+        root._watchers = root._watchers + 1;
+    }
+
+    function endDetailedMonitoring(): void {
+        root._watchers = Math.max(0, root._watchers - 1);
+    }
+
+    // Only the selected GPU. Polling every detected controller kept a
+    // second card's reading warm for the moment the user cycles the
+    // selector, at the cost of a process per card on every tick forever
+    // -- and where intel-gpu-tools is installed the iGPU's branch is a
+    // one-second intel_gpu_top run, for a card nothing is displaying.
+    // selectGpu() polls the newly chosen card immediately instead, which
+    // is fresher than a reading up to a tick old.
+    function _pollGpu(): void {
+        if (root._gpus.length > 0 && !gpuStatsProc.running)
+            gpuStatsProc.running = true;
     }
 
     readonly property real memPerc: _memTotal > 0 ? _memUsed / _memTotal : 0
@@ -55,6 +87,7 @@ Singleton {
     property real _memUsed: 0
     property real _memTotal: 0
     property var _disks: []
+    property int _watchers: 0
 
     property var _prevCpu: null
 
@@ -138,19 +171,16 @@ Singleton {
                 // discrete GPU, after the sort above) the first time.
                 const rematch = prevSelectedVendor !== undefined ? root._gpus.findIndex(g => g.vendor === prevSelectedVendor) : -1;
                 root._selectedGpuIndex = rematch >= 0 ? rematch : 0;
-                gpuStatsProc.running = true;
+                if (root.detailedMonitoring)
+                    root._pollGpu();
             }
         }
     }
 
-    // Polls every detected GPU's live stats, not just the selected one --
-    // so switching the selector shows an already-warm reading instead of
-    // a blank "N/A" until the next 30s tick.
     Process {
         id: gpuStatsProc
-        property int _pendingIndex: 0
         command: {
-            const gpu = root._gpus[_pendingIndex];
+            const gpu = root._gpus[root._selectedGpuIndex];
             if (!gpu)
                 return ["true"];
             switch (gpu.vendor) {
@@ -174,7 +204,7 @@ Singleton {
         }
         stdout: StdioCollector {
             onStreamFinished: {
-                const idx = gpuStatsProc._pendingIndex;
+                const idx = root._selectedGpuIndex;
                 const gpu = root._gpus[idx];
                 if (gpu) {
                     const lines = text.trim().split("\n").map(s => s.trim()).filter(s => s.length > 0);
@@ -226,14 +256,6 @@ Singleton {
                     const gpus = root._gpus.slice();
                     gpus[idx] = updated;
                     root._gpus = gpus;
-                }
-
-                const nextIndex = gpuStatsProc._pendingIndex + 1;
-                if (nextIndex < root._gpus.length) {
-                    gpuStatsProc._pendingIndex = nextIndex;
-                    gpuStatsProc.running = true;
-                } else {
-                    gpuStatsProc._pendingIndex = 0;
                 }
             }
         }
@@ -361,17 +383,17 @@ Singleton {
         }
     }
 
+    // triggeredOnStart is what makes opening a surface feel instant: the
+    // gate going true fires a tick immediately rather than leaving the
+    // card blank for up to 30s.
     Timer {
         interval: 30000
-        running: true
+        running: root.detailedMonitoring
         repeat: true
         triggeredOnStart: true
         onTriggered: {
             tempProc.running = true;
-            if (root._gpus.length > 0 && !gpuStatsProc.running) {
-                gpuStatsProc._pendingIndex = 0;
-                gpuStatsProc.running = true;
-            }
+            root._pollGpu();
         }
     }
 


### PR DESCRIPTION
The first landed piece of §4.2's coordinated performance pass. §4.2 names this exact case: *"no reason to monitor every GPU simultaneously when the UI only ever displays one — monitor only what's actually visible/active."* `SystemUsage` did neither.

Same discipline as `GpuVramSource`'s `scanning` gate, which the substrate test already blesses as the reference shape.

### Poll only the selected GPU

`gpuStatsProc` cycled through **every** detected controller on every tick, chaining `_pendingIndex` through the list, so a card the UI is not showing was polled forever to keep its reading warm for the moment the user cycles the selector. On a hybrid Intel + NVIDIA desktop that is a process per card per tick for a card nothing is displaying — and where `intel-gpu-tools` is installed, the iGPU branch is a one-second `intel_gpu_top` run.

`selectGpu()` now polls the newly chosen card immediately instead. That is *fresher* than the old behaviour, which could hand over a reading up to a full tick old.

### Poll only while something is displaying it

`cpuTemp` and every GPU reading have no always-visible consumer. The bar reads `cpuPerc` and `memPerc` and nothing else — verified by grepping every `SystemUsage.*` reference in the tree. Everything that shows the rest is a surface the user opens:

- the Command Center's performance tab
- Settings' System pane
- the bar's resources popout

Each mounts a `SystemUsageWatch` for as long as it is on screen. Object lifetime *is* the registration, so a surface behind a `Loader` cannot leak a watch through an unpaired call. The 30s tick runs only while at least one is mounted, and `triggeredOnStart` makes opening a surface populate it immediately rather than leaving a blank card for up to 30s.

### One thing worth knowing for the next surface that does this

The dashboard and settings windows gate their watch on `screenState.dashboard` / `.settings`, **not** on their own `visible`. Found live, not by reading: a `LazyLoader` evaluates `active` during its own completion, before the window's `visible` binding has settled, so gating on `root.visible` latched four watches open (two windows × two monitors) at startup and made the whole gate a no-op. The instrumented count went `begin → 1, 2, 3, 4` at launch with nothing on screen.

### Measured

i9-14900K + RTX 4090 + UHD 770 iGPU, two monitors. Counting stat processes spawned by the shell, sampled from `/proc`:

| scenario | before | after |
|---|---|---|
| 90s idle, nothing open | `nvidia-smi` ×3, `sensors` ×3 | **none** |
| 65s, Command Center open | — | `nvidia-smi` ×2, `sensors` ×2 |
| 40s open, iGPU selected | — | `sensors` ×1, `nvidia-smi` **×0** |

That last row is the selection check: the discrete card is not polled while the iGPU is the selected one. Under `main` both cards were polled every tick regardless.

Performance tab verified live on open — CPU 34 °C / 3% and GPU 26 °C / 34% both populate immediately, no "N/A" gap, GPU cycle button present since two cards are detected.

### Scope

Deliberately narrow. §4.2's idle-GPU debloat is **not** addressed here — that is a separate finding with its own numbers, reported alongside this work. This PR is the polling half only.

### Testing

All 23 `tests/test_*.sh` pass, `pytest tests/ -q` 48 passed. Verified live against a re-synced `~/.config/quickshell/aphotic` (confirmed `deployed == repo`) rather than a stale copy.