### PR TITLE
profiles: ship Thunar's thumbnailer, so the file manager shows previews

### DIFF
--- a/profiles/base/full.toml
+++ b/profiles/base/full.toml
@@ -4,4 +4,12 @@ description = "Full install: today's complete package set"
 
 [packages]
 prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "procps-ng", "util-linux"]
-main = ["kitty", "quickshell", "awww", "swaylock-effects", "hypridle", "zsh-theme-powerlevel10k-git", "zsh-autosuggestions", "oh-my-zsh-git", "zsh-syntax-highlighting", "xdg-desktop-portal-hyprland", "adw-gtk-theme", "openvpn", "papirus-folders", "bibata-cursor-theme", "swappy", "eza", "grim", "python-pyamdgpuinfo", "slurp", "thunar", "cava", "btop", "firefox", "mpv", "pamixer", "pavucontrol", "brightnessctl", "playerctl", "bluez", "bluez-utils", "blueman", "wallust-git", "matugen", "python-pywalfox", "python-pywayland", "network-manager-applet", "visual-studio-code-bin", "gvfs", "thunar-archive-plugin", "file-roller", "starship", "papirus-icon-theme", "ttf-jetbrains-mono-nerd", "ttf-material-symbols-variable", "inter-font", "noto-fonts-emoji", "lxappearance", "xfce4-settings", "nwg-look", "sddm"]
+# tumbler and the three format helpers after `thunar` are Thunar's
+# thumbnailing stack, not extras: Thunar renders no thumbnails itself, it
+# asks the Tumbler D-Bus service, so without tumbler installed every file
+# in the file manager falls back to its generic MIME icon and a finished
+# install looks half-built. Nothing in this repo references these by name
+# (they are pulled in by D-Bus activation and gdk-pixbuf), so don't prune
+# them as unused. ffmpegthumbnailer/poppler-glib cover video/PDF previews
+# and webp-pixbuf-loader covers .webp, which gdk-pixbuf can't read alone.
+main = ["kitty", "quickshell", "awww", "swaylock-effects", "hypridle", "zsh-theme-powerlevel10k-git", "zsh-autosuggestions", "oh-my-zsh-git", "zsh-syntax-highlighting", "xdg-desktop-portal-hyprland", "adw-gtk-theme", "openvpn", "papirus-folders", "bibata-cursor-theme", "swappy", "eza", "grim", "python-pyamdgpuinfo", "slurp", "thunar", "tumbler", "ffmpegthumbnailer", "poppler-glib", "webp-pixbuf-loader", "cava", "btop", "firefox", "mpv", "pamixer", "pavucontrol", "brightnessctl", "playerctl", "bluez", "bluez-utils", "blueman", "wallust-git", "matugen", "python-pywalfox", "python-pywayland", "network-manager-applet", "visual-studio-code-bin", "gvfs", "thunar-archive-plugin", "file-roller", "starship", "papirus-icon-theme", "ttf-jetbrains-mono-nerd", "ttf-material-symbols-variable", "inter-font", "noto-fonts-emoji", "lxappearance", "xfce4-settings", "nwg-look", "sddm"]

--- a/tests/test_profiles_real.py
+++ b/tests/test_profiles_real.py
@@ -23,6 +23,27 @@ def test_full_profile_has_expected_packages():
     assert result["main"].count("firefox") == 1
 
 
+def test_full_profile_ships_thunars_thumbnailer():
+    """Thunar renders no thumbnails itself -- it asks the Tumbler D-Bus
+    service. Shipping thunar without tumbler leaves every file in the file
+    manager showing its generic MIME icon, which is what a user reads as a
+    half-finished rice. Nothing in the repo references these by name, so
+    this guards them against being pruned as unused."""
+    result = merge_packages(str(ROOT / "profiles/base/full.toml"), [])
+    assert "thunar" in result["main"]
+    for pkg in ["tumbler", "ffmpegthumbnailer", "poppler-glib", "webp-pixbuf-loader"]:
+        assert pkg in result["main"], f"{pkg} missing -- Thunar previews will be broken"
+
+
+def test_minimal_profile_has_no_file_manager_or_thumbnailer():
+    """minimal ships no thunar, so it has no reason to carry the
+    thumbnailing stack either -- unlike a binary the Quickshell shell
+    shells out to, which has to be in both profiles."""
+    result = merge_packages(str(ROOT / "profiles/base/minimal.toml"), [])
+    assert "thunar" not in result["main"]
+    assert "tumbler" not in result["main"]
+
+
 def test_gaming_layer_adds_packages():
     result = merge_packages(
         str(ROOT / "profiles/base/full.toml"),


### PR DESCRIPTION
`profiles/base/full.toml` installed `thunar` but never `tumbler`, so image
previews have never worked on any full install.

Thunar doesn't render thumbnails itself — it asks the Tumbler D-Bus service.
With no tumbler on the system there is nothing to ask, so every file falls back
to its generic MIME icon: a folder of wallpapers shows as a grid of identical
PNG icons. That reads as a half-finished rice rather than as a missing package,
which is why it went unreported for so long.

## Diagnosis

Reproduced on a full install:

```
$ pacman -Qq tumbler ffmpegthumbnailer poppler-glib webp-pixbuf-loader
   -> all MISSING
$ ls /usr/share/dbus-1/services/ | grep -i tumbler
   -> nothing
$ xfconf-query -c thunar -p /misc-thumbnail-mode
   THUNAR_THUMBNAIL_MODE_ALWAYS
$ find ~/.cache/thumbnails/fail -type f | wc -l
   0
```

Thunar's own setting was already `ALWAYS` and there were zero cached failure
records, so neither configuration nor a poisoned cache was involved — the
thumbnailer simply wasn't installed. Nothing in the repo has ever referenced
`tumbler` or thumbnailing, so this is an omission rather than a reverted
decision.

## Change

Adds to `full.toml`'s `main`, kept adjacent to `thunar` so the relationship
reads at a glance:

| Package | Covers | Download |
| --- | --- | --- |
| `tumbler` | the thumbnailer service itself — images work off gdk-pixbuf once it exists | 169 KiB |
| `ffmpegthumbnailer` | video thumbnails | 98 KiB |
| `poppler-glib` | PDF thumbnails | 367 KiB |
| `webp-pixbuf-loader` | `.webp`, which gdk-pixbuf can't read on its own | 10 KiB |

~644 KiB total. All four are in `extra`, so none of this adds an AUR build to
the install path.

Skipped the rest of `tumbler`'s optional deps as niche for a desktop rice:
`libgsf` (ODF), `libgepub` (EPUB), `libopenraw` (camera RAW), `freetype2` (font
file previews). Anyone who wants those can `pacman -S` them and tumbler picks
them up.

`webp-pixbuf-loader` is the one I'd call borderline: only 2 of ~180 entries in
Aphotic's own extra wallpaper manifest are `.webp`, so its value is mostly for
images a user downloads themselves. At 10 KiB I judged that worth it, but it's
the easiest line to drop if a reviewer disagrees.

## Why `full.toml` only

`CONTRIBUTING.md` says a new binary dependency goes in **both** `full.toml` and
`minimal.toml`. That rule exists because the Quickshell shell always loads in
full regardless of install profile, so a binary *the shell shells out to* must
be present either way or you get a silent runtime gap.

Tumbler isn't that. It's Thunar's dependency, reached by D-Bus activation
rather than by the shell, and `minimal.toml` ships no `thunar` at all — adding
a thumbnailer there would install a service with nothing to serve. Flagging the
deviation explicitly rather than quietly skipping the rule.

## Tests

Two additions to `tests/test_profiles_real.py`:

- `test_full_profile_ships_thunars_thumbnailer` — asserts all four are present
  alongside `thunar`. Since nothing in the repo references them by name, they'd
  otherwise be easy to prune as unused later; the test and a comment in
  `full.toml` both say so.
- `test_minimal_profile_has_no_file_manager_or_thumbnailer` — pins the
  full-only decision above, so it's a deliberate choice rather than drift.

Full suite green: 50 pytest, 24 bash tests. Also confirmed the packages resolve
through the real install path rather than just parsing:

```
$ bash install.sh --dry-run --profile full --theme default | grep -E 'tumbler|ffmpegthumbnailer|poppler-glib|webp'
    - tumbler
    - ffmpegthumbnailer
    - poppler-glib
    - webp-pixbuf-loader
```

## Verification

Package-list-only change — no `install.sh` logic touched, so the dev-VM
requirement for installer-affecting changes doesn't apply.

Confirmed end to end on a full install by actually installing the four
packages and driving the thumbnailer directly, rather than inferring it from
the package list:

```
$ pacman -Qq tumbler ffmpegthumbnailer poppler-glib webp-pixbuf-loader
tumbler 4.20.2-1, ffmpegthumbnailer 2.3.1-1, poppler-glib 26.08.0-1, webp-pixbuf-loader 0.2.7-2

$ ls /usr/share/dbus-1/services/ | grep -i tumbler
org.xfce.Tumbler.Cache1.service
org.xfce.Tumbler.Manager1.service
org.xfce.Tumbler.Thumbnailer1.service
```

All three Tumbler services now register where there were none before. Asking
the service to thumbnail a real wallpaper over D-Bus:

```
$ gdbus call --session --dest org.freedesktop.thumbnails.Thumbnailer1 \
    --object-path /org/freedesktop/thumbnails/Thumbnailer1 \
    --method org.freedesktop.thumbnails.Thumbnailer1.Queue \
    "['file://.../awww/gruvbox/gruvbox-angeljumbo-....jpg']" "['image/jpeg']" normal default 0
(uint32 20,)
```

The cache went from 32 to 33 entries, and the new entry is a genuine rendered
thumbnail rather than a placeholder:

```
~/.cache/thumbnails/normal/c72df622c690395a23afad9a66d1c6bc.png
  PNG image data, 128 x 85, 8-bit/color RGBA
  Thumb::URI=file:///home/.../awww/gruvbox/gruvbox-angeljumbo-...jpg
```

Previews confirmed visible in Thunar afterwards. The `Thumb::URI` tag tying the
output back to the source image is what rules out a coincidental cache write.
