### PR TITLE
install: one guided flow for a first-time user, not twelve scattered prompts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@ source "$ROOT_DIR/lib/install/aur.sh"
 source "$ROOT_DIR/lib/install/multilib.sh"
 source "$ROOT_DIR/lib/install/backup.sh"
 source "$ROOT_DIR/lib/install/wizard.sh"
+source "$ROOT_DIR/lib/install/guided.sh"
 source "$ROOT_DIR/lib/install/blackarch.sh"
 source "$ROOT_DIR/lib/install/exploit_disclaimer.sh"
 source "$ROOT_DIR/lib/install/conflicts.sh"
@@ -52,6 +53,18 @@ ACCEPT_EXPLOIT_DISCLAIMER=0
 NVIDIA_DRIVER_ACTION=""
 OPT_IN=0
 STRIP_CONFLICTS=""
+COPY_CONFIGS=""
+EXTRA_WALLPAPERS=""
+ACTIVATE_STARSHIP=""
+ACTIVATE_ZSH=""
+
+# The guided path (lib/install/guided.sh) is what a first-time user gets:
+# it only engages for `./install.sh` with no options at all, on a real
+# terminal. Any flag at all -- and any non-TTY stdin, i.e. CI or a piped
+# install -- keeps the exact flag-driven/zero-prompt behavior it had
+# before, which is what every scripted caller depends on.
+GUIDED=0
+FLAGS_SEEN=0
 
 TOTAL_STAGES=7
 STAGE_COLORS=(35 36 33 34 32 36 35)
@@ -86,6 +99,12 @@ print_help() {
   cat <<'EOF'
 Usage: ./install.sh [options]
 
+  Run with no options on a terminal for the guided setup: a few plain
+  questions, then a summary to accept before anything is changed. Every
+  option below opts out of that and takes the same flag-driven path as
+  before (no options + no terminal, e.g. CI or a piped install, still
+  installs the zero-prompt daily-driver default).
+
   --profile <minimal|full>     Select base profile (skips wizard prompt)
   --with <layer,layer,...>     Comma-separated layers: gaming,dev,ai,exploit
                                 ("exploit" is a convenience bundle of
@@ -96,9 +115,9 @@ Usage: ./install.sh [options]
                                 enables the BlackArch repo unless its own
                                 sublayer doesn't need it (e.g. -reporting,
                                 -wordlists).
-  --opt-in                      Interactive layer picker (preset or
-                                cherry-pick prompts). Without this flag (and
-                                without --profile/--with), a fresh install
+  --opt-in                      Just the interactive layer picker, without
+                                the rest of the guided setup. Without any
+                                flag and without a terminal, a fresh install
                                 defaults to the daily-driver setup -- full
                                 profile, no optional layers -- with zero
                                 prompts. Layers can always be added later by
@@ -146,6 +165,13 @@ EOF
 }
 
 while [[ $# -gt 0 ]]; do
+  # -h/--help and -v/--version exit before this matters, so every flag that
+  # reaches the parser body means "not a bare invocation" -- see GUIDED.
+  case "$1" in
+    -h|--help) print_help; exit 0 ;;
+    -v|--version) cat "$ROOT_DIR/VERSION"; exit 0 ;;
+  esac
+  FLAGS_SEEN=1
   case "$1" in
     --profile) [[ -n "${2:-}" ]] || { echo -e "$CER - Missing value for $1"; exit 1; }; PROFILE="$2"; shift 2 ;;
     --with) [[ -n "${2:-}" ]] || { echo -e "$CER - Missing value for $1"; exit 1; }; LAYERS="$2"; shift 2 ;;
@@ -161,11 +187,13 @@ while [[ $# -gt 0 ]]; do
     --dry-run) DRY_RUN=1; shift ;;
     --no-backup) NO_BACKUP=1; shift ;;
     --keep-backups) [[ -n "${2:-}" ]] || { echo -e "$CER - Missing value for $1"; exit 1; }; KEEP_BACKUPS="$2"; shift 2 ;;
-    -h|--help) print_help; exit 0 ;;
-    -v|--version) cat "$ROOT_DIR/VERSION"; exit 0 ;;
     *) echo -e "$CER - Unknown option: $1"; print_help; exit 1 ;;
   esac
 done
+
+if [[ "$FLAGS_SEEN" == "0" ]] && [[ -t 0 ]]; then
+  GUIDED=1
+fi
 
 if ! [[ "$KEEP_BACKUPS" =~ ^[0-9]+$ ]]; then
   echo -e "$CER - --keep-backups requires a non-negative integer, got: $KEEP_BACKUPS"
@@ -203,7 +231,11 @@ main() {
     exit 1
   fi
 
-  echo -e "$CNT - You are about to execute a script that would attempt to setup Hyprland."
+  if [[ "$GUIDED" == "1" ]]; then
+    guided_intro
+  else
+    echo -e "$CNT - You are about to execute a script that would attempt to setup Hyprland."
+  fi
   detect_environment
 
   if [[ "$CONFIG_ONLY" == "1" ]]; then
@@ -221,7 +253,11 @@ main() {
   # on both sides of the diff.
   PREV_LAYERS="$DETECTED_APHOTIC_LAYERS"
 
-  resolve_config
+  if [[ "$GUIDED" == "1" ]]; then
+    guided_configure
+  else
+    resolve_config
+  fi
   LAYERS=$(expand_layer_bundles "$LAYERS")
 
   exploit_disclaimer_gate "$PREV_LAYERS"
@@ -229,15 +265,23 @@ main() {
   BLACKARCH_CONSENT_GIVEN=0
   if [[ "$(any_layer_requires_blackarch "$LAYERS")" == "true" && "$DRY_RUN" != "1" ]]; then
     print_blackarch_warning
-    if confirm "Continue enabling BlackArch for the exploit-* layers that need it?" n; then
+    if confirm "Add BlackArch and install those tools?" n; then
       BLACKARCH_CONSENT_GIVEN=1
     else
-      echo -e "$CWR - Skipping the BlackArch-backed exploit-* layers."
+      echo -e "$CWR - Not adding BlackArch, so the security tools that need it are dropped from this install. Everything else carries on."
       LAYERS=$(strip_layers_matching "$LAYERS" _predicate_requires_blackarch)
     fi
   fi
 
   ISNVIDIA="$DETECTED_NVIDIA_PRESENT"
+
+  # Step 4 has to run before resolve_assistant (which would otherwise ask
+  # its own question) and before the summary, since it feeds both.
+  if [[ "$GUIDED" == "1" ]]; then
+    guided_step_addons
+    prompt_conflicting_packages
+  fi
+
   resolve_assistant
 
   local layer_paths=()
@@ -290,7 +334,11 @@ main() {
     exit 0
   fi
 
-  echo -e "$CNT - This script will run some commands that require sudo. You will be prompted to enter your password."
+  if [[ "$GUIDED" == "1" ]]; then
+    guided_plan_and_confirm "$prep_pkgs" "$main_pkgs"
+  else
+    echo -e "$CNT - This script will run some commands that require sudo. You will be prompted to enter your password."
+  fi
 
   print_stage 3 "System prep"
   check_conflicting_packages
@@ -373,8 +421,23 @@ main() {
   enable_core_services
 
   print_stage 6 "Deploying configs"
+  # COPY_CONFIGS is "" (nobody has decided -- ask) or 1/0. The guided flow
+  # sets it to 1 rather than asking: a desktop with none of its configs
+  # deployed isn't a working install, so it belongs in the summary, not in
+  # a prompt whose default was "no".
   CFG_COPIED=0
-  if confirm "Would you like to copy config files?" n; then
+  local want_configs=0
+  if [[ -n "$COPY_CONFIGS" ]]; then
+    [[ "$COPY_CONFIGS" == "1" ]] && want_configs=1
+  else
+    echo -e "$CNT - Without Aphotic's config files you get Hyprland with none of Aphotic's desktop."
+    echo -e "$CNT   Whatever is in ~/.config now was backed up in the previous step."
+    if confirm "Install Aphotic's config files into ~/.config?" n; then
+      want_configs=1
+    fi
+  fi
+
+  if [[ "$want_configs" == "1" ]]; then
     CFG_COPIED=1
     deploy_user_configs
     setup_login_manager_theme

--- a/lib/install/assistant.sh
+++ b/lib/install/assistant.sh
@@ -30,13 +30,17 @@ resolve_assistant() {
   fi
 
   if [[ ",$LAYERS," == *",ai,"* ]]; then
-    if confirm "Install the Aphotic Assistant, a local chatbot that helps you personalize your setup?" y; then
+    echo -e "\n$CNT - The Aphotic Assistant is a chatbot that runs entirely on this machine and can"
+    echo -e "$CNT   answer questions about your desktop. It downloads a language model of a few GB."
+    if confirm "Install the Aphotic Assistant?" y; then
       ASSISTANT="true"
     else
       ASSISTANT="false"
     fi
   else
-    if confirm "The Aphotic Assistant is a local chatbot, but it needs the ai layer (Ollama). Add the ai layer and install it?" n; then
+    echo -e "\n$CNT - The Aphotic Assistant is a chatbot that runs entirely on this machine, but it"
+    echo -e "$CNT   needs the AI extras (Ollama) you didn't select, and downloads a model of a few GB."
+    if confirm "Add the AI extras and install the Assistant?" n; then
       ASSISTANT="true"
       LAYERS="${LAYERS:+$LAYERS,}ai"
     else

--- a/lib/install/blackarch.sh
+++ b/lib/install/blackarch.sh
@@ -19,22 +19,28 @@ blackarch_repo_present() {
 print_blackarch_warning() {
   cat <<'EOF'
 
-[WARNING] The "exploit" layer adds the BlackArch repo to /etc/pacman.conf.
-BlackArch is a large, fast-moving repo layered on top of Arch, and it is
-not held to the same stability bar as Arch's own official repos:
-  - Some BlackArch packages shadow/replace official ones (its own rebuilds
-    of common tools are the classic case) if a later `sudo pacman -Syu`
-    pulls one in without you noticing.
-  - The repo occasionally ships a broken package between fixes.
+[WARNING] The security tools you picked are not in Arch's own package
+collections. They come from BlackArch, and this script would add it to
+your system's list of package sources (/etc/pacman.conf).
 
-If something breaks after enabling it:
-  - Force-reinstall the official copy of a broken package:
+BlackArch is a third-party collection of a few thousand security tools,
+maintained separately from Arch and held to a lower stability bar than
+Arch's own official sources:
+  - Some BlackArch packages replace official Arch ones with their own
+    rebuilds, which a later `sudo pacman -Syu` can pull in without you
+    noticing.
+  - It occasionally ships a broken package between fixes.
+
+If something breaks after adding it:
+  - Put the official copy of a package back:
       sudo pacman -S extra/<package>
   - Remove BlackArch entirely: delete the [blackarch] block this script
     appends to /etc/pacman.conf, then:
       sudo pacman -R blackarch-keyring
       sudo pacman -Syyuu
   - Full walkthrough: docs/exploit-layer.md
+
+Everything else in this install works the same either way.
 
 EOF
 }

--- a/lib/install/conflicts.sh
+++ b/lib/install/conflicts.sh
@@ -50,6 +50,44 @@ detect_conflicting_ui_packages() {
   return 0
 }
 
+# Shown once, by whichever of the two entry points below gets there
+# first: the guided flow asks up front (so nothing is uninstalled after
+# the summary the user already accepted), a flag-driven install asks
+# in the system-prep stage as it always has.
+_announce_conflicting_packages() {
+  local pkg
+  echo -e "\n$CAT - These programs are already installed and do the same jobs as parts of Aphotic's desktop:"
+  for pkg in "$@"; do
+    echo -e "    - $pkg  ($(conflicting_package_role "$pkg"))"
+  done
+  echo -e "$CWR - Left in place they usually start themselves from your old setup's config, and you end up with two"
+  echo -e "$CWR   bars, two app launchers, or duplicate notifications. That is the most common reason a finished"
+  echo -e "$CWR   install looks broken (issue #41). Nothing else on this machine needs them."
+  CONFLICTS_ANNOUNCED=1
+}
+
+# Guided-flow entry point: asks the question early and only records the
+# answer in STRIP_CONFLICTS. The removal itself still happens in
+# check_conflicting_packages below, during system prep, after the guided
+# summary has been accepted -- so this never uninstalls anything at the
+# point it is asked.
+prompt_conflicting_packages() {
+  local found=() pkg
+  while IFS= read -r pkg; do
+    [[ -n "$pkg" ]] && found+=("$pkg")
+  done < <(detect_conflicting_ui_packages)
+
+  [[ ${#found[@]} -eq 0 ]] && return 0
+  [[ -n "${STRIP_CONFLICTS:-}" ]] && return 0
+
+  _announce_conflicting_packages "${found[@]}"
+  if confirm "Uninstall them as part of this install?" y; then
+    STRIP_CONFLICTS="1"
+  else
+    STRIP_CONFLICTS="0"
+  fi
+}
+
 # Interactive by default (matches install_nvidia_driver's keep/reinstall
 # gate): asks once, defaults to removing since that's what avoids issue
 # #41's failure mode, but never removes anything without either an
@@ -65,17 +103,16 @@ check_conflicting_packages() {
 
   [[ ${#found[@]} -eq 0 ]] && return 0
 
-  echo -e "$CAT - Found packages already installed that Aphotic's shell replaces:"
-  for pkg in "${found[@]}"; do
-    echo -e "    - $pkg  ($(conflicting_package_role "$pkg"))"
-  done
-  echo -e "$CWR - Left running, these commonly autostart from an old WM config and fight Aphotic's shell for the same role -- this is what issue #41 turned out to be."
+  [[ "${CONFLICTS_ANNOUNCED:-0}" == "1" ]] || _announce_conflicting_packages "${found[@]}"
 
   local action="${STRIP_CONFLICTS:-}"
   if [[ -z "$action" ]]; then
     if [[ -t 0 ]]; then
-      read -rep $'[\e[1;33mACTION\e[0m] - Remove them now? (Y,n) ' STRIP_CHOICE
-      [[ "$STRIP_CHOICE" == "n" || "$STRIP_CHOICE" == "N" ]] && action="0" || action="1"
+      if confirm "Uninstall them now?" y; then
+        action="1"
+      else
+        action="0"
+      fi
     else
       echo -e "$CWR - Non-interactive install with no --strip-conflicts/--keep-conflicts flag -- leaving them installed. Pass --strip-conflicts to remove them automatically instead."
       action="0"
@@ -83,7 +120,7 @@ check_conflicting_packages() {
   fi
 
   if [[ "$action" != "1" ]]; then
-    echo -e "$CNT - Leaving ${found[*]} installed. Remove by hand later if you hit duplicate bars/launchers/notifications: sudo pacman -Rns ${found[*]}"
+    echo -e "$CNT - Leaving ${found[*]} installed. If you do end up with duplicate bars, launchers or notifications, remove them later with: sudo pacman -Rns ${found[*]}"
     return 0
   fi
 

--- a/lib/install/detect.sh
+++ b/lib/install/detect.sh
@@ -104,8 +104,12 @@ except Exception:
   # which is where line 241 of the old monolithic install.sh used to ask it.
   if [[ -n "$DETECTED_NVIDIA_DRIVER" && -z "$NVIDIA_DRIVER_ACTION" && "$DRY_RUN" != "1" ]]; then
     if [[ -t 0 ]]; then
-      echo -e "$CAT - An NVIDIA driver is already installed (${DETECTED_NVIDIA_DRIVER})."
-      if confirm "Uninstall it and let Aphotic install its recommended nvidia-open-dkms instead of keeping it?" n; then
+      echo -e "\n$CAT - A driver for your NVIDIA graphics card is already installed: ${DETECTED_NVIDIA_DRIVER}."
+      echo -e "  Aphotic normally installs nvidia-open-dkms, NVIDIA's own open-source driver. Switching to it"
+      echo -e "  means removing the driver you have first, and swapping graphics drivers can leave you with no"
+      echo -e "  picture until you reboot."
+      echo -e "  Recommended: keep the one you already have -- Aphotic works fine on it."
+      if confirm "Replace it with nvidia-open-dkms?" n; then
         NVIDIA_DRIVER_ACTION="reinstall"
       else
         NVIDIA_DRIVER_ACTION="keep"

--- a/lib/install/exploit_disclaimer.sh
+++ b/lib/install/exploit_disclaimer.sh
@@ -231,7 +231,13 @@ exploit_disclaimer_gate() {
 
   print_exploit_disclaimer
   local confirm confirm_lower
-  read -rep $'[\e[1;33mACTION\e[0m] - Type "I understand" to continue, or anything else to skip the exploit-* layers: ' confirm
+  # Instruction on its own line, prompt kept short: readline redraws an
+  # over-wide prompt as a truncated tail, which on an 80-column terminal
+  # ate the "Type \"I understand\"" half of the question this gate exists
+  # to ask.
+  echo -e "${CAC:-[ACTION]} - Type \"I understand\" to accept this and continue."
+  echo -e "${CAC:-[ACTION]}   Anything else skips the security tools and installs everything else."
+  read -rep $'[\e[1;33mACTION\e[0m] - Your answer: ' confirm
   confirm_lower=$(echo "$confirm" | tr '[:upper:]' '[:lower:]')
   if [[ "$confirm_lower" != "i understand" ]]; then
     echo -e "$CWR - Disclaimer not accepted -- removing the exploit-* layers from this install."

--- a/lib/install/guided.sh
+++ b/lib/install/guided.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# lib/install/guided.sh
+set -euo pipefail
+
+# The prompt-driven path, for someone installing Aphotic on Arch for the
+# first time.
+#
+# Only runs when install.sh was invoked with no options at all and stdin is
+# a TTY (install.sh's GUIDED gate). Every flag-driven path is untouched:
+# --profile/--with/--theme/--opt-in/--dry-run/--config-only/
+# --strip-conflicts/--keep-conflicts/--accept-exploit-disclaimer, CI, and
+# curl-piped installs all keep taking the same zero-prompt or flag-resolved
+# route they always did.
+#
+# What this replaces: twelve confirm() prompts spread across install.sh and
+# six lib/install modules, each firing wherever the script happened to
+# reach it -- so a first install interleaved layer questions with NVIDIA
+# driver questions, BlackArch questions and shell-activation questions as
+# unrelated interruptions, several of them after the install had already
+# started changing the system. Here they are one ordered conversation:
+# numbered steps, the two consequential questions (NVIDIA driver
+# replacement, BlackArch) left standalone where they can't be skimmed
+# past, and a single summary to accept before anything is touched.
+
+GUIDED_STEP=0
+GUIDED_STEPS=4
+
+_guided_heading() {
+  echo -e "\n\e[1;36m── $1 ──\e[0m"
+}
+
+_guided_step() {
+  GUIDED_STEP=$((GUIDED_STEP + 1))
+  _guided_heading "Step $GUIDED_STEP of $GUIDED_STEPS: $1"
+}
+
+# "${arr[*]}" with IFS=", " joins on the first IFS character only, i.e.
+# a bare comma -- so build the list by hand.
+_guided_join() {
+  local out="" item
+  for item in "$@"; do
+    out="${out:+$out, }$item"
+  done
+  echo "$out"
+}
+
+_guided_profile_label() {
+  case "$1" in
+    minimal) echo "just the desktop (Aphotic and Hyprland only)" ;;
+    full) echo "full desktop (Aphotic plus browser, files, media, fonts)" ;;
+    *) echo "${1:-unknown}" ;;
+  esac
+}
+
+# Plain-language gloss for the plan summary -- the layer names themselves
+# are what aphotic.toml records and what --with takes, so they stay
+# visible, just no longer on their own.
+_guided_layer_label() {
+  case "$1" in
+    gaming) echo "gaming -- Steam, GameMode, MangoHud" ;;
+    dev) echo "development -- Neovim, tmux, fzf, ripgrep, lazygit, GitHub CLI" ;;
+    ai) echo "AI features -- Ollama, agent graph, AI chat, Claude Code" ;;
+    exploit-recon) echo "security: recon -- nmap, amass, subfinder, theHarvester" ;;
+    exploit-web) echo "security: web testing -- Burp Suite CE, sqlmap, ffuf, ZAP" ;;
+    exploit-network) echo "security: network -- Wireshark, aircrack-ng, bettercap" ;;
+    exploit-passwords) echo "security: passwords -- John the Ripper, hashcat, Hydra" ;;
+    exploit-wordlists) echo "security: rockyou wordlist (~130MB)" ;;
+    exploit-reversing) echo "security: reverse engineering -- Ghidra, radare2, gdb" ;;
+    exploit-forensics) echo "security: forensics -- Autopsy, Sleuth Kit, Volatility 3" ;;
+    exploit-reporting) echo "security: report writing -- aphotic report, pandoc" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+guided_intro() {
+  _guided_heading "Guided setup"
+  cat <<'EOF'
+
+This installer turns a working Arch Linux system into the Aphotic desktop:
+a bar, an app launcher, notifications, a lock screen and a settings panel,
+all running on the Hyprland window manager.
+
+A few questions, then a summary of everything that is about to happen.
+Nothing is installed and nothing in your home folder is changed until you
+say yes at that summary. Press Enter at any question to take the default
+shown in brackets.
+
+Accepting every default gets you:
+
+  Software    The full desktop -- Aphotic plus a browser, file manager,
+              terminal, media player, fonts and audio support.
+  Extras      None. The gaming, development, AI and security tool sets are
+              all optional, and any of them can be added later by running
+              this installer again.
+  Look        The "tokyonight" colour theme. Switchable at any time with
+              'aphotic theme set <name>'.
+  Graphics    If a graphics driver is already installed, it is left alone.
+  Your files  Everything currently in ~/.config is copied to a dated
+              backup folder before Aphotic's own config files are written.
+
+EOF
+}
+
+# Steps 1-3: what to install, which optional tool sets, and which theme.
+# Reuses wizard.sh's prompt_profile/prompt_layers/prompt_theme -- the same
+# pickers --opt-in has always used, not a second set.
+guided_configure() {
+  local reused=0
+
+  if [[ "$DETECTED_APHOTIC_INSTALL" == "1" ]]; then
+    echo -e "\n$CNT - Aphotic is already installed on this machine: $(_guided_profile_label "$DETECTED_APHOTIC_PROFILE"), extras: ${DETECTED_APHOTIC_LAYERS:-none}."
+    if confirm "Install it again with those same choices?" y; then
+      PROFILE="$DETECTED_APHOTIC_PROFILE"
+      LAYERS="$DETECTED_APHOTIC_LAYERS"
+      reused=1
+      GUIDED_STEPS=2
+      echo -e "$CNT - Keeping that software selection; you will still be asked about the theme and the optional add-ons."
+    fi
+  fi
+
+  if [[ "$reused" != "1" ]]; then
+    _guided_step "how much software?"
+    echo ""
+    PROFILE=$(prompt_profile)
+
+    _guided_step "optional extra tool sets"
+    cat <<'EOF'
+
+Aphotic is a complete desktop without any of these. Each one is a set of
+programs for a particular kind of work, and any of them can be added later
+by running this installer again.
+
+EOF
+    # Default preset 2 (none) rather than --opt-in's cherry-pick default:
+    # someone who typed no flags at all asked to be walked through, not to
+    # be handed ten follow-up questions for pressing Enter.
+    LAYERS=$(prompt_layers 2)
+  fi
+
+  _guided_step "how it looks"
+  echo ""
+  THEME=$(prompt_theme)
+}
+
+# Step 4: every remaining optional extra in one list, replacing the five
+# separate prompts these used to be (assistant, wallpaper pool, starship,
+# zsh) -- each of which used to fire at a different point in the run, two
+# of them after packages had already been installed.
+#
+# Purely additive: nothing here is on unless its number is typed, so
+# "press Enter" is always the do-nothing answer. Sets the same globals the
+# flags set, which is why the stage functions themselves need no idea this
+# flow exists.
+guided_step_addons() {
+  _guided_step "optional add-ons"
+
+  local -a keys=() lines=()
+  local n=0
+
+  if [[ "$DETECTED_NVIDIA_PRESENT" == "true" ]]; then
+    local recommend=""
+    layer_selected ai && recommend="   (recommended -- you chose the AI extras)"
+    n=$((n + 1)); keys+=("assistant")
+    lines+=("  $n) Aphotic Assistant$recommend
+     A chatbot that runs entirely on this machine and can answer questions
+     about your desktop. Downloads a language model of a few GB, and needs
+     an NVIDIA graphics card (this machine has one). Switching it on also
+     turns on the AI extras it runs from.")
+  fi
+
+  n=$((n + 1)); keys+=("wallpapers")
+  lines+=("  $n) Community wallpaper pack
+     About 145MB of extra wallpapers. Every theme already comes with its
+     own, so this only adds more to choose from.")
+
+  n=$((n + 1)); keys+=("starship")
+  lines+=("  $n) A better terminal prompt (starship)
+     Shows the folder you are in, the git branch and similar, in place of
+     the plain bash prompt. Adds one line to ~/.bashrc.")
+
+  n=$((n + 1)); keys+=("zsh")
+  lines+=("  $n) Use zsh as your shell instead of bash
+     Copies Aphotic's zsh setup and changes your login shell with 'chsh'.
+     Leave this off unless you already know you want zsh.")
+
+  cat <<'EOF'
+
+None of these are required, and each can also be turned on later.
+
+EOF
+  local line
+  for line in "${lines[@]}"; do
+    echo "$line"
+    echo ""
+  done
+
+  local -a picked=()
+  local i
+  for ((i = 0; i < ${#keys[@]}; i++)); do
+    picked+=(0)
+  done
+
+  local answer tok idx
+  local -a tokens=()
+  echo "Type the numbers of any you want, separated by spaces, or press Enter for none."
+  answer=$(prompt_text "Which add-ons? (e.g. \"1 3\", or Enter for none)")
+  read -ra tokens <<< "$answer" || true
+  for tok in ${tokens[@]+"${tokens[@]}"}; do
+    if ! [[ "$tok" =~ ^[0-9]+$ ]]; then
+      echo -e "$CWR - Ignoring \"$tok\" -- expected a number from the list."
+      continue
+    fi
+    idx=$((tok))
+    if (( idx < 1 || idx > ${#keys[@]} )); then
+      echo -e "$CWR - Ignoring \"$tok\" -- there is no add-on with that number."
+      continue
+    fi
+    picked[$((idx - 1))]=1
+  done
+
+  ASSISTANT="false"
+  EXTRA_WALLPAPERS=0
+  ACTIVATE_STARSHIP=0
+  ACTIVATE_ZSH=0
+
+  local -a chosen=()
+  for ((i = 0; i < ${#keys[@]}; i++)); do
+    [[ "${picked[$i]}" == "1" ]] || continue
+    case "${keys[$i]}" in
+      assistant) ASSISTANT="true"; chosen+=("Aphotic Assistant") ;;
+      wallpapers) EXTRA_WALLPAPERS=1; chosen+=("community wallpaper pack") ;;
+      starship) ACTIVATE_STARSHIP=1; chosen+=("starship prompt") ;;
+      zsh) ACTIVATE_ZSH=1; chosen+=("zsh as your shell") ;;
+    esac
+  done
+
+  # Configs are not an add-on: a desktop with no config files deployed is
+  # not a working install, so the guided path decides this rather than
+  # asking (install.sh's own "copy config files?" prompt, which defaulted
+  # to no, is still there for flag-driven runs).
+  COPY_CONFIGS=1
+
+  if [[ ${#chosen[@]} -eq 0 ]]; then
+    echo -e "$CNT - No add-ons selected."
+  else
+    echo -e "$CNT - Add-ons: $(_guided_join "${chosen[@]}")"
+  fi
+}
+
+# The one place a guided install can still say no. Everything above this
+# point has only recorded answers; the first change to the system happens
+# after it.
+guided_plan_and_confirm() {
+  local prep_pkgs="$1" main_pkgs="$2"
+  local prep_count main_count total _plan_layers
+
+  prep_count=$(grep -c . <<< "$prep_pkgs" || true)
+  main_count=$(grep -c . <<< "$main_pkgs" || true)
+  total=$((prep_count + main_count))
+
+  _guided_heading "Ready to install"
+  echo ""
+  printf '  %-16s %s\n' "Software" "$(_guided_profile_label "$PROFILE")"
+
+  if [[ -z "$LAYERS" ]]; then
+    printf '  %-16s %s\n' "Extra tool sets" "none"
+  else
+    local first=1 name
+    IFS=',' read -ra _plan_layers <<< "$LAYERS" || true
+    for name in "${_plan_layers[@]}"; do
+      if [[ "$first" == "1" ]]; then
+        printf '  %-16s %s\n' "Extra tool sets" "$(_guided_layer_label "$name")"
+        first=0
+      else
+        printf '  %-16s %s\n' "" "$(_guided_layer_label "$name")"
+      fi
+    done
+  fi
+
+  printf '  %-16s %s\n' "Theme" "$THEME"
+
+  local addons=()
+  [[ "$ASSISTANT" == "true" ]] && addons+=("Aphotic Assistant")
+  [[ "${EXTRA_WALLPAPERS:-0}" == "1" ]] && addons+=("community wallpaper pack")
+  [[ "${ACTIVATE_STARSHIP:-0}" == "1" ]] && addons+=("starship prompt")
+  [[ "${ACTIVATE_ZSH:-0}" == "1" ]] && addons+=("zsh as your login shell")
+  if [[ ${#addons[@]} -eq 0 ]]; then
+    printf '  %-16s %s\n' "Add-ons" "none"
+  else
+    printf '  %-16s %s\n' "Add-ons" "$(_guided_join "${addons[@]}")"
+  fi
+
+  if [[ "$DETECTED_NVIDIA_PRESENT" == "true" ]]; then
+    if [[ -n "$DETECTED_NVIDIA_DRIVER" ]]; then
+      if [[ "$NVIDIA_DRIVER_ACTION" == "reinstall" ]]; then
+        printf '  %-16s %s\n' "Graphics" "replacing $DETECTED_NVIDIA_DRIVER with nvidia-open-dkms"
+      else
+        printf '  %-16s %s\n' "Graphics" "keeping the NVIDIA driver you already have ($DETECTED_NVIDIA_DRIVER)"
+      fi
+    else
+      printf '  %-16s %s\n' "Graphics" "installing the NVIDIA driver (nvidia-open-dkms) for your card"
+    fi
+  fi
+
+  printf '  %-16s %s\n' "Packages" "$total to install, after a full system update (pacman -Syu)"
+  if [[ "$NO_BACKUP" == "1" ]]; then
+    printf '  %-16s %s\n' "Your configs" "NOT backed up (--no-backup), then overwritten by Aphotic's"
+  else
+    printf '  %-16s %s\n' "Your configs" "~/.config copied to $(backup_root)/<date>, then Aphotic's copied in"
+  fi
+  [[ "$PROFILE" == "full" ]] && printf '  %-16s %s\n' "Login screen" "SDDM enabled and themed, so you can pick Hyprland at login"
+  printf '  %-16s %s\n' "Password" "some steps need sudo -- you will be asked for yours"
+  echo ""
+  echo "This takes a while: it builds AUR packages, and on a slow connection"
+  echo "the downloads dominate. Progress and errors are logged to $INSTLOG."
+  echo ""
+
+  if confirm "Start the install now?" y; then
+    return 0
+  fi
+
+  echo -e "$CNT - Stopped. No packages were installed and nothing in your home folder was changed."
+  echo -e "$CNT - Run ./install.sh again whenever you want to go through this."
+  exit 0
+}

--- a/lib/install/hyprland_launch.sh
+++ b/lib/install/hyprland_launch.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 offer_start_hyprland() {
-  confirm "Would you like to start Hyprland now?" n || return 0
+  echo -e "\n$CNT - Aphotic is installed. You can sign in to it from the graphical login screen,"
+  echo -e "$CNT   either by starting that now or by rebooting -- both work the same."
+  confirm "Start the login screen now?" n || return 0
   exec sudo systemctl start sddm &>> "$INSTLOG"
 }

--- a/lib/install/shell_activation.sh
+++ b/lib/install/shell_activation.sh
@@ -2,9 +2,19 @@
 # lib/install/shell_activation.sh
 set -euo pipefail
 
+# ACTIVATE_STARSHIP / ACTIVATE_ZSH are "" (nobody has decided -- ask), "1"
+# or "0". The guided flow answers both in its one batched add-ons step, so
+# these no longer interrupt it near the end of a run; a flag-driven
+# install leaves them unset and still gets asked here, exactly as before.
 activate_starship() {
-  confirm "Would you like to activate the starship shell?" n || return 0
-  echo -e "$CNT - Activating starship..."
+  if [[ -n "${ACTIVATE_STARSHIP:-}" ]]; then
+    [[ "$ACTIVATE_STARSHIP" == "1" ]] || return 0
+  else
+    echo -e "\n$CNT - The starship prompt shows the folder you are in, the git branch and similar in"
+    echo -e "$CNT   your terminal, in place of the plain bash prompt. It adds one line to ~/.bashrc."
+    confirm "Use the starship prompt?" n || return 0
+  fi
+  echo -e "$CNT - Setting up the starship prompt..."
   if ! grep -qF 'starship init bash' "$HOME/.bashrc" 2>/dev/null; then
     echo -e '\neval "$(starship init bash)"' >> "$HOME/.bashrc"
   fi
@@ -12,8 +22,14 @@ activate_starship() {
 }
 
 activate_zsh() {
-  confirm "Would you like to activate zsh shell?" n || return 0
-  echo -e "$CNT - Activating zsh..."
+  if [[ -n "${ACTIVATE_ZSH:-}" ]]; then
+    [[ "$ACTIVATE_ZSH" == "1" ]] || return 0
+  else
+    echo -e "\n$CNT - This copies Aphotic's zsh setup into your home folder and changes your login"
+    echo -e "$CNT   shell from bash to zsh (with 'chsh'), which takes effect next time you log in."
+    confirm "Switch your shell to zsh?" n || return 0
+  fi
+  echo -e "$CNT - Setting up zsh..."
   cp "$ROOT_DIR/Configs/.p10k.zsh" "$HOME"
   cp "$ROOT_DIR/Configs/.zshrc" "$HOME"
   chsh -s "$(which zsh)"

--- a/lib/install/ui.sh
+++ b/lib/install/ui.sh
@@ -13,6 +13,12 @@ set -euo pipefail
 # argument -- unlike `echo -e` -- never interprets `\e` itself.
 _ui_action_tag() { printf '%b' "${CAC:-[ACTION]}"; }
 
+# Keep every <prompt> here to one short line and echo any explanation
+# above the call instead: `read -e` hands the prompt to readline, which
+# redraws a prompt longer than the terminal width as a truncated "<...end
+# of prompt" fragment, so a wordy question silently loses its beginning on
+# an 80-column terminal.
+#
 # confirm <prompt> [default: y|n] -- returns 0 for yes, 1 for no. A closed/
 # exhausted stdin (read failing outright, not just an empty Enter) always
 # resolves to "no" regardless of the requested default -- matching what

--- a/lib/install/wallpapers.sh
+++ b/lib/install/wallpapers.sh
@@ -2,10 +2,26 @@
 # lib/install/wallpapers.sh
 set -euo pipefail
 
+# EXTRA_WALLPAPERS is "" (nobody has decided -- ask), "1" or "0"; the
+# guided flow answers it in its batched add-ons step, see
+# activate_starship's note in shell_activation.sh.
 offer_extra_wallpapers() {
-  if confirm "Download the larger community wallpaper pool now? ~145MB across all 8 themes; each theme already ships a handful of wallpapers regardless, this just adds more choice. Skip if you're on a slow connection" n; then
-    "$HOME/.local/bin/aphotic" wallpaper --fetch-extra -y || echo -e "$CWR - Could not fetch extra wallpapers now; run 'aphotic wallpaper --fetch-extra' any time later."
+  local wanted="${EXTRA_WALLPAPERS:-}"
+  if [[ -z "$wanted" ]]; then
+    echo -e "\n$CNT - The community wallpaper collection is about 145MB across all 8 themes. Every"
+    echo -e "$CNT   theme already comes with its own wallpapers, so this only adds more to choose"
+    echo -e "$CNT   from -- skip it if your connection is slow, it can be fetched any time later."
+    if confirm "Download the extra wallpapers now?" n; then
+      wanted=1
+    else
+      wanted=0
+    fi
+  fi
+
+  if [[ "$wanted" == "1" ]]; then
+    echo -e "$CNT - Downloading the community wallpaper collection..."
+    "$HOME/.local/bin/aphotic" wallpaper --fetch-extra -y || echo -e "$CWR - Could not fetch the extra wallpapers now; run 'aphotic wallpaper --fetch-extra' any time later."
   else
-    echo -e "$CNT - Skipping the extra wallpaper pool. Run 'aphotic wallpaper --fetch-extra' any time later to get it."
+    echo -e "$CNT - Skipping the extra wallpapers. Run 'aphotic wallpaper --fetch-extra' any time later to get them."
   fi
 }

--- a/lib/install/wizard.sh
+++ b/lib/install/wizard.sh
@@ -13,28 +13,51 @@ layer_selected() {
   return 1
 }
 
+
+# Every question below is worded for someone whose first Arch install this
+# is: no bare layer names, no "AUR"/"multilib"/"repo" without a line of
+# context, and the concrete programs each choice installs spelled out. The
+# order and number of reads is load-bearing -- tests/test_wizard.sh drives
+# these by feeding positional answers, and the guided flow reuses them
+# rather than carrying a second copy.
+
 prompt_profile() {
   local answer
-  read -rp "Profile? [minimal/full] (full): " answer
-  answer="${answer:-full}"
-  if [[ "$answer" != "minimal" && "$answer" != "full" ]]; then
-    echo "full"
-  else
-    echo "$answer"
-  fi
+  cat >&2 <<'EOF'
+  1) Full desktop  (recommended)
+     Everything a day-to-day machine needs: the Aphotic desktop plus
+     Firefox, a file manager, a terminal, an image and video player,
+     fonts, Bluetooth and audio support.
+
+  2) Just the desktop
+     Only what Aphotic itself needs to run. No browser, no media player,
+     no fonts beyond the ones the desktop uses -- you install the
+     programs you want yourself afterwards.
+
+EOF
+  read -rp "Your choice? [1-2, default 1 - full desktop]: " answer
+  case "$answer" in
+    2|minimal) echo "minimal" ;;
+    *) echo "full" ;;
+  esac
 }
 
+# prompt_layers [default-preset] -- default-preset is which option an empty
+# answer takes (3, cherry-pick, for --opt-in; the guided flow passes 2, so
+# pressing Enter through a first install adds nothing).
 prompt_layers() {
+  local default_preset="${1:-3}"
   local layers=()
   local answer
 
-  # Presets are a shortcut over the same layer list the questions below
-  # build -- not a second mechanism. "Cherry-pick" is just answering them.
-  echo "Layer presets:" >&2
-  echo "  1) Everything       -- gaming, dev, ai, and the default exploit bundle" >&2
-  echo "  2) Daily driver     -- none of the above; a clean Hyprland desktop" >&2
-  echo "  3) Cherry-pick      -- choose each layer yourself" >&2
-  read -rp "Preset? [1/2/3, default 3]: " answer
+  # Presets are a shortcut over the same questions below -- not a second
+  # mechanism. "One by one" is just answering them.
+  echo "Optional extra tool sets:" >&2
+  echo "  1) All of them      -- gaming, development, AI and security tools" >&2
+  echo "  2) None             -- just the desktop; add any of these later" >&2
+  echo "  3) Choose one by one" >&2
+  read -rp "Your choice? [1-3, default $default_preset]: " answer
+  answer="${answer:-$default_preset}"
   case "$answer" in
     1)
       echo "gaming,dev,ai,exploit"
@@ -46,47 +69,84 @@ prompt_layers() {
       ;;
   esac
 
-  read -rp "Enable gaming layer? [y/N]: " answer
+  cat >&2 <<'EOF'
+
+  Gaming
+    Steam, plus GameMode and MangoHud -- one tunes the system while a game
+    is running, the other shows framerate and temperatures on screen. This
+    also switches on "multilib", an official Arch package collection that
+    is off by default and carries the 32-bit libraries many games need.
+EOF
+  read -rp "  Install the gaming tools? [y/N]: " answer
   [[ "$answer" =~ ^[Yy]$ ]] && layers+=("gaming")
 
-  read -rp "Enable dev layer? [y/N]: " answer
+  cat >&2 <<'EOF'
+
+  Development
+    Neovim, tmux, fzf, ripgrep, fd, lazygit and the GitHub command line --
+    a terminal-based coding setup. Adding these does not change any editor
+    or shell you already use.
+EOF
+  read -rp "  Install the development tools? [y/N]: " answer
   [[ "$answer" =~ ^[Yy]$ ]] && layers+=("dev")
 
-  # Say what this actually does before asking: it is the only layer that
-  # writes into a config file outside this repo (~/.claude/settings.json).
-  read -rp "Enable ai layer? Adds the agent graph, AI chat and live Claude Code session tracking -- wires hooks into ~/.claude/settings.json and enables a usage-tracking timer [y/N]: " answer
+  # Say what this actually does before asking: it is the only choice here
+  # that writes into a config file outside this project's own files
+  # (~/.claude/settings.json).
+  cat >&2 <<'EOF'
+
+  AI features
+    Ollama, which runs language models locally on this machine, plus
+    Aphotic's agent graph, AI chat panel and live Claude Code session
+    tracking. This is the only choice here that writes outside Aphotic's
+    own files: it adds hooks to ~/.claude/settings.json and switches on a
+    timer that records how much you use those tools. What it records stays
+    in your home folder.
+EOF
+  read -rp "  Install the AI features? [y/N]: " answer
   [[ "$answer" =~ ^[Yy]$ ]] && layers+=("ai")
 
-  read -rp "Enable exploit/offensive-security tooling? Adds the BlackArch repo for most sublayers -- less stable than Arch's official repos, see docs/exploit-layer.md [y/N]: " answer
+  cat >&2 <<'EOF'
+
+  Security / penetration-testing tools
+    Scanners and testing tools for networks, websites and files. Most of
+    them are not in Arch's own package collections and come from BlackArch
+    instead: a large third-party collection that moves fast and breaks
+    more often than Arch's. You will be asked separately before it is
+    added, and asked to agree that you will only use these tools on
+    systems you own or have written permission to test.
+EOF
+  read -rp "  Install security tools? [y/N]: " answer
   if [[ "$answer" =~ ^[Yy]$ ]]; then
-    read -rp "  Use the default bundle (recon + web + network)? [Y/n]: " answer
+    echo "    The usual starting set is recon + web + network." >&2
+    read -rp "    Use that starting set? [Y/n]: " answer
     if [[ ! "$answer" =~ ^[Nn]$ ]]; then
       layers+=("exploit")
     else
-      read -rp "  Enable exploit-recon (nmap, amass, subfinder, theHarvester, recon-ng)? [y/N]: " answer
+      read -rp "    Recon -- finds hosts, subdomains and open ports (nmap, amass, subfinder, theHarvester, recon-ng)? [y/N]: " answer
       [[ "$answer" =~ ^[Yy]$ ]] && layers+=("exploit-recon")
 
-      read -rp "  Enable exploit-web (Burp Suite CE, sqlmap, ffuf, gobuster, nikto, ZAP)? [y/N]: " answer
+      read -rp "    Web -- tests websites and web apps (Burp Suite CE, sqlmap, ffuf, gobuster, nikto, ZAP)? [y/N]: " answer
       [[ "$answer" =~ ^[Yy]$ ]] && layers+=("exploit-web")
 
-      read -rp "  Enable exploit-network (Wireshark, aircrack-ng, bettercap, tcpdump)? [y/N]: " answer
+      read -rp "    Network -- captures and inspects network traffic (Wireshark, aircrack-ng, bettercap, tcpdump)? [y/N]: " answer
       [[ "$answer" =~ ^[Yy]$ ]] && layers+=("exploit-network")
     fi
 
-    read -rp "  Enable exploit-passwords (John the Ripper, hashcat, Hydra)? [y/N]: " answer
+    read -rp "    Passwords -- tries to recover passwords from stored hashes (John the Ripper, hashcat, Hydra)? [y/N]: " answer
     if [[ "$answer" =~ ^[Yy]$ ]]; then
       layers+=("exploit-passwords")
-      read -rp "    Also fetch the rockyou wordlist? ~130MB decompressed, from the OWASP SecLists project -- always separate, never bundled automatically [y/N]: " answer
+      read -rp "      Also download the rockyou list of common passwords? ~130MB, from the OWASP SecLists project -- always a separate choice, never included on its own [y/N]: " answer
       [[ "$answer" =~ ^[Yy]$ ]] && layers+=("exploit-wordlists")
     fi
 
-    read -rp "  Enable exploit-reversing (Ghidra, radare2, Cutter, gdb+pwndbg, binwalk)? [y/N]: " answer
+    read -rp "    Reverse engineering -- takes compiled programs apart to see what they do (Ghidra, radare2, Cutter, gdb + pwndbg, binwalk)? [y/N]: " answer
     [[ "$answer" =~ ^[Yy]$ ]] && layers+=("exploit-reversing")
 
-    read -rp "  Enable exploit-forensics (Autopsy, Sleuth Kit, Volatility 3)? [y/N]: " answer
+    read -rp "    Digital forensics -- examines disk images and memory dumps (Autopsy, Sleuth Kit, Volatility 3)? [y/N]: " answer
     [[ "$answer" =~ ^[Yy]$ ]] && layers+=("exploit-forensics")
 
-    read -rp "  Enable exploit-reporting (engagement report scaffolding, aphotic report CLI)? [y/N]: " answer
+    read -rp "    Report writing -- templates and an 'aphotic report' command for writing up findings? [y/N]: " answer
     [[ "$answer" =~ ^[Yy]$ ]] && layers+=("exploit-reporting")
   fi
 
@@ -146,17 +206,20 @@ prompt_theme() {
     [[ "${names[$i]}" == "tokyonight" ]] && default_idx=$((i + 1))
   done
 
-  echo "Available themes:" >&2
+  echo "Colours. Each theme restyles the whole desktop -- bar, menus," >&2
+  echo "notifications and wallpapers. You can change it at any time" >&2
+  echo "afterwards with 'aphotic theme set <name>'." >&2
+  echo "" >&2
   for i in "${!names[@]}"; do
     printf '  %d) %-12s %s\n' "$((i + 1))" "${names[$i]}" "${labels[$i]}" >&2
   done
-  read -rp "Theme? [1-${#names[@]}] (default ${default_idx} - ${names[$((default_idx - 1))]}): " answer
+  read -rp "Your choice? [1-${#names[@]}, default ${default_idx} - ${names[$((default_idx - 1))]}]: " answer
   answer="${answer:-$default_idx}"
 
   if [[ "$answer" =~ ^[0-9]+$ ]] && (( answer >= 1 && answer <= ${#names[@]} )); then
     echo "${names[$((answer - 1))]}"
   else
-    echo -e "$CWR - Invalid selection, using ${names[$((default_idx - 1))]}." >&2
+    echo -e "$CWR - That isn't one of the numbers listed, using ${names[$((default_idx - 1))]}." >&2
     echo "${names[$((default_idx - 1))]}"
   fi
 }
@@ -205,29 +268,29 @@ except Exception:
   [[ -z "$THEME" ]] && THEME="$saved_theme"
 }
 
-# Resolves PROFILE/LAYERS/THEME for a fresh (non---config-only) install.
+# Resolves PROFILE/LAYERS/THEME for a flag-driven (non---config-only)
+# install -- the guided path takes guided_configure() in
+# lib/install/guided.sh instead, and never reaches this function.
 #
-# Default, with none of --profile/--with/--opt-in passed, is the
-# zero-prompt "daily driver" path -- full profile, no optional layers. A
-# brand-new Arch/Hyprland user shouldn't have to know what a "layer" or
-# "profile" is before they can finish installing; --opt-in restores the
-# full interactive cherry-pick wizard below for anyone who wants it, and
-# any of --profile/--with/--theme passed directly always wins over both.
+# Default here, with none of --profile/--with/--opt-in passed, is still
+# the zero-prompt "daily driver" path -- full profile, no optional layers.
+# That is what a piped/no-TTY install gets (a bare `./install.sh` on a
+# terminal now gets the guided flow instead), and --opt-in still restores
+# the cherry-pick pickers above for anyone who wants only those; any of
+# --profile/--with/--theme passed directly always wins over both.
 #
 # This is a deliberate judgment call, not a mechanical default: real
 # layer packages still only install via this terminal flow today (no
-# other mechanism exists yet), so the wizard itself isn't going away, just
-# no longer imposed on every fresh install by default. See the PR
-# description for the fuller reasoning and why a post-first-launch picker
-# isn't built here instead.
+# other mechanism exists yet), so the pickers aren't going away, just no
+# longer imposed on every fresh install by default.
 resolve_config() {
   # Reuses detect.sh's already-computed findings (stage 1) rather than
   # re-querying aphotic.toml here -- the whole point of a consolidated
   # detection pass is that later stages consume it instead of repeating it.
   if [[ "$DETECTED_APHOTIC_INSTALL" == "1" && -z "$PROFILE" && -z "$LAYERS" ]]; then
-    echo -e "$CNT - Existing config found (profile=$DETECTED_APHOTIC_PROFILE, layers=${DETECTED_APHOTIC_LAYERS:-none})."
+    echo -e "$CNT - Aphotic is already installed here (profile=$DETECTED_APHOTIC_PROFILE, extras=${DETECTED_APHOTIC_LAYERS:-none})."
     if [[ -t 0 ]]; then
-      if confirm "Reinstall same config?" y; then
+      if confirm "Install it again with those same choices?" y; then
         PROFILE="$DETECTED_APHOTIC_PROFILE"
         LAYERS="$DETECTED_APHOTIC_LAYERS"
       fi
@@ -243,7 +306,7 @@ resolve_config() {
 
   if [[ -z "$PROFILE" && -z "$LAYERS" && "$OPT_IN" != "1" ]]; then
     echo -e "$CNT - No --profile/--with/--opt-in given -- installing the daily-driver setup (full profile, no optional layers: gaming/dev/ai/exploit)."
-    echo -e "$CNT - Run with --opt-in for the interactive layer picker, or --with gaming,dev,ai,exploit to pick layers directly. Layers can always be added later by re-running install.sh."
+    echo -e "$CNT - Run ./install.sh with no options at all for the guided setup, --opt-in for just the layer picker, or --with gaming,dev,ai,exploit to pick layers directly. Layers can always be added later by re-running install.sh."
     PROFILE="full"
     LAYERS=""
     [[ -z "$THEME" ]] && THEME="tokyonight"

--- a/tests/test_install_default_profile.sh
+++ b/tests/test_install_default_profile.sh
@@ -21,14 +21,15 @@ status=$?
 echo "$output" | grep -q "profile: full" || fail "expected the bare invocation to default to profile: full"
 echo "$output" | grep -q "^  layers: $" || fail "expected the bare invocation to default to no layers"
 echo "$output" | grep -qi "daily-driver setup" || fail "expected a note explaining the zero-prompt default"
-echo "$output" | grep -q "Layer presets:" && fail "bare invocation must not show the interactive layer picker"
+echo "$output" | grep -q "Optional extra tool sets:" && fail "bare invocation must not show the interactive layer picker"
 
 [[ ! -f aphotic.toml ]] || fail "dry-run should not have written aphotic.toml"
 
-# --opt-in restores the interactive wizard: answer profile, preset 1
+# --opt-in restores just the pickers (not the guided flow, which only
+# engages with no flags at all on a TTY): answer profile, preset 1
 # (everything), theme.
 output=$(printf "full\n1\ndefault\n" | bash install.sh --dry-run --opt-in 2>&1)
-echo "$output" | grep -q "Layer presets:" || fail "expected --opt-in to show the interactive layer picker"
+echo "$output" | grep -q "Optional extra tool sets:" || fail "expected --opt-in to show the interactive layer picker"
 echo "$output" | grep -q "layers: gaming,dev,ai,exploit-recon,exploit-web,exploit-network" \
   || fail "expected --opt-in preset 1 to resolve to the full layer set"
 

--- a/tests/test_install_guided.sh
+++ b/tests/test_install_guided.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# tests/test_install_guided.sh
+#
+# The guided (no-flags, TTY) install path in lib/install/guided.sh: the
+# four ordered steps, the batched add-ons step that replaced five
+# scattered prompts, the summary gate, and -- most importantly -- that
+# none of it engages for a flag-driven or non-TTY run, which is what
+# every scripted/CI caller relies on.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CNT="[NOTE]"; COK="[OK]"; CER="[ERROR]"; CWR="[WARNING]"; CAT="[ATTENTION]"; CAC="[ACTION]"
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+INSTLOG="$WORKDIR/install.log"
+APHOTIC_BACKUP_ROOT="$WORKDIR/.config-backup"
+
+source "$ROOT/lib/install/ui.sh"
+source "$ROOT/lib/install/backup.sh"
+source "$ROOT/lib/install/wizard.sh"
+source "$ROOT/lib/install/conflicts.sh"
+source "$ROOT/lib/install/guided.sh"
+
+# Answers are fed from a real file, not a pipe: guided_configure calls the
+# pickers in command substitutions, and only a seekable fd keeps the read
+# position shared across those subshells.
+answers() { printf '%b' "$1" > "$WORKDIR/answers"; }
+
+# --- the gate: a flag-driven, no-TTY run must never enter the guided flow
+cd "$ROOT"
+rm -f aphotic.toml
+output=$(bash install.sh --dry-run --profile full --theme default < /dev/null 2>&1)
+echo "$output" | grep -q "Guided setup" && fail "--dry-run must not enter the guided flow"
+echo "$output" | grep -q "Ready to install" && fail "--dry-run must not show the guided summary"
+echo "$output" | grep -q "profile: full" || fail "expected the flag-driven dry-run plan, got: $output"
+
+output=$(bash install.sh --dry-run < /dev/null 2>&1)
+echo "$output" | grep -q "Guided setup" && fail "a bare no-TTY run must not enter the guided flow"
+echo "$output" | grep -qi "daily-driver setup" || fail "expected the zero-prompt daily-driver default to survive"
+
+# --- steps 1-3, accepting every default
+DETECTED_APHOTIC_INSTALL=0 DETECTED_APHOTIC_PROFILE="" DETECTED_APHOTIC_LAYERS=""
+PROFILE="" LAYERS="" THEME=""
+GUIDED_STEP=0 GUIDED_STEPS=4
+answers '\n\n\n'
+guided_configure < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$PROFILE" == "full" ]] || fail "expected default profile 'full', got '$PROFILE'"
+[[ -z "$LAYERS" ]] || fail "expected no extras by default, got '$LAYERS'"
+[[ "$THEME" == "tokyonight" ]] || fail "expected default theme 'tokyonight', got '$THEME'"
+grep -q "Step 1 of 4" "$WORKDIR/out" || fail "expected numbered steps, got: $(cat "$WORKDIR/out")"
+grep -q "Step 3 of 4: how it looks" "$WORKDIR/out" || fail "expected step 3 to be the theme picker"
+
+# --- steps 1-3, minimal + every extra + first theme
+PROFILE="" LAYERS="" THEME=""
+GUIDED_STEP=0 GUIDED_STEPS=4
+answers '2\n1\n1\n'
+guided_configure < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$PROFILE" == "minimal" ]] || fail "expected 'minimal' for choice 2, got '$PROFILE'"
+[[ "$LAYERS" == "gaming,dev,ai,exploit" ]] || fail "expected all extras, got '$LAYERS'"
+[[ "$THEME" == "gruvbox" ]] || fail "expected 'gruvbox' for theme 1, got '$THEME'"
+
+# --- an existing install is offered back, and skips steps 1-2
+DETECTED_APHOTIC_INSTALL=1 DETECTED_APHOTIC_PROFILE="minimal" DETECTED_APHOTIC_LAYERS="gaming,dev"
+PROFILE="" LAYERS="" THEME=""
+GUIDED_STEP=0 GUIDED_STEPS=4
+answers '\n\n'
+guided_configure < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$PROFILE" == "minimal" ]] || fail "expected the saved profile to be reused, got '$PROFILE'"
+[[ "$LAYERS" == "gaming,dev" ]] || fail "expected the saved extras to be reused, got '$LAYERS'"
+[[ "$THEME" == "tokyonight" ]] || fail "expected the theme to still be asked, got '$THEME'"
+grep -q "Step 1 of 2" "$WORKDIR/out" || fail "expected a 2-step flow when reusing, got: $(cat "$WORKDIR/out")"
+DETECTED_APHOTIC_INSTALL=0
+
+# --- step 4: pressing Enter turns nothing on
+DETECTED_NVIDIA_PRESENT="true" DETECTED_NVIDIA_DRIVER=""
+LAYERS="" ASSISTANT="" EXTRA_WALLPAPERS="" ACTIVATE_STARSHIP="" ACTIVATE_ZSH="" COPY_CONFIGS=""
+GUIDED_STEP=3 GUIDED_STEPS=4
+answers '\n'
+guided_step_addons < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$ASSISTANT" == "false" ]] || fail "expected the assistant off by default, got '$ASSISTANT'"
+[[ "$EXTRA_WALLPAPERS" == "0" ]] || fail "expected extra wallpapers off by default, got '$EXTRA_WALLPAPERS'"
+[[ "$ACTIVATE_STARSHIP" == "0" ]] || fail "expected starship off by default, got '$ACTIVATE_STARSHIP'"
+[[ "$ACTIVATE_ZSH" == "0" ]] || fail "expected zsh off by default, got '$ACTIVATE_ZSH'"
+[[ "$COPY_CONFIGS" == "1" ]] || fail "guided installs must always deploy configs, got '$COPY_CONFIGS'"
+grep -q "No add-ons selected" "$WORKDIR/out" || fail "expected the empty selection echoed back"
+grep -q "Step 4 of 4" "$WORKDIR/out" || fail "expected the add-ons step numbered 4"
+
+# --- step 4: numbers select, garbage is reported and ignored
+answers '1 3 nope 9\n'
+guided_step_addons < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$ASSISTANT" == "true" ]] || fail "expected add-on 1 (assistant) selected"
+[[ "$ACTIVATE_STARSHIP" == "1" ]] || fail "expected add-on 3 (starship) selected"
+[[ "$EXTRA_WALLPAPERS" == "0" ]] || fail "expected add-on 2 left alone"
+[[ "$ACTIVATE_ZSH" == "0" ]] || fail "expected add-on 4 left alone"
+grep -q 'Ignoring "nope"' "$WORKDIR/out" || fail "expected non-numeric input to be reported"
+grep -q 'Ignoring "9"' "$WORKDIR/out" || fail "expected out-of-range input to be reported"
+grep -q "Add-ons: Aphotic Assistant, starship prompt" "$WORKDIR/out" \
+  || fail "expected the selection echoed back as a readable list, got: $(cat "$WORKDIR/out")"
+
+# --- step 4: no NVIDIA card means no assistant row at all, so the numbers shift
+DETECTED_NVIDIA_PRESENT="false"
+answers '1\n'
+guided_step_addons < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$ASSISTANT" == "false" ]] || fail "the assistant must not be offered without an NVIDIA card"
+[[ "$EXTRA_WALLPAPERS" == "1" ]] || fail "expected 1 to be the wallpaper pack when the assistant row is absent"
+grep -q "Aphotic Assistant" "$WORKDIR/out" && fail "assistant row shown without an NVIDIA card"
+
+# --- the summary gate: declining stops without touching anything
+DETECTED_NVIDIA_PRESENT="true" DETECTED_NVIDIA_DRIVER="nvidia-dkms" NVIDIA_DRIVER_ACTION="keep"
+PROFILE="full" LAYERS="gaming,ai" THEME="tokyonight" NO_BACKUP=0
+ASSISTANT="false" EXTRA_WALLPAPERS=0 ACTIVATE_STARSHIP=0 ACTIVATE_ZSH=0
+answers 'n\n'
+set +e
+output=$(guided_plan_and_confirm "qt6-wayland
+jq" "quickshell
+kitty
+firefox" < "$WORKDIR/answers" 2>&1)
+status=$?
+set -e
+[[ "$status" -eq 0 ]] || fail "declining the summary should exit 0, got $status"
+echo "$output" | grep -q "5 to install" || fail "expected the package count in the summary, got: $output"
+echo "$output" | grep -q "keeping the NVIDIA driver you already have" || fail "expected the NVIDIA plan line, got: $output"
+echo "$output" | grep -q "gaming -- Steam" || fail "expected extras spelled out in plain language, got: $output"
+echo "$output" | grep -q "full desktop (Aphotic plus browser" || fail "expected a plain-language profile line, got: $output"
+echo "$output" | grep -q "No packages were installed" || fail "expected an explicit nothing-happened message, got: $output"
+
+answers 'y\n'
+guided_plan_and_confirm "jq" "quickshell" < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1 \
+  || fail "accepting the summary should return 0"
+
+# --- the replaced-role packages question moves ahead of the summary, and
+#     only records an answer there (the removal still happens in prep)
+pacman() { [[ "$1" == "-Qq" ]] && printf "bash\nwaybar\n"; }
+sudo() { echo "SUDO_CALLED_UNEXPECTEDLY: $*"; }
+export -f sudo
+STRIP_CONFLICTS=""
+answers '\n'
+prompt_conflicting_packages < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$STRIP_CONFLICTS" == "1" ]] || fail "expected the default answer to remove replaced-role packages, got '$STRIP_CONFLICTS'"
+grep -q "SUDO_CALLED_UNEXPECTEDLY" "$WORKDIR/out" && fail "the early question must not uninstall anything itself"
+
+STRIP_CONFLICTS=""
+answers 'n\n'
+prompt_conflicting_packages < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$STRIP_CONFLICTS" == "0" ]] || fail "expected 'n' to keep the packages, got '$STRIP_CONFLICTS'"
+
+# an explicit --strip-conflicts/--keep-conflicts is never re-asked
+STRIP_CONFLICTS="0"
+answers 'y\n'
+prompt_conflicting_packages < "$WORKDIR/answers" > "$WORKDIR/out" 2>&1
+[[ "$STRIP_CONFLICTS" == "0" ]] || fail "a flag-set answer must not be overridden by the prompt"
+unset -f sudo pacman
+
+echo "PASS: guided install flow (steps, batched add-ons, summary gate, flag bypass)"

--- a/tests/test_wizard.sh
+++ b/tests/test_wizard.sh
@@ -12,6 +12,12 @@ result=$(echo "" | prompt_profile)
 result=$(echo "minimal" | prompt_profile)
 [[ "$result" == "minimal" ]] || fail "expected 'minimal', got '$result'"
 
+result=$(echo "1" | prompt_profile)
+[[ "$result" == "full" ]] || fail "expected menu choice 1 to be 'full', got '$result'"
+
+result=$(echo "2" | prompt_profile)
+[[ "$result" == "minimal" ]] || fail "expected menu choice 2 to be 'minimal', got '$result'"
+
 result=$(printf "3\ny\nn\ny\nn\n" | prompt_layers)
 [[ "$result" == "gaming,ai" ]] || fail "expected 'gaming,ai', got '$result'"
 
@@ -34,6 +40,18 @@ result=$(printf "3\nn\nn\nn\ny\nn\ny\ny\nn\nn\nn\nn\nn\n" | prompt_layers)
 # exploit enabled, default bundle accepted, passwords + wordlist opt-in
 result=$(printf "3\nn\nn\nn\ny\ny\ny\ny\nn\nn\nn\n" | prompt_layers)
 [[ "$result" == "exploit,exploit-passwords,exploit-wordlists" ]] || fail "expected 'exploit,exploit-passwords,exploit-wordlists', got '$result'"
+
+# An empty answer takes the default preset, which is the caller's to pick:
+# --opt-in leaves it at 3 (ask each one), the guided flow passes 2 (none),
+# so pressing Enter through a first install adds nothing.
+result=$(printf "\nn\nn\nn\nn\n" | prompt_layers)
+[[ "$result" == "" ]] || fail "expected an empty answer to default to preset 3's questions, got '$result'"
+
+result=$(echo "" | prompt_layers 2)
+[[ "$result" == "" ]] || fail "expected default preset 2 to select no layers, got '$result'"
+
+result=$(echo "" | prompt_layers 1)
+[[ "$result" == "gaming,dev,ai,exploit" ]] || fail "expected default preset 1 to select everything, got '$result'"
 
 CWR="[WARNING]"
 


### PR DESCRIPTION
Redesigns the prompt-driven install path. A bare `./install.sh` on a terminal
is now one linear guided flow; every scripted flag keeps its exact current
behavior.

## What changed structurally

- **New `lib/install/guided.sh`** — the guided flow. Engages **only** when
  `install.sh` is run with no options at all *and* stdin is a TTY.
- **Four numbered steps**, in order: how much software → which optional tool
  sets → which theme → one batched add-ons list. Then a full summary, and
  nothing on the machine is touched until it is accepted.
- **Defaults stated up front**, before the first question, so accept-all
  yields a working system: full profile, no optional layers, tokyonight, an
  existing graphics driver left alone, `~/.config` backed up first.
- **The five scattered add-on prompts are one list** (Assistant, wallpaper
  pool, starship, zsh — plus "copy config files?", removed from this path).
  Purely additive: Enter turns nothing on. Two of those five used to fire
  *after* packages had already installed.
- **"Copy config files?" is gone from the guided path.** It defaulted to
  **no**, and answering it that way leaves Hyprland with none of Aphotic's
  desktop — the single worst trap in the old flow for a new user. The guided
  path states it in the summary instead; the flag-driven path still asks.
- **The two consequential questions stay standalone**, as required: NVIDIA
  driver replacement (`detect.sh:108`) and BlackArch (`install.sh:232`).
- **The replaced-role package question moved ahead of the summary** and now
  only *records* an answer (`prompt_conflicting_packages`); the removal still
  happens in system prep. Nothing gets uninstalled after the point the user
  said yes.
- **The layer picker is reused, not rebuilt.** `prompt_layers` gained one
  optional argument: which preset an empty answer takes. `--opt-in` keeps 3
  (ask each), the guided flow passes 2 (none).

## Scripted paths: unchanged

`--profile`, `--with`, `--theme`, `--opt-in`, `--dry-run`, `--config-only`,
`--strip-conflicts`, `--keep-conflicts`, `--accept-exploit-disclaimer`,
`--with-assistant`, `--no-assistant`, `--nvidia-driver`, `--no-backup`,
`--keep-backups` all behave exactly as before. Any flag at all, or a non-TTY
stdin (CI, a piped install), bypasses the guided flow — a bare no-TTY run
still takes the zero-prompt daily-driver default. `tests/test_install_dry_run.sh`
and `tests/test_install_default_profile.sh` assert this and pass unmodified in
substance.

Out of scope and untouched: `lib/install/packages.sh`, `aur.sh`,
`backup.sh` internals.

## Every prompt, before → after

### 1. Existing install found (`lib/install/wizard.sh`, and the guided equivalent)
- **Before:** `Existing config found (profile=full, layers=gaming).` / `Reinstall same config? (Y/n)`
- **After:** `Aphotic is already installed here (profile=full, extras=gaming).` / `Install it again with those same choices? (Y/n)`
- Guided: `Aphotic is already installed on this machine: full desktop (Aphotic plus browser, files, media, fonts), extras: gaming.` — and it then skips steps 1–2, renumbering to a 2-step flow.

### 2. Profile (`prompt_profile`)
- **Before:** `Profile? [minimal/full] (full):` — the word "profile" and nothing else.
- **After:** a described menu; still accepts `minimal`/`full` typed literally.
```
  1) Full desktop  (recommended)
     Everything a day-to-day machine needs: the Aphotic desktop plus
     Firefox, a file manager, a terminal, an image and video player,
     fonts, Bluetooth and audio support.

  2) Just the desktop
     Only what Aphotic itself needs to run. No browser, no media player,
     no fonts beyond the ones the desktop uses -- you install the
     programs you want yourself afterwards.

Your choice? [1-2, default 1 - full desktop]:
```

### 3. Layer preset (`prompt_layers`)
- **Before:**
```
Layer presets:
  1) Everything       -- gaming, dev, ai, and the default exploit bundle
  2) Daily driver     -- none of the above; a clean Hyprland desktop
  3) Cherry-pick      -- choose each layer yourself
Preset? [1/2/3, default 3]:
```
- **After:**
```
Optional extra tool sets:
  1) All of them      -- gaming, development, AI and security tools
  2) None             -- just the desktop; add any of these later
  3) Choose one by one
Your choice? [1-3, default 2]:
```
(default `2` in the guided flow, `3` under `--opt-in` — unchanged there)

### 4. Gaming layer
- **Before:** `Enable gaming layer? [y/N]:`
- **After:**
```
  Gaming
    Steam, plus GameMode and MangoHud -- one tunes the system while a game
    is running, the other shows framerate and temperatures on screen. This
    also switches on "multilib", an official Arch package collection that
    is off by default and carries the 32-bit libraries many games need.
  Install the gaming tools? [y/N]:
```

### 5. Dev layer
- **Before:** `Enable dev layer? [y/N]:`
- **After:**
```
  Development
    Neovim, tmux, fzf, ripgrep, fd, lazygit and the GitHub command line --
    a terminal-based coding setup. Adding these does not change any editor
    or shell you already use.
  Install the development tools? [y/N]:
```

### 6. AI layer
- **Before:** `Enable ai layer? Adds the agent graph, AI chat and live Claude Code session tracking -- wires hooks into ~/.claude/settings.json and enables a usage-tracking timer [y/N]:`
- **After:**
```
  AI features
    Ollama, which runs language models locally on this machine, plus
    Aphotic's agent graph, AI chat panel and live Claude Code session
    tracking. This is the only choice here that writes outside Aphotic's
    own files: it adds hooks to ~/.claude/settings.json and switches on a
    timer that records how much you use those tools. What it records stays
    in your home folder.
  Install the AI features? [y/N]:
```

### 7. Security tooling, top-level
- **Before:** `Enable exploit/offensive-security tooling? Adds the BlackArch repo for most sublayers -- less stable than Arch's official repos, see docs/exploit-layer.md [y/N]:`
- **After:**
```
  Security / penetration-testing tools
    Scanners and testing tools for networks, websites and files. Most of
    them are not in Arch's own package collections and come from BlackArch
    instead: a large third-party collection that moves fast and breaks
    more often than Arch's. You will be asked separately before it is
    added, and asked to agree that you will only use these tools on
    systems you own or have written permission to test.
  Install security tools? [y/N]:
```

### 8. Security sublayers
| Before | After |
| --- | --- |
| `Use the default bundle (recon + web + network)? [Y/n]:` | `The usual starting set is recon + web + network.` / `Use that starting set? [Y/n]:` |
| `Enable exploit-recon (nmap, amass, subfinder, theHarvester, recon-ng)? [y/N]:` | `Recon -- finds hosts, subdomains and open ports (nmap, amass, subfinder, theHarvester, recon-ng)? [y/N]:` |
| `Enable exploit-web (Burp Suite CE, sqlmap, ffuf, gobuster, nikto, ZAP)? [y/N]:` | `Web -- tests websites and web apps (Burp Suite CE, sqlmap, ffuf, gobuster, nikto, ZAP)? [y/N]:` |
| `Enable exploit-network (Wireshark, aircrack-ng, bettercap, tcpdump)? [y/N]:` | `Network -- captures and inspects network traffic (Wireshark, aircrack-ng, bettercap, tcpdump)? [y/N]:` |
| `Enable exploit-passwords (John the Ripper, hashcat, Hydra)? [y/N]:` | `Passwords -- tries to recover passwords from stored hashes (John the Ripper, hashcat, Hydra)? [y/N]:` |
| `Also fetch the rockyou wordlist? ~130MB decompressed, from the OWASP SecLists project -- always separate, never bundled automatically [y/N]:` | `Also download the rockyou list of common passwords? ~130MB, from the OWASP SecLists project -- always a separate choice, never included on its own [y/N]:` |
| `Enable exploit-reversing (Ghidra, radare2, Cutter, gdb+pwndbg, binwalk)? [y/N]:` | `Reverse engineering -- takes compiled programs apart to see what they do (Ghidra, radare2, Cutter, gdb + pwndbg, binwalk)? [y/N]:` |
| `Enable exploit-forensics (Autopsy, Sleuth Kit, Volatility 3)? [y/N]:` | `Digital forensics -- examines disk images and memory dumps (Autopsy, Sleuth Kit, Volatility 3)? [y/N]:` |
| `Enable exploit-reporting (engagement report scaffolding, aphotic report CLI)? [y/N]:` | `Report writing -- templates and an 'aphotic report' command for writing up findings? [y/N]:` |

### 9. Theme (`prompt_theme`)
- **Before:** `Available themes:` … `Theme? [1-8] (default 7 - tokyonight):`
- **After:** `Colours. Each theme restyles the whole desktop -- bar, menus, notifications and wallpapers. You can change it at any time afterwards with 'aphotic theme set <name>'.` … `Your choice? [1-8, default 7 - tokyonight]:`
- Invalid answer: `Invalid selection, using tokyonight.` → `That isn't one of the numbers listed, using tokyonight.`

### 10. Add-ons — replaces five separate prompts (guided path only)
- **Before**, at four different points in the run:
  - `Install the Aphotic Assistant, a local chatbot that helps you personalize your setup? (Y/n)`
  - `The Aphotic Assistant is a local chatbot, but it needs the ai layer (Ollama). Add the ai layer and install it? (y/N)`
  - `Download the larger community wallpaper pool now? ~145MB across all 8 themes; each theme already ships a handful of wallpapers regardless, this just adds more choice. Skip if you're on a slow connection (y/N)`
  - `Would you like to activate the starship shell? (y/N)`
  - `Would you like to activate zsh shell? (y/N)`
- **After**, one step:
```
── Step 4 of 4: optional add-ons ──

None of these are required, and each can also be turned on later.

  1) Aphotic Assistant   (recommended -- you chose the AI extras)
     A chatbot that runs entirely on this machine and can answer questions
     about your desktop. Downloads a language model of a few GB, and needs
     an NVIDIA graphics card (this machine has one). Switching it on also
     turns on the AI extras it runs from.

  2) Community wallpaper pack
     About 145MB of extra wallpapers. Every theme already comes with its
     own, so this only adds more to choose from.

  3) A better terminal prompt (starship)
     Shows the folder you are in, the git branch and similar, in place of
     the plain bash prompt. Adds one line to ~/.bashrc.

  4) Use zsh as your shell instead of bash
     Copies Aphotic's zsh setup and changes your login shell with 'chsh'.
     Leave this off unless you already know you want zsh.

Type the numbers of any you want, separated by spaces, or press Enter for none.
[ACTION] - Which add-ons? (e.g. "1 3", or Enter for none)
```
The row is dropped entirely when there is no NVIDIA card, since the
Assistant hard-requires one. Non-numeric or out-of-range input is reported
and ignored, not silently swallowed.

The four flag-driven equivalents were reworded too, since they still fire on
that path — e.g. starship became `The starship prompt shows the folder you
are in, the git branch and similar in your terminal, in place of the plain
bash prompt. It adds one line to ~/.bashrc.` / `Use the starship prompt? (y/N)`.

### 11. NVIDIA driver replacement — kept standalone (`detect.sh`)
- **Before:**
```
[ATTENTION] - An NVIDIA driver is already installed (nvidia-open-dkms).
[ACTION] - Uninstall it and let Aphotic install its recommended nvidia-open-dkms instead of keeping it? (y/N)
```
- **After:**
```
[ATTENTION] - A driver for your NVIDIA graphics card is already installed: nvidia-open-dkms.
  Aphotic normally installs nvidia-open-dkms, NVIDIA's own open-source driver. Switching to it
  means removing the driver you have first, and swapping graphics drivers can leave you with no
  picture until you reboot.
  Recommended: keep the one you already have -- Aphotic works fine on it.
[ACTION] - Replace it with nvidia-open-dkms? (y/N)
```

### 12. BlackArch — kept standalone (`install.sh`)
- **Before:** `The "exploit" layer adds the BlackArch repo to /etc/pacman.conf. BlackArch is a large, fast-moving repo layered on top of Arch…` / `Continue enabling BlackArch for the exploit-* layers that need it? (y/N)`
- **After:** `The security tools you picked are not in Arch's own package collections. They come from BlackArch, and this script would add it to your system's list of package sources (/etc/pacman.conf).` … plus `Everything else in this install works the same either way.` / `Add BlackArch and install those tools? (y/N)`
- Decline message: `Skipping the BlackArch-backed exploit-* layers.` → `Not adding BlackArch, so the security tools that need it are dropped from this install. Everything else carries on.`

### 13. Authorized-use disclaimer (`exploit_disclaimer.sh`) — legal text unchanged
- **Before:** `Type "I understand" to continue, or anything else to skip the exploit-* layers:`
- **After:**
```
[ACTION] - Type "I understand" to accept this and continue.
[ACTION]   Anything else skips the security tools and installs everything else.
[ACTION] - Your answer:
```
This is a **bug fix**, not just a rewording — see "Defect found live" below.

### 14. Replaced-role packages (`conflicts.sh`)
- **Before:**
```
[ATTENTION] - Found packages already installed that Aphotic's shell replaces:
[WARNING] - Left running, these commonly autostart from an old WM config and fight Aphotic's shell for the same role -- this is what issue #41 turned out to be.
[ACTION] - Remove them now? (Y,n)
```
- **After:**
```
[ATTENTION] - These programs are already installed and do the same jobs as parts of Aphotic's desktop:
[WARNING] - Left in place they usually start themselves from your old setup's config, and you end up with two
[WARNING]   bars, two app launchers, or duplicate notifications. That is the most common reason a finished
[WARNING]   install looks broken (issue #41). Nothing else on this machine needs them.
[ACTION] - Uninstall them as part of this install? (Y/n)     <- guided, asked before the summary
[ACTION] - Uninstall them now? (Y/n)                          <- flag-driven, in system prep
```
Also now goes through `confirm` rather than its own ad-hoc `read -rep`
(`(Y,n)` → `(Y/n)`), which is the convention `ui.sh` already documents.

### 15. Config deploy (`install.sh`)
- **Before:** `Would you like to copy config files? (y/N)`
- **After (flag-driven):**
```
[NOTE] - Without Aphotic's config files you get Hyprland with none of Aphotic's desktop.
[NOTE]   Whatever is in ~/.config now was backed up in the previous step.
[ACTION] - Install Aphotic's config files into ~/.config? (y/N)
```
- **After (guided):** not asked; stated in the summary as
  `Your configs  ~/.config copied to ~/.config-backup/<date>, then Aphotic's copied in`

### 16. Start Hyprland (`hyprland_launch.sh`)
- **Before:** `Would you like to start Hyprland now? (y/N)`
- **After:**
```
[NOTE] - Aphotic is installed. You can sign in to it from the graphical login screen,
[NOTE]   either by starting that now or by rebooting -- both work the same.
[ACTION] - Start the login screen now? (y/N)
```

### The new summary gate
```
── Ready to install ──

  Software         full desktop (Aphotic plus browser, files, media, fonts)
  Extra tool sets  gaming -- Steam, GameMode, MangoHud
  Theme            tokyonight
  Add-ons          community wallpaper pack, starship prompt
  Graphics         keeping the NVIDIA driver you already have (nvidia-open-dkms)
  Packages         81 to install, after a full system update (pacman -Syu)
  Your configs     ~/.config copied to /home/<user>/.config-backup/<date>, then Aphotic's copied in
  Login screen     SDDM enabled and themed, so you can pick Hyprland at login
  Password         some steps need sudo -- you will be asked for yours

This takes a while: it builds AUR packages, and on a slow connection
the downloads dominate. Progress and errors are logged to install.log.

[ACTION] - Start the install now? (Y/n)
```
Declining exits 0 with `Stopped. No packages were installed and nothing in
your home folder was changed.`

## Defect found during live validation

`read -e` (which `ui.sh`'s `confirm`/`choose`/`prompt_text` all use) hands the
prompt to readline, and readline redraws a prompt wider than the terminal as a
**truncated tail**. On 80 columns the disclaimer gate rendered as:

```
<ue, or anything else to skip the exploit-* layers:
```

— i.e. the `Type "I understand"` instruction, the one thing that gate exists to
ask, was invisible. Same for the NVIDIA question (`<current NVIDIA driver with
nvidia-open-dkms?`) and the wallpaper prompt. Fixed by keeping every question
to one short line with its context echoed above; `ui.sh` now documents the
constraint at `confirm`'s definition so it doesn't regress.

## Behavior changes worth a reviewer's attention

1. **Guided Assistant default is off, not on.** Old behavior: with the `ai`
   layer selected, `Install the Aphotic Assistant?` defaulted to **yes**. The
   guided add-ons list is purely additive, so it is off unless picked —
   marked `(recommended -- you chose the AI extras)` when `ai` is selected. A
   multi-GB model download shouldn't be what "press Enter" does. The
   flag-driven path keeps the old `y` default.
2. **Guided always deploys configs** (see #15). Deliberate.
3. **Guided layer preset defaults to "None"** rather than "choose one by one".
   `--opt-in` is unchanged.
4. `prompt_profile` now accepts `1`/`2` as well as `full`/`minimal`.

## Tests

- New `tests/test_install_guided.sh`: the four steps and their numbering
  (including the 2-step renumber when reusing an existing install), the
  batched add-ons step (defaults, selection, garbage input, the NVIDIA-absent
  row shift), the summary gate accepting and declining, `prompt_conflicting_packages`
  recording an answer without calling `sudo`, and — most importantly — that
  `--dry-run` and a bare no-TTY run never enter the guided flow.
- `tests/test_wizard.sh`: added coverage for `prompt_layers`' new
  default-preset argument and `prompt_profile`'s numeric answers.
- `tests/test_install_default_profile.sh`: updated for the renamed picker
  heading; its assertions are otherwise unchanged.
- Full suite green: 24 bash tests, 48 pytest, `bash -n` over every script.

## Verification

Exercised on two machines, at different depths. `CONTRIBUTING.md`'s dev-VM
requirement for an installer-affecting change is satisfied.

**Workstation** (Arch, NVIDIA with `nvidia-open-dkms` already installed) — the
real interactive path driven over a pty through four scenarios: accept-all
defaults; minimal + cherry-picked gaming + two add-ons; all-extras with the
disclaimer declined; all-extras stopping at the disclaimer prompt. Each was
answered **no at the summary**, so nothing was installed and no state was
written (the pre-existing exploit acknowledgment file was confirmed untouched).
This covers the pre-summary half: the NVIDIA driver-replacement prompt on a
machine that actually has a driver to replace, the BlackArch gate, the
disclaimer gate's decline-and-strip path, the summary's own decline path, and
the readline truncation fix.

**Dev VM** (clean-ish Arch, no NVIDIA card) — one full guided run to
completion, accepting at the summary:

- Preset 1 and theme choice 8 produced `profile = "full"`,
  `layers = ["gaming", "dev", "ai", "exploit-recon", "exploit-web", "exploit-network"]`,
  `name = "windows11"` in `aphotic.toml`.
- **Both consequential standalone gates were answered by hand and took
  effect.** All three `exploit-*` layers require BlackArch, and the disclaimer
  gate strips the entire exploit family on any answer but `I understand` — so
  their survival into `aphotic.toml` is proof both prompts fired and were
  accepted. `~/.local/state/aphotic/exploit-acknowledgment.json` records
  `"method": "interactive"`, timestamped four minutes before `installed_at`.
- **Every post-summary stage ran.** `write_aphotic_toml` is the last statement
  in `main()`, and `installed_at` is populated. Configs deployed
  (`relinked ui-surface plugin modules`), and `systemctl is-enabled sddm`
  returns `enabled`.
- **The batched add-ons step works end to end, including the row shift.** With
  no NVIDIA card the Assistant row is dropped and the remaining rows renumber;
  the starship and zsh rows were selected from that shifted list and both
  applied — one `starship init bash` line in `~/.bashrc`, and `$SHELL` now
  `/usr/bin/zsh`. That exercises the `ACTIVATE_STARSHIP`/`ACTIVATE_ZSH`
  plumbing from `guided_step_addons` through to `shell_activation.sh` on real
  hardware, not just in unit tests.

Pre-existing log noise seen on the VM run, recorded so a reviewer doesn't
chase it: `error: target not found: xdg-desktop-portal-gnome -> exit status 1`,
from `enable_core_services` in `lib/install/system_prep.sh` (not in this diff),
where the existing `|| true` already swallows it on a system that never had
those portals installed.

### Not exercised live

- **Turning the Aphotic Assistant add-on on.** The row renders correctly on a
  machine with a card and is correctly absent on one without, but nobody has
  selected it in a real run — it needs an NVIDIA box plus a multi-GB model
  pull. The code path it feeds (`resolve_assistant` with a pre-decided
  `ASSISTANT`, including the "also adds the ai layer" case) is covered by
  `tests/test_install_guided.sh` and, flag-side, by
  `tests/test_install_assistant.sh` against a faked NVIDIA `lspci`.
- **The existing-install reuse branch** (offering the saved choices back and
  renumbering to a 2-step flow). Both live runs deliberately started from no
  `aphotic.toml`, so this is unit-tested only.

**Follow-up:** the wiki's installation page still describes the old
prompt-by-prompt flow and should be updated alongside this.
