### PR TITLE
settings: let the agent graph's catch-up history be scoped

### DIFF
--- a/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
@@ -14,6 +14,7 @@ ColumnLayout {
     readonly property var accentPresets: ["", "#4A5A52", "#669B04", "#3B82F6", "#EF4444", "#F59E0B", "#8B5CF6", "#EC4899", "#14B8A6"]
     readonly property var depthEffectsPresets: [{ value: "off", label: qsTr("Off") }, { value: "subtle", label: qsTr("Subtle") }, { value: "full", label: qsTr("Full") }]
     readonly property var agentGraphPresets: [{ value: "auto", label: qsTr("Auto") }, { value: "lite", label: qsTr("Lite") }, { value: "standard", label: qsTr("Standard") }, { value: "full", label: qsTr("Full") }]
+    readonly property var agentGraphHistoryPresets: [{ value: 0, label: qsTr("Live only") }, { value: 150, label: qsTr("150") }, { value: 400, label: qsTr("400") }, { value: 1000, label: qsTr("1000") }]
 
     property var cursorThemes: []
     property var iconThemes: []
@@ -213,6 +214,15 @@ ColumnLayout {
             description: qsTr("Color-codes a subagent's own tool calls separately from its session — computed once when the graph updates, off by default")
             checked: Settings.agentGraphGroupByParent
             onToggled: state => Settings.agentGraphGroupByParent = state
+        }
+
+        SettingsPresetRow {
+            icon: "history"
+            label: qsTr("Catch-up history")
+            description: qsTr("How many past events the graph replays when it starts following the log. Live only opens with an empty graph and grows from new activity.")
+            presets: root.agentGraphHistoryPresets
+            value: Settings.agentGraphHistoryLines
+            onSelected: value => Settings.agentGraphHistoryLines = value
         }
     }
 

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -120,6 +120,12 @@ Singleton {
     property string agentGraphQuality: "auto"
     property string agentGraphAccent: ""
     property bool agentGraphGroupByParent: false
+    // How much of the event log the agent graph replays when it starts
+    // following it. 0 means start live and show only what happens from
+    // here forward. Trading history for a lighter surface is the user's
+    // call, not a workaround: the replay cost itself is bounded by the
+    // graph's own rebuild coalescing.
+    property int agentGraphHistoryLines: 150
     property string ggufModelsDir: `${Quickshell.env("HOME")}/Models/gguf`
 
     property bool intelligenceEnabled: true
@@ -285,6 +291,7 @@ Singleton {
             agentGraphQuality: root.agentGraphQuality,
             agentGraphAccent: root.agentGraphAccent,
             agentGraphGroupByParent: root.agentGraphGroupByParent,
+            agentGraphHistoryLines: root.agentGraphHistoryLines,
             ggufModelsDir: root.ggufModelsDir,
             assistantWelcomeShown: root.assistantWelcomeShown,
             dndEnabled: root.dndEnabled,
@@ -597,6 +604,8 @@ Singleton {
                     root.agentGraphAccent = data.agentGraphAccent;
                 if (typeof data.agentGraphGroupByParent === "boolean")
                     root.agentGraphGroupByParent = data.agentGraphGroupByParent;
+                if (typeof data.agentGraphHistoryLines === "number" && data.agentGraphHistoryLines >= 0)
+                    root.agentGraphHistoryLines = Math.min(2000, Math.floor(data.agentGraphHistoryLines));
                 if (typeof data.ggufModelsDir === "string" && data.ggufModelsDir.length > 0)
                     root.ggufModelsDir = data.ggufModelsDir;
                 if (typeof data.assistantWelcomeShown === "boolean")


### PR DESCRIPTION
Shell-side half of T-Crypt/aphotic-plugins#2.

The agent-graph plugin replays a hardcoded 400 lines of `agent-events.jsonl` when it starts following it, with no way to ask for less. This adds the setting it reads.

## What's here

- `Settings.agentGraphHistoryLines` (int, default **150**), persisted and range-guarded on load (0–2000).
- A **Catch-up history** preset row in Personalization, next to the graph's other controls: `Live only | 150 | 400 | 1000`.

`Live only` (0) opens the graph empty and grows it from new activity — for anyone who wants the surface without the backlog. It's a deliberate history-for-lightness trade, not a workaround: the replay's cost is fixed separately in the plugin, by coalescing the rebuild it used to run once per replayed line (812 rebuilds / 25.1 s → 8 / 0.109 s, measured).

**Nothing reads this key until agent-graph 1.3.0 is installed**, and that version falls back to the old 400 if this setting is absent, so the two sides can land in either order.

## Verified live

The new row renders in Personalization under the graph's existing controls, with the persisted value selected.

Setting each preset produced the matching `tail -n <n>` and node count (400 → 199 nodes, 150 → 74, Live only → 0, then growing from new events). Runtime changes re-scope without a restart.

All 23 shell tests and 48 pytest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
