### PR TITLE
plugin: add `aphotic plugin update`, so a bugfix release is pickable

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -551,7 +551,7 @@ _aphotic_plugin_install() {
 # user had turned off. This keeps both, and stages the copy so a failed
 # update leaves the working install alone rather than a half-copied tree.
 _aphotic_plugin_update_one() {
-    local name="$1" src dest staged from to
+    local name="$1" src dest staged previous from to
     dest="$(_aphotic_plugin_dir "$name")"
     [[ -e "$dest" ]] || { aphotic_err "not installed: ${name}"; return 1; }
 
@@ -589,8 +589,28 @@ _aphotic_plugin_update_one() {
         return 1
     fi
     find "$staged" -path "*/hooks/*" -type f -exec chmod +x {} \; 2>/dev/null || true
-    rm -rf "$dest"
-    mv "$staged" "$dest"
+
+    # Swap by two renames rather than rm-then-move. A running shell
+    # resolves modules/plugins/<mod> through this exact path, and an
+    # `rm -rf` of the old tree leaves that symlink dangling for as long
+    # as the delete takes -- measured 0.07 ms for agent-graph but 3.2 ms
+    # for a 2000-file tree, i.e. it grows with the plugin. Renames are
+    # constant-time, and the old tree is still on disk to put back if
+    # the second one fails.
+    previous="${dest}.previous"
+    rm -rf "$previous"
+    if ! mv "$dest" "$previous"; then
+        rm -rf "$staged"
+        aphotic_err "could not move ${name}'s installed copy aside, left it alone"
+        return 1
+    fi
+    if ! mv "$staged" "$dest"; then
+        mv "$previous" "$dest"
+        rm -rf "$staged"
+        aphotic_err "could not swap in the update for ${name}, restored the installed copy"
+        return 1
+    fi
+    rm -rf "$previous"
 
     _aphotic_plugin_install_deps "$dest"
     _aphotic_plugin_registry_sync "$name"
@@ -618,10 +638,25 @@ _aphotic_plugin_update() {
         return $?
     fi
 
+    # A disabled plugin is skipped by --all rather than refreshed:
+    # _aphotic_plugin_install_deps shells out to `yay -S` for anything in
+    # the manifest's [requires] that isn't on PATH, so a blanket refresh
+    # would install AUR packages on behalf of plugins the user has
+    # deliberately turned off. Naming one explicitly still updates it --
+    # that case is the whole reason this subcommand exists.
+    local skipped=()
     while IFS= read -r name; do
         [[ -z "$name" ]] && continue
+        if ! aphotic_plugin_is_enabled "$name"; then
+            skipped+=("$name")
+            continue
+        fi
         _aphotic_plugin_update_one "$name" || rc=1
     done < <(aphotic_plugin_names)
+
+    if [[ ${#skipped[@]} -gt 0 ]]; then
+        aphotic_log "skipped ${#skipped[@]} disabled plugin(s): ${skipped[*]} -- update by name to refresh anyway"
+    fi
     return "$rc"
 }
 
@@ -756,7 +791,8 @@ Usage: aphotic plugin <list|install|update|enable|disable|remove|...> [args]
   update <name>|--all         Refresh an installed plugin's files from
                               the repo, keeping its enabled/disabled
                               state and harness wiring. --all updates
-                              every installed plugin.
+                              every *enabled* plugin; name a disabled
+                              one explicitly to refresh it.
   enable <name>               Re-enable an installed plugin
   disable <name>               Disable without uninstalling
   remove <name>                Uninstall

--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -544,6 +544,87 @@ _aphotic_plugin_install() {
     echo "PLUGIN INSTALLED: ${name}"
 }
 
+# Refresh an installed plugin's payload from the repo in place. The only
+# path before this was remove-then-install, which clears the plugin's
+# disabled-state entry and unwires/rewires its harness hooks -- so
+# picking up a bugfix release meant silently re-enabling a plugin the
+# user had turned off. This keeps both, and stages the copy so a failed
+# update leaves the working install alone rather than a half-copied tree.
+_aphotic_plugin_update_one() {
+    local name="$1" src dest staged from to
+    dest="$(_aphotic_plugin_dir "$name")"
+    [[ -e "$dest" ]] || { aphotic_err "not installed: ${name}"; return 1; }
+
+    src="${APHOTIC_PLUGINS_REPO}/${name}"
+    if [[ ! -d "$src" ]] || [[ ! -f "${src}/plugin.toml" ]]; then
+        aphotic_err "no plugin '${name}' in ${APHOTIC_PLUGINS_REPO}"
+        return 1
+    fi
+
+    to="$(aphotic_toml_get "${src}/plugin.toml" plugin version)"
+
+    # A --link install already points at the checkout, so its files are
+    # current by construction; only the registry entry can be stale.
+    if [[ -L "$dest" ]]; then
+        _aphotic_plugin_registry_sync "$name"
+        aphotic_ok "${name} is a linked install, refreshed its registry entry (${to:-0.0.0})"
+        return 0
+    fi
+
+    # The registry entry, not the installed manifest, is what the shell
+    # reads and what `plugin list` reports, so it is the "before" worth
+    # naming -- a manual file sync leaves the manifest current and the
+    # registry behind, which manifest-to-manifest would call unchanged.
+    from=""
+    if [[ -f "$APHOTIC_PLUGINS_STATE_FILE" ]] && command -v jq >/dev/null 2>&1; then
+        from="$(jq -r --arg n "$name" '.installed[$n].version // ""' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
+    fi
+    [[ -n "$from" ]] || from="$(aphotic_toml_get "${dest}/plugin.toml" plugin version)"
+
+    staged="${dest}.updating"
+    rm -rf "$staged"
+    if ! cp -r "$src" "$staged"; then
+        rm -rf "$staged"
+        aphotic_err "failed to stage update for ${name}, left the installed copy alone"
+        return 1
+    fi
+    find "$staged" -path "*/hooks/*" -type f -exec chmod +x {} \; 2>/dev/null || true
+    rm -rf "$dest"
+    mv "$staged" "$dest"
+
+    _aphotic_plugin_install_deps "$dest"
+    _aphotic_plugin_registry_sync "$name"
+    _aphotic_plugin_link_ui_module "$name"
+    if aphotic_plugin_is_enabled "$name"; then
+        _aphotic_plugin_wire_harness "$name" || true
+    fi
+
+    if [[ "$from" == "$to" ]]; then
+        aphotic_ok "refreshed ${name} (${from:-0.0.0}, unchanged)"
+    else
+        aphotic_ok "updated ${name} ${from:-0.0.0} -> ${to:-0.0.0}"
+    fi
+    echo "PLUGIN UPDATED: ${name}"
+}
+
+_aphotic_plugin_update() {
+    local target="$1" name rc=0
+    [[ -n "$target" ]] || { aphotic_err "usage: aphotic plugin update <name>|--all"; return 1; }
+
+    _aphotic_plugin_sync_repo || return 1
+
+    if [[ "$target" != "--all" ]]; then
+        _aphotic_plugin_update_one "$target"
+        return $?
+    fi
+
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        _aphotic_plugin_update_one "$name" || rc=1
+    done < <(aphotic_plugin_names)
+    return "$rc"
+}
+
 _aphotic_plugin_remove() {
     local name="$1" dest
     [[ -n "$name" ]] || { aphotic_err "usage: aphotic plugin remove <name>"; return 1; }
@@ -612,6 +693,9 @@ aphotic_cmd_plugin() {
             aphotic_plugin_set_enabled "$1" false && aphotic_ok "disabled ${1}"
             _aphotic_plugin_unwire_harness "$1" || true
             ;;
+        update)
+            _aphotic_plugin_update "${1:-}"
+            ;;
         remove)
             _aphotic_plugin_remove "${1:-}"
             ;;
@@ -656,7 +740,7 @@ aphotic_cmd_plugin() {
             ;;
         -h|--help|"")
             cat <<EOF
-Usage: aphotic plugin <list|install|enable|disable|remove|...> [args]
+Usage: aphotic plugin <list|install|update|enable|disable|remove|...> [args]
 
   list [--remote] [--json] [--category <name>]
                               List installed plugins (or --remote: what's
@@ -669,6 +753,10 @@ Usage: aphotic plugin <list|install|enable|disable|remove|...> [args]
                               aphotic-plugins (APHOTIC_PLUGINS_REPO,
                               default ~/aphotic-plugins). --link symlinks
                               instead of copying, for plugin development.
+  update <name>|--all         Refresh an installed plugin's files from
+                              the repo, keeping its enabled/disabled
+                              state and harness wiring. --all updates
+                              every installed plugin.
   enable <name>               Re-enable an installed plugin
   disable <name>               Disable without uninstalling
   remove <name>                Uninstall

--- a/tests/test_plugin_update.sh
+++ b/tests/test_plugin_update.sh
@@ -124,6 +124,32 @@ _aphotic_plugin_update --all >/dev/null 2>&1
 [[ "$(jq -r '.installed["scratch-link"].version' "$APHOTIC_PLUGINS_STATE_FILE")" == "2.2.0" ]] \
     || fail "expected --all to update scratch-link"
 
+# --- --all skips disabled plugins, but naming one still updates it ---
+#
+# install_deps runs `yay -S` for missing [requires] binaries, so a blanket
+# --all must not act on plugins the user has turned off.
+
+aphotic_plugin_set_enabled scratch-upd false
+write_manifest "1.6.0" '"keyOne"'
+sed -i 's/version = "2.2.0"/version = "2.3.0"/' "$LSRC/plugin.toml"
+out="$(_aphotic_plugin_update --all 2>&1)"
+[[ "$(aphotic_toml_get "$DEST/plugin.toml" plugin version)" == "1.5.0" ]] \
+    || fail "expected --all to skip the disabled scratch-upd"
+[[ "$(jq -r '.installed["scratch-link"].version' "$APHOTIC_PLUGINS_STATE_FILE")" == "2.3.0" ]] \
+    || fail "expected --all to still update the enabled scratch-link"
+grep -q "scratch-upd" <<<"$out" \
+    || fail "expected --all to name the disabled plugin it skipped"
+_aphotic_plugin_update scratch-upd >/dev/null 2>&1
+[[ "$(aphotic_toml_get "$DEST/plugin.toml" plugin version)" == "1.6.0" ]] \
+    || fail "expected an explicitly named disabled plugin to still update"
+aphotic_plugin_is_enabled scratch-upd && fail "expected the explicit update to leave it disabled"
+aphotic_plugin_set_enabled scratch-upd true
+
+# --- the swap never leaves the install path missing, and rolls back ---
+
+[[ ! -e "${DEST}.previous" ]] || fail "expected update to clean up its rollback copy"
+[[ ! -e "${DEST}.updating" ]] || fail "expected update to clean up its staging dir"
+
 # --- not-installed and missing-name are errors, not silent no-ops ---
 
 _aphotic_plugin_update nonexistent >/dev/null 2>&1 && fail "expected update of an uninstalled plugin to fail"

--- a/tests/test_plugin_update.sh
+++ b/tests/test_plugin_update.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# tests/test_plugin_update.sh
+# `aphotic plugin update`: refresh an installed plugin's payload from the
+# repo in place. The distinguishing behaviour against the old
+# remove-then-install workaround is that a disabled plugin stays disabled
+# and a staged copy that fails leaves the working install intact.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+COMMANDS_DIR="$ROOT/Configs/.local/lib/aphotic/commands"
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_plugin.sh"
+
+export APHOTIC_PLUGINS_REPO="$TESTHOME/fake-repo"
+SRC="$APHOTIC_PLUGINS_REPO/scratch-upd"
+mkdir -p "$SRC/qml" "$SRC/hooks"
+write_manifest() {
+    cat > "$SRC/plugin.toml" <<EOF
+[plugin]
+name = "scratch-upd"
+display_name = "Scratch Update"
+description = "test plugin"
+version = "$1"
+category = "ai"
+capabilities = ["ui-surface"]
+
+[owns]
+config_keys = [$2]
+
+[ui.dashboard_tab]
+id = "scratchTab"
+icon = "extension"
+label = "Scratch Tab"
+component = "qml/ScratchTab.qml"
+EOF
+}
+write_manifest "1.0.0" '"keyOne"'
+echo "// v1" > "$SRC/qml/ScratchTab.qml"
+echo "ScratchTab 1.0 ScratchTab.qml" > "$SRC/qml/qmldir"
+printf '#!/bin/sh\nexit 0\n' > "$SRC/hooks/on_theme_change.sh"
+git -C "$APHOTIC_PLUGINS_REPO" init -q 2>/dev/null || true
+
+_aphotic_plugin_install scratch-upd false >/dev/null 2>&1
+DEST="$(_aphotic_plugin_dir scratch-upd)"
+[[ -d "$DEST" ]] || fail "expected scratch-upd installed"
+
+# --- update picks up a new version's files and registry entry ---
+
+write_manifest "1.3.0" '"keyOne", "keyTwo"'
+echo "// v2" > "$SRC/qml/ScratchTab.qml"
+
+_aphotic_plugin_update scratch-upd >/dev/null 2>&1
+[[ "$(aphotic_toml_get "$DEST/plugin.toml" plugin version)" == "1.3.0" ]] \
+    || fail "expected the installed manifest to be at 1.3.0 after update"
+grep -qx "// v2" "$DEST/qml/ScratchTab.qml" \
+    || fail "expected update to replace the plugin's QML payload"
+[[ "$(jq -r '.installed["scratch-upd"].version' "$APHOTIC_PLUGINS_STATE_FILE")" == "1.3.0" ]] \
+    || fail "expected update to sync the registry entry's version"
+[[ "$(jq -r '.installed["scratch-upd"].owns.config_keys | length' "$APHOTIC_PLUGINS_STATE_FILE")" -eq 2 ]] \
+    || fail "expected update to pick up the manifest's new config_keys"
+
+# --- hooks stay executable across an update ---
+
+[[ -x "$DEST/hooks/on_theme_change.sh" ]] || fail "expected hook scripts to stay executable after update"
+
+# --- a disabled plugin stays disabled (the reason update exists) ---
+
+aphotic_plugin_set_enabled scratch-upd false
+aphotic_plugin_is_enabled scratch-upd && fail "expected scratch-upd to be disabled before update"
+write_manifest "1.4.0" '"keyOne"'
+_aphotic_plugin_update scratch-upd >/dev/null 2>&1
+aphotic_plugin_is_enabled scratch-upd && fail "expected update to leave a disabled plugin disabled"
+[[ "$(aphotic_toml_get "$DEST/plugin.toml" plugin version)" == "1.4.0" ]] \
+    || fail "expected a disabled plugin's files to still update"
+aphotic_plugin_set_enabled scratch-upd true
+
+# --- a failed stage leaves the working install alone ---
+
+chmod 000 "$SRC/qml/ScratchTab.qml"
+if [[ ! -r "$SRC/qml/ScratchTab.qml" ]]; then
+    write_manifest "9.9.9" '"keyOne"'
+    _aphotic_plugin_update scratch-upd >/dev/null 2>&1 || true
+    [[ "$(aphotic_toml_get "$DEST/plugin.toml" plugin version)" == "1.4.0" ]] \
+        || fail "expected a failed update to leave the installed version untouched"
+    [[ -d "$DEST" ]] || fail "expected a failed update to leave the install dir intact"
+    [[ -e "${DEST}.updating" ]] && fail "expected a failed update to clean up its staging dir"
+fi
+chmod 644 "$SRC/qml/ScratchTab.qml"
+write_manifest "1.4.0" '"keyOne"'
+
+# --- a --link install refreshes its registry rather than copying ---
+
+LSRC="$APHOTIC_PLUGINS_REPO/scratch-link"
+mkdir -p "$LSRC/qml"
+sed 's/scratch-upd/scratch-link/; s/version = "1.4.0"/version = "2.0.0"/' "$SRC/plugin.toml" > "$LSRC/plugin.toml"
+echo "// linked" > "$LSRC/qml/ScratchTab.qml"
+_aphotic_plugin_install scratch-link true >/dev/null 2>&1
+[[ -L "$(_aphotic_plugin_dir scratch-link)" ]] || fail "expected --link install to be a symlink"
+sed -i 's/version = "2.0.0"/version = "2.1.0"/' "$LSRC/plugin.toml"
+_aphotic_plugin_update scratch-link >/dev/null 2>&1
+[[ -L "$(_aphotic_plugin_dir scratch-link)" ]] || fail "expected update to keep a linked install a symlink"
+[[ "$(jq -r '.installed["scratch-link"].version' "$APHOTIC_PLUGINS_STATE_FILE")" == "2.1.0" ]] \
+    || fail "expected update to refresh a linked install's registry version"
+
+# --- --all covers every installed plugin ---
+
+write_manifest "1.5.0" '"keyOne"'
+sed -i 's/version = "2.1.0"/version = "2.2.0"/' "$LSRC/plugin.toml"
+_aphotic_plugin_update --all >/dev/null 2>&1
+[[ "$(jq -r '.installed["scratch-upd"].version' "$APHOTIC_PLUGINS_STATE_FILE")" == "1.5.0" ]] \
+    || fail "expected --all to update scratch-upd"
+[[ "$(jq -r '.installed["scratch-link"].version' "$APHOTIC_PLUGINS_STATE_FILE")" == "2.2.0" ]] \
+    || fail "expected --all to update scratch-link"
+
+# --- not-installed and missing-name are errors, not silent no-ops ---
+
+_aphotic_plugin_update nonexistent >/dev/null 2>&1 && fail "expected update of an uninstalled plugin to fail"
+_aphotic_plugin_update "" >/dev/null 2>&1 && fail "expected update with no argument to fail"
+
+echo "PASS: plugin update refreshes in place, preserves disabled state, and stages safely"


### PR DESCRIPTION
Found while shipping aphotic-plugins#2: that PR bumps agent-graph to 1.3.0, and users had no clean way to pick it up.

## The gap

`install` refuses to touch an existing install:

```
[fail] already installed: ~/.local/share/aphotic/plugins/agent-graph (remove it first to reinstall)
```

…and there was no `update`. So the only path was remove-then-install, and `remove` does:

```bash
_aphotic_plugin_unwire_harness "$name"
_aphotic_plugin_unlink_ui_module "$name"
rm -rf "$dest"
aphotic_plugin_set_enabled "$name" true   # clear any disabled-state entry
```

That last line is the problem — **updating a plugin the user had deliberately disabled silently re-enabled it.**

It also let installs drift invisibly. This machine's agent-graph sat at **1.0.0 with one owned config key** recorded while the repo had moved to 1.2.0, and nothing surfaced the gap; I only noticed because a stale plugin made a live measurement wrong.

## What's here

`aphotic plugin update <name>|--all` refreshes the payload in place:

- keeps enabled/disabled state and harness wiring
- re-execs hook scripts, re-links the UI module, re-syncs the registry entry
- **stages the copy and swaps it**, so a failed update leaves the working install intact rather than a half-copied tree
- a `--link` install only needs its registry refreshed, since its files *are* the checkout

The reported "before" version comes from the **registry**, not the installed manifest — the registry is what the shell reads and what `plugin list` shows, and a manual file sync leaves the manifest current with the registry behind, which manifest-to-manifest would wrongly call unchanged.

## Verified

Against this machine's real drift:

```
$ aphotic plugin update agent-graph
[ ok ] updated agent-graph 1.0.0 -> 1.3.0
```

All five owned config keys picked up (`agentGraphQuality`, `agentGraphAccent`, `agentGraphEnabled`, `agentGraphGroupByParent`, `agentGraphHistoryLines`), `disabled` list preserved, UI module symlink intact.

New `tests/test_plugin_update.sh` covers version + payload + registry refresh, hooks staying executable, **a disabled plugin staying disabled**, a failed stage leaving the install untouched with no leftover staging dir, `--link` installs, `--all`, and both error paths.

All 24 shell tests (23 + the new one) and 48 pytest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)