### PR TITLE
resource engine: stop a lost declaration killing arbitration silently

### DIFF
--- a/Configs/quickshell/aphotic/services/GpuVramSource.qml
+++ b/Configs/quickshell/aphotic/services/GpuVramSource.qml
@@ -45,7 +45,22 @@ QtObject {
     readonly property int claimDeadbandMb: 64
     readonly property string vendor: SystemUsage.selectedGpu?.vendor ?? ""
 
-    readonly property bool declared: root._declared
+    // Read back from the engine rather than cached here. A local flag is
+    // a second copy of a fact ResourceEngine already owns, and
+    // ResourceEngine.reset() clears its copy only -- which left _probe()
+    // early-returning forever, so gpu-vram was never re-declared and
+    // every negotiation on it was silently impossible for the rest of
+    // the session. Derived, the two cannot disagree.
+    readonly property bool declared: !!(ResourceEngine.resources ?? ({}))[root.resource]
+
+    // Whatever dropped the declaration -- a reset, an undeclare -- the
+    // file that owns this resource re-asserts it. Deferred for the reason
+    // onScanningChanged is: this is a handler on a property derived from
+    // ResourceEngine's own state, re-entering it to declare.
+    onDeclaredChanged: {
+        if (!root.declared)
+            Qt.callLater(root._probe);
+    }
 
     // Zero idle cost: the scan only runs when there is something to
     // arbitrate *against* -- a claim this file did not register itself, or
@@ -56,7 +71,7 @@ QtObject {
     //
     // Excluding its own claims from that test is what stops the scan
     // keeping itself alive forever once it has run a single time.
-    readonly property bool scanning: root._declared && root.vendor === "nvidia" && (root._hasForeignClaim || root._hasAdoptions)
+    readonly property bool scanning: root.declared && root.vendor === "nvidia" && (root._hasForeignClaim || root._hasAdoptions)
 
     readonly property bool _hasAdoptions: Object.keys(root._adopted).length > 0
     readonly property bool _hasForeignClaim: (ResourceEngine.claims ?? []).some(c => c.resource === root.resource && !root._isMine(c.id))
@@ -119,7 +134,6 @@ QtObject {
         return `${owner}-proc-${pid}`;
     }
 
-    property bool _declared: false
     property string _probeVendor: ""
 
     onVendorChanged: root._probe()
@@ -127,7 +141,7 @@ QtObject {
     Component.onCompleted: root._probe()
 
     function _probe(): void {
-        if (root._declared || !root.vendor)
+        if (root.declared || root._capacityProc.running || !root.vendor)
             return;
 
         switch (root.vendor) {
@@ -173,7 +187,6 @@ QtObject {
             capacity: mb,
             safetyMargin: 0.1
         });
-        root._declared = true;
     }
 
     // Ollama is excluded because OllamaClaims registers a precise

--- a/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
+++ b/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
@@ -38,6 +38,19 @@ Singleton {
 
     readonly property bool dormant: root._claims.length === 0 && root._queue.length === 0
 
+    // Resources that have claims but no declared capacity. _contentionFor
+    // skips those deliberately -- an undeclared resource has nothing to
+    // compare against -- but that skip used to be invisible, so a
+    // declaration lost after startup (reset(), a declarant that cached
+    // "I declared" and diverged) left arbitration dead with nothing
+    // reading any differently: claims still register, `dormant` still
+    // says false, and no negotiation can ever be raised again. This makes
+    // that state something a caller can see instead of something it has
+    // to infer. Empty is the healthy answer.
+    readonly property var unarbitrated: root._claims
+        .map(c => c.resource)
+        .filter((r, i, all) => all.indexOf(r) === i && !root._resources[r])
+
     readonly property real defaultSafetyMargin: 0.1
 
     signal claimRegistered(claim: var)

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -316,6 +316,7 @@ ShellRoot {
                 pending: ResourceEngine.pending,
                 pendingCount: ResourceEngine.pendingCount,
                 dormant: ResourceEngine.dormant,
+                unarbitrated: ResourceEngine.unarbitrated,
                 snapshots: StateSnapshot.capturedIds,
                 lastRestore: StateSnapshot.lastRestore,
                 subscribers: ProfileEvents.subscriberCount

--- a/tests/test_profile_substrate.sh
+++ b/tests/test_profile_substrate.sh
@@ -102,4 +102,24 @@ done
 grep -q 'hyprctl' "$QS/services/Hypr.qml" \
   || fail "hyprctl is no longer spawned by the base shell -- the substrate now adds it as a new dependency and it must be declared in both profiles/base/*.toml"
 
+# A declaration lost after startup used to kill arbitration silently:
+# ResourceEngine.reset() clears its resource table, GpuVramSource kept its
+# own `_declared` flag, and the two diverged -- gpu-vram was never
+# re-declared and no negotiation on it could ever be raised again, with
+# nothing reading any differently. Two guards so that cannot come back.
+
+# 1. A declarant must not cache "I declared" alongside the engine's copy.
+GVS="$QS/services/GpuVramSource.qml"
+[[ -f "$GVS" ]] || fail "missing $GVS"
+grep -qE '^\s*readonly property bool declared:.*ResourceEngine\.resources' "$GVS" \
+  || fail "GpuVramSource.declared must be derived from ResourceEngine.resources, not cached -- a private flag diverges from reset()"
+code "$GVS" | grep -qE '(property bool _declared|_declared\s*=)' \
+  && fail "GpuVramSource keeps a private cached declaration flag again -- that is the divergence B-10 was"
+
+# 2. Claims on an undeclared resource must stay observable, not silent.
+grep -q 'readonly property var unarbitrated:' "$SUB/ResourceEngine.qml" \
+  || fail "ResourceEngine no longer exposes 'unarbitrated' -- dead arbitration goes back to being invisible"
+grep -q 'unarbitrated: ResourceEngine.unarbitrated' "$QS/shell.qml" \
+  || fail "the profile IPC state no longer reports unarbitrated"
+
 echo "PASS: profile substrate"


### PR DESCRIPTION
**B-10.** `ResourceEngine.reset()` clears its resource table, but `GpuVramSource` kept its own `_declared` flag. Two copies of one fact, reset() updates one — so `_probe()` early-returned forever, gpu-vram was never re-declared, and no negotiation on it could be raised again for the rest of the session. It produced a false negative in a real A/B last session.

## Reproduced live

Same two over-budget claims either side of a reset (capacity 24564 MB, budget 22107.6):

| | result | `pendingCount` |
|---|---|---|
| before reset | `ok`, **`negotiation 1`** | 1 |
| after reset | `ok`, `ok` | **0** |

`resources` read `{}` immediately after the reset and still `{}` 15 s later, past the 12 s poll.

## Why it was silent, and what changed

Nothing read any differently: claims still registered, `dormant` still reported `false`. That silence is the actual defect, so both halves are addressed.

- **`declared` is derived, not cached.** It reads back from `ResourceEngine.resources`, so there is no second copy to diverge. The resource going away is itself what re-opens `_probe()`, and the file that owns the resource re-asserts its declaration — deferred with `Qt.callLater`, since it is a handler on a property derived from the engine's own state (OPT-IN-FEATURES.md §2.4.1).
- **`ResourceEngine.unarbitrated`** lists resources holding claims with no declared capacity, and `ipc call profile state` reports it. `_contentionFor` skipping them is deliberate; it no longer has to be inferred.

Declaration direction is unchanged — the engine still never probes hardware, and core still declares nothing.

## Verified live after the fix

- `reset()` re-declares gpu-vram within 1 s.
- The identical two claims raise `negotiation 1` again.
- A claim on a never-declared resource surfaces as `unarbitrated: ["never-declared"]` while `dormant` says nothing.
- Five resets in a row: no stray `nvidia-smi`, no binding loop, shell PID unchanged.

Two structural guards added to `test_profile_substrate.sh`; both fail against the pre-fix files. 23 shell tests and 48 pytest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)