### PR TITLE
README: banner, resolved image assets, grouped gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-::: {align="center"}
-# Aphotic
+<p align="center">
+  <img src="assets/aphotic-banner.svg" alt="Aphotic — Hyprland dotfiles, after dark" width="900">
+</p>
 
-**Hyprland dotfiles built around Quickshell, modular profiles, and
-optional runtime features.**
-
-[![Stars](https://img.shields.io/github/stars/T-Crypt/Aphotic-Hypr?style=flat-square)](https://github.com/T-Crypt/Aphotic-Hypr/stargazers)
-[![Issues](https://img.shields.io/github/issues/T-Crypt/Aphotic-Hypr?style=flat-square)](https://github.com/T-Crypt/Aphotic-Hypr/issues)
-[![License](https://img.shields.io/github/license/T-Crypt/Aphotic-Hypr?style=flat-square)](LICENSE)
-:::
+<p align="center">
+  <img src="https://img.shields.io/github/stars/T-Crypt/Aphotic-Hypr?style=for-the-badge&color=7DCFFF&labelColor=0b0d12">
+  <img src="https://img.shields.io/github/issues/T-Crypt/Aphotic-Hypr?style=for-the-badge&color=E0AF68&labelColor=0b0d12">
+  <img src="https://img.shields.io/github/forks/T-Crypt/Aphotic-Hypr?style=for-the-badge&color=F7768E&labelColor=0b0d12">
+  <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/T-Crypt/Aphotic-Hypr?style=for-the-badge&color=AD8EE6&labelColor=0b0d12">
+  <img alt="License" src="https://img.shields.io/github/license/T-Crypt/Aphotic-Hypr?style=for-the-badge&color=7DCFFF&labelColor=0b0d12">
+  <img alt="Status: Beta" src="https://img.shields.io/badge/status-beta-E0AF68?style=for-the-badge&labelColor=0b0d12">
+</p>
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,89 @@ Inactive features should add little to no runtime overhead.
 
 ## Preview
 
-```{=html}
+One shell, reskinned live from a wallpaper — no rebuild, no relogin. Shown
+over **Tokyo Night**, **Lofi**, and **Gruvbox**, three of the eight themes
+that ship out of the box:
+
 <p align="center">
-```
-`<img src="assets/preview.png" width="900">`{=html}
-```{=html}
+  <img src="./assets/preview.png" width="900">
 </p>
-```
+
+Agentic workflow, live render: every Bash and Read call landing on the graph
+as the agent makes it, with replay scrubbing and zoom.
+
+https://github.com/user-attachments/assets/a9a2ff29-4c57-4e1f-b4e9-e3a93e995c2a
+
+## Gallery
+
+<details>
+<summary><b>Desktop &amp; bar</b></summary>
+<br>
+
+<table>
+<tr>
+<td width="50%"><p align="center"><img src="./assets/screenshots/bar-full.png" width="440"><br><sub>Bar: Full style</sub></p></td>
+<td width="50%"><p align="center"><img src="./assets/screenshots/bar-dock.png" width="440"><br><sub>Bar: Dock style</sub></p></td>
+</tr>
+<tr>
+<td width="50%"><p align="center"><img src="./assets/screenshots/workspaces.png" width="440"><br><sub>Workspaces</sub></p></td>
+<td width="50%"><p align="center"><img src="./assets/screenshots/launcher.png" width="440"><br><sub>Launcher</sub></p></td>
+</tr>
+</table>
+
+</details>
+
+<details>
+<summary><b>Command Center</b></summary>
+<br>
+
+<table>
+<tr>
+<td width="50%"><p align="center"><img src="./assets/screenshots/dashboard.png" width="440"><br><sub>Dashboard</sub></p></td>
+<td width="50%"><p align="center"><img src="./assets/screenshots/performance.png" width="440"><br><sub>Performance</sub></p></td>
+</tr>
+<tr>
+<td width="50%"><p align="center"><img src="./assets/screenshots/workspace-profiles.png" width="440"><br><sub>Workspace Profiles</sub></p></td>
+<td width="50%"></td>
+</tr>
+</table>
+
+</details>
+
+<details>
+<summary><b>AI</b></summary>
+<br>
+
+<table>
+<tr>
+<td width="50%"><p align="center"><img src="./assets/screenshots/ai-chat.png" width="440"><br><sub>AI Chat</sub></p></td>
+<td width="50%"><p align="center"><img src="./assets/screenshots/ai-settings.png" width="440"><br><sub>AI Settings &amp; Hardware Advisor</sub></p></td>
+</tr>
+<tr>
+<td width="50%"><p align="center"><img src="./assets/screenshots/intelligence-assistant.png" width="440"><br><sub>Aphotic Assistant</sub></p></td>
+<td width="50%"></td>
+</tr>
+</table>
+
+</details>
+
+<details>
+<summary><b>Theming &amp; settings</b></summary>
+<br>
+
+<table>
+<tr>
+<td width="50%"><p align="center"><img src="./assets/screenshots/wallpaper-picker.png" width="440"><br><sub>Wallpaper Picker</sub></p></td>
+<td width="50%"><p align="center"><img src="./assets/screenshots/theme-creator.png" width="440"><br><sub>Theme Creator</sub></p></td>
+</tr>
+<tr>
+<td width="50%"><p align="center"><img src="./assets/screenshots/personalization.png" width="440"><br><sub>Personalization</sub></p></td>
+<td width="50%"><p align="center"><img src="./assets/screenshots/plugins.png" width="440"><br><sub>Plugins</sub></p></td>
+</tr>
+</table>
+
+</details>
+
 ## Features
 
 -   Quickshell desktop shell
@@ -142,9 +218,7 @@ Plugins can be installed, enabled, disabled, and removed independently.
 
 The core desktop does not require optional plugins to function.
 
-Repository:
-
-https://github.com/T-Crypt/aphotic-plugins
+Repository: [T-Crypt/aphotic-plugins](https://github.com/T-Crypt/aphotic-plugins)
 
 ## Themes
 
@@ -194,15 +268,15 @@ See the installation documentation for available options.
 
 ## Stack
 
-  Component          Implementation
-  ------------------ ----------------
-  Compositor         Hyprland
-  Desktop shell      Quickshell
-  Terminal           Kitty
-  File manager       Thunar
-  Wallpaper          awww
-  Shell              ZSH / Starship
-  Audio visualizer   Cava
+| Component | Implementation |
+| --- | --- |
+| Compositor | Hyprland |
+| Desktop shell | Quickshell |
+| Terminal | Kitty |
+| File manager | Thunar |
+| Wallpaper | awww |
+| Shell | ZSH / Starship |
+| Audio visualizer | Cava |
 
 ## Performance
 


### PR DESCRIPTION
Keeps the short README structure, adds the banner, and fixes the parts that never rendered.

## What was broken

The Pandoc round-trip in #74 left markup GitHub renders literally:

- **`assets/preview.png` never displayed** — it was wrapped in ` ```{=html} ` fences and `` `<img …>`{=html} ``.
- **The Stack table rendered as an indented code block** — Pandoc's simple-table form, not GFM.
- The plugin repo URL sat bare under a `Repository:` line.

Verified: HTTP 200 on the demo video asset, and all 17 local asset paths resolve against tracked files (`assets/preview.png`, the banner SVG, and 14 screenshots).

## What's here

- **Banner + badges** (your commit, untouched).
- **Preview** — `preview.png` now displays, plus the agent-graph demo video that the rewrite dropped.
- **Gallery** — all 14 tracked screenshots are back, grouped into four collapsed `<details>` sections so the page stays short: four summary lines instead of ~100 lines of inline tables.
  - Desktop & bar (4) · Command Center (3) · AI (3) · Theming & settings (4)
- **Stack** as a real GFM table.

319 lines, against 245 with broken markup and 579+ before the rewrite. Every `<details>`/`<table>`/`<td>`/`<p>` tag pair is balanced, and no `{=html}` or `:::` artifacts remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)