### PR TITLE
themes: download community themes from a remote index, same shape as plugins

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_theme.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_theme.sh
@@ -1,21 +1,51 @@
 #!/usr/bin/env bash
 # aphotic theme — switch between installed Aphotic themes.
 # @cmd: theme
-# @cmd.desc: List, set, or cycle themes
+# @cmd.desc: List, set, cycle, or download themes
 # @cmd.group: CONFIG
-# @cmd.opt: list           | List installed themes
-# @cmd.opt: set <name>     | Apply a theme by name
-# @cmd.opt: next|prev      | Cycle to the next/previous theme
-# @cmd.opt: ensure-default | Apply the install-time theme if none is set yet (startup.lua only)
+# @cmd.opt: list [--remote] [--json]  | List downloaded (or available-remote) themes
+# @cmd.opt: set <name>                | Apply a theme by name
+# @cmd.opt: next|prev                 | Cycle to the next/previous theme
+# @cmd.opt: download <name>           | Download a theme from APHOTIC_THEMES_REPO
+# @cmd.opt: update <name>|--all       | Refresh a downloaded theme's files from the repo
+# @cmd.opt: remove <name>             | Delete a downloaded (non-core) theme
+# @cmd.opt: ensure-default            | Apply the install-time theme if none is set yet (startup.lua only)
 #
 # Themes live as directories under APHOTIC_AWWW_DIR, each with a
 # theme.toml manifest (see Aphotic-Hypr/themes/THEME_SPEC.md) — this is
 # the same layout Themes.qml scans and the same state file
 # (theme.json) that Themes.qml and wallswitcher.py read/write, so the
 # CLI, the launcher, and the SUPER+W keybind all stay in sync.
+#
+# download/update/remove pull additional community themes from a remote
+# aphotic-themes index -- same clone/pull-a-repo shape as `aphotic plugin
+# install` (cmd_plugin.sh), but not the plugin system: no hooks, no
+# capabilities, no enable/disable state. "Downloaded" just means the
+# directory exists under APHOTIC_AWWW_DIR, same contract _aphotic_theme_list
+# already uses -- there's no separate state file to track it.
 
 APHOTIC_AWWW_DIR="${APHOTIC_AWWW_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/awww}"
 APHOTIC_THEME_STATE_FILE="${APHOTIC_STATE_HOME}/theme.json"
+
+# Themes that ship in this repo can never be taken out with `theme
+# remove` -- read from the checked-out repo rather than hardcoded here,
+# so this stays correct as the curated set changes instead of drifting.
+APHOTIC_CORE_THEMES=()
+if [[ -d "${APHOTIC_DOTS_DIR}/Configs/awww" ]]; then
+    for _aphotic_core_dir in "${APHOTIC_DOTS_DIR}/Configs/awww"/*/; do
+        [[ -d "$_aphotic_core_dir" ]] || continue
+        APHOTIC_CORE_THEMES+=("$(basename "$_aphotic_core_dir")")
+    done
+    unset _aphotic_core_dir
+fi
+
+_aphotic_theme_is_core() {
+    local name="$1" core
+    for core in "${APHOTIC_CORE_THEMES[@]:-}"; do
+        [[ "$core" == "$name" ]] && return 0
+    done
+    return 1
+}
 
 # _aphotic_toml_get (the flat theme.toml reader) now lives in
 # globalcontrol.sh, shared with cmd_plugin.sh's plugin.toml reading —
@@ -47,6 +77,29 @@ _aphotic_theme_list() {
     fi
 }
 
+# `core` lets AppearancePane.qml badge community-downloaded themes
+# without keeping its own duplicate copy of APHOTIC_CORE_THEMES.
+_aphotic_theme_list_json() {
+    aphotic_require jq || return 1
+    mkdir -p "$APHOTIC_AWWW_DIR"
+    local dir name display core entries=()
+    for dir in "$APHOTIC_AWWW_DIR"/*/; do
+        [[ -d "$dir" ]] || continue
+        name="$(basename "$dir")"
+        display="$(_aphotic_toml_get "${dir}theme.toml" theme display_name)"
+        core="false"
+        _aphotic_theme_is_core "$name" && core="true"
+        entries+=("$(jq -n --arg name "$name" --arg display_name "${display:-$name}" --argjson core "$core" \
+            '{name: $name, display_name: $display_name, core: $core}')")
+    done
+    printf '%s\n' "${entries[@]:-}" | jq -s 'map(select(. != null))'
+}
+
+_aphotic_theme_list_remote_json() {
+    aphotic_require curl || return 1
+    curl -fsSL -m 10 "$APHOTIC_THEMES_INDEX_URL" 2>/dev/null || echo '{"themes": []}'
+}
+
 # Read {theme, wallpaper} out of theme.json. Prints two lines: theme, wallpaper.
 _aphotic_theme_read_state() {
     if [[ -f "$APHOTIC_THEME_STATE_FILE" ]]; then
@@ -60,6 +113,138 @@ _aphotic_theme_write_state() {
     local theme="$1" wallpaper="$2" tmp
     tmp="$(mktemp)"
     jq -n --arg t "$theme" --arg w "$wallpaper" '{theme: $t, wallpaper: $w}' > "$tmp" && mv "$tmp" "$APHOTIC_THEME_STATE_FILE"
+}
+
+# Clone APHOTIC_THEMES_REPO on first use, `git pull --ff-only` on later
+# ones -- mirrors _aphotic_plugin_sync_repo (cmd_plugin.sh) exactly. A
+# pull failure is non-fatal, falls through to whatever's on disk already.
+_aphotic_theme_sync_repo() {
+    aphotic_require git || return 1
+    if [[ -d "${APHOTIC_THEMES_REPO}/.git" ]]; then
+        echo "Updating theme repo: git -C ${APHOTIC_THEMES_REPO} pull --ff-only"
+        git -C "$APHOTIC_THEMES_REPO" pull --ff-only || aphotic_err "pull failed — continuing with the existing local checkout at ${APHOTIC_THEMES_REPO}"
+    else
+        echo "Cloning theme repo: git clone ${APHOTIC_THEMES_GIT_URL} ${APHOTIC_THEMES_REPO}"
+        git clone "$APHOTIC_THEMES_GIT_URL" "$APHOTIC_THEMES_REPO" || { aphotic_err "clone failed: ${APHOTIC_THEMES_GIT_URL}"; return 1; }
+    fi
+}
+
+_aphotic_theme_download() {
+    local name="$1" src dest
+    [[ -n "$name" ]] || { aphotic_err "usage: aphotic theme download <name>"; return 1; }
+
+    _aphotic_theme_sync_repo || return 1
+
+    src="${APHOTIC_THEMES_REPO}/${name}"
+    if [[ ! -d "$src" ]] || [[ ! -f "${src}/theme.toml" ]]; then
+        aphotic_err "no theme '${name}' in ${APHOTIC_THEMES_REPO} (repo synced okay, but this name isn't in it — check 'aphotic theme list --remote')"
+        return 1
+    fi
+
+    dest="$(_aphotic_theme_dir "$name")"
+    if [[ -e "$dest" ]]; then
+        aphotic_err "already downloaded: ${dest} (use 'aphotic theme update ${name}' to refresh it)"
+        return 1
+    fi
+
+    echo "Downloading ${name}..."
+    cp -r "$src" "$dest"
+
+    aphotic_ok "downloaded ${name}"
+    echo "THEME DOWNLOADED: ${name}"
+}
+
+# Staged swap (never a naked `rm -rf` on the live directory) -- mirrors
+# _aphotic_plugin_update_one's rename dance, minus the registry/harness
+# bits that don't apply to a theme.
+_aphotic_theme_update_one() {
+    local name="$1" src dest staged previous
+    dest="$(_aphotic_theme_dir "$name")"
+    [[ -e "$dest" ]] || { aphotic_err "not downloaded: ${name}"; return 1; }
+
+    src="${APHOTIC_THEMES_REPO}/${name}"
+    if [[ ! -d "$src" ]] || [[ ! -f "${src}/theme.toml" ]]; then
+        aphotic_err "no theme '${name}' in ${APHOTIC_THEMES_REPO}"
+        return 1
+    fi
+
+    staged="${dest}.updating"
+    rm -rf "$staged"
+    if ! cp -r "$src" "$staged"; then
+        rm -rf "$staged"
+        aphotic_err "failed to stage update for ${name}, left the downloaded copy alone"
+        return 1
+    fi
+
+    previous="${dest}.previous"
+    rm -rf "$previous"
+    if ! mv "$dest" "$previous"; then
+        rm -rf "$staged"
+        aphotic_err "could not move ${name}'s downloaded copy aside, left it alone"
+        return 1
+    fi
+    if ! mv "$staged" "$dest"; then
+        mv "$previous" "$dest"
+        rm -rf "$staged"
+        aphotic_err "could not swap in the update for ${name}, restored the downloaded copy"
+        return 1
+    fi
+    rm -rf "$previous"
+
+    aphotic_ok "updated ${name}"
+    echo "THEME UPDATED: ${name}"
+}
+
+_aphotic_theme_update() {
+    local target="$1" rc=0
+    [[ -n "$target" ]] || { aphotic_err "usage: aphotic theme update <name>|--all"; return 1; }
+
+    _aphotic_theme_sync_repo || return 1
+
+    if [[ "$target" != "--all" ]]; then
+        _aphotic_theme_update_one "$target"
+        return $?
+    fi
+
+    local dir name
+    for dir in "$APHOTIC_AWWW_DIR"/*/; do
+        [[ -d "$dir" ]] || continue
+        name="$(basename "$dir")"
+        _aphotic_theme_is_core "$name" && continue
+        _aphotic_theme_update_one "$name" || rc=1
+    done
+    return "$rc"
+}
+
+_aphotic_theme_remove() {
+    local name="$1" dest
+    [[ -n "$name" ]] || { aphotic_err "usage: aphotic theme remove <name>"; return 1; }
+    if _aphotic_theme_is_core "$name"; then
+        aphotic_err "${name} ships with Aphotic — not something 'theme remove' can take out"
+        return 1
+    fi
+
+    dest="$(_aphotic_theme_dir "$name")"
+    [[ -e "$dest" ]] || { aphotic_err "not downloaded: ${name}"; return 1; }
+
+    local was_active; was_active="$(_aphotic_theme_read_state | head -n1)"
+    rm -rf "$dest"
+    aphotic_ok "removed ${name}"
+
+    # Same alphabetically-first fallback _aphotic_theme_ensure_default
+    # uses -- don't leave theme.json pointing at a theme that's gone.
+    [[ "$was_active" == "$name" ]] || return 0
+    local dir fallback=""
+    for dir in "$APHOTIC_AWWW_DIR"/*/; do
+        [[ -d "$dir" ]] || continue
+        fallback="$(basename "$dir")"
+        break
+    done
+    if [[ -n "$fallback" ]]; then
+        _aphotic_theme_apply "$fallback"
+    else
+        aphotic_warn "no themes remain in ${APHOTIC_AWWW_DIR}"
+    fi
 }
 
 # Apply theme_name/wallpaper_file: run awww + wallust with any engine
@@ -253,7 +438,33 @@ _aphotic_theme_ensure_default() {
 aphotic_cmd_theme() {
     local sub="${1:-}"; shift || true
     case "$sub" in
-        list) _aphotic_theme_list ;;
+        list)
+            local remote="false" as_json="false"
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --remote) remote="true" ;;
+                    --json) as_json="true" ;;
+                esac
+                shift
+            done
+
+            if [[ "$remote" == "true" ]]; then
+                aphotic_require jq || return 1
+                local data; data="$(_aphotic_theme_list_remote_json)"
+                if [[ "$as_json" == "true" ]]; then
+                    echo "$data" | jq '.themes // []'
+                else
+                    echo "$data" | jq -r '(.themes // [])[] | "\(.name)\t\(.display_name)\t\(.version)\t\(.wallpaper_count) wallpapers\t\(if .approx_size_bytes >= 1000000 then (.approx_size_bytes/1000000*10|round/10|tostring)+"MB" else ((.approx_size_bytes/1000|round)|tostring)+"KB" end)\t\(.description)"' | column -t -s $'\t'
+                fi
+            elif [[ "$as_json" == "true" ]]; then
+                _aphotic_theme_list_json
+            else
+                _aphotic_theme_list
+            fi
+            ;;
+        download) _aphotic_theme_download "${1:-}" ;;
+        update) _aphotic_theme_update "${1:-}" ;;
+        remove) _aphotic_theme_remove "${1:-}" ;;
         ensure-default) _aphotic_theme_ensure_default ;;
         set)
             local name="${1:-}"
@@ -313,14 +524,25 @@ aphotic_cmd_theme() {
             ;;
         ""|-h|--help)
             cat <<HELP
-Usage: aphotic theme <list|set|next|prev|ensure-default> [name]
+Usage: aphotic theme <list|set|next|prev|download|update|remove|ensure-default> [args]
 
-  list            List theme folders (${APHOTIC_AWWW_DIR})
-  set <name>      Apply a theme (its declared default wallpaper)
-  next / prev     Cycle themes
-  ensure-default  Apply the install-time theme if none is set yet (no-op
-                  once a theme has ever been applied); called once from
-                  Hyprland's startup.lua, not meant for everyday use
+  list [--remote] [--json]  List theme folders (${APHOTIC_AWWW_DIR}), or
+                             --remote: what's available from
+                             APHOTIC_THEMES_INDEX_URL
+  set <name>                Apply a theme (its declared default wallpaper)
+  next / prev                Cycle themes
+  download <name>            Download a theme from a local checkout of
+                             aphotic-themes (APHOTIC_THEMES_REPO, default
+                             ~/aphotic-themes)
+  update <name>|--all       Refresh a downloaded theme's files from the
+                             repo. --all updates every community-downloaded
+                             theme (skips the ones that ship with Aphotic)
+  remove <name>              Delete a downloaded theme; refuses to take out
+                             one of the themes that ships with Aphotic
+  ensure-default             Apply the install-time theme if none is set
+                             yet (no-op once a theme has ever been
+                             applied); called once from Hyprland's
+                             startup.lua, not meant for everyday use
 HELP
             ;;
         *)

--- a/Configs/.local/lib/aphotic/globalcontrol.sh
+++ b/Configs/.local/lib/aphotic/globalcontrol.sh
@@ -48,6 +48,16 @@ APHOTIC_PLUGINS_INDEX_URL="${APHOTIC_PLUGINS_INDEX_URL:-https://raw.githubuserco
 # below and cmd_plugin.sh's trust-security-index subcommand.
 APHOTIC_PLUGINS_SECURITY_INDEX_URL="${APHOTIC_PLUGINS_SECURITY_INDEX_URL:-https://raw.githubusercontent.com/T-Crypt/aphotic-plugins-security/main/index.json}"
 
+# Community theme index (see themes/THEME_SPEC.md and cmd_theme.sh's
+# `download`/`update`/`remove`). Same clone/pull-a-repo shape as the
+# plugin block above, but a theme is just a directory + theme.toml with
+# no enable/disable state -- "is this theme downloaded" is answered by
+# APHOTIC_AWWW_DIR itself, so unlike APHOTIC_PLUGINS_STATE_FILE there's
+# no state file to track here.
+APHOTIC_THEMES_REPO="${APHOTIC_THEMES_REPO:-$HOME/aphotic-themes}"
+APHOTIC_THEMES_GIT_URL="${APHOTIC_THEMES_GIT_URL:-https://github.com/T-Crypt/aphotic-themes.git}"
+APHOTIC_THEMES_INDEX_URL="${APHOTIC_THEMES_INDEX_URL:-https://raw.githubusercontent.com/T-Crypt/aphotic-themes/main/index.json}"
+
 # one-time migration: noctis -> aphotic config path
 _APHOTIC_OLD_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/noctis"
 if [[ -d "$_APHOTIC_OLD_CONFIG_HOME" ]] && [[ ! -e "$APHOTIC_CONFIG_HOME" ]]; then
@@ -61,7 +71,8 @@ mkdir -p "$APHOTIC_CONFIG_HOME" "$APHOTIC_STATE_HOME" "$APHOTIC_DATA_HOME" \
 export APHOTIC_VERSION APHOTIC_CONFIG_HOME APHOTIC_STATE_HOME APHOTIC_DATA_HOME \
        APHOTIC_RUNTIME_DIR APHOTIC_CONFIG_FILE APHOTIC_BACKUP_DIR APHOTIC_DOTS_DIR \
        QUICKSHELL_CONFIG_DIR APHOTIC_PLUGINS_DIR APHOTIC_PLUGINS_STATE_FILE \
-       APHOTIC_PLUGINS_REPO APHOTIC_PLUGINS_GIT_URL APHOTIC_PLUGINS_INDEX_URL APHOTIC_PLUGINS_SECURITY_INDEX_URL
+       APHOTIC_PLUGINS_REPO APHOTIC_PLUGINS_GIT_URL APHOTIC_PLUGINS_INDEX_URL APHOTIC_PLUGINS_SECURITY_INDEX_URL \
+       APHOTIC_THEMES_REPO APHOTIC_THEMES_GIT_URL APHOTIC_THEMES_INDEX_URL
 
 # ---- logging -----------------------------------------------------------
 _APHOTIC_DIM=$'\e[2m'; _APHOTIC_R=$'\e[0m'

--- a/Configs/quickshell/aphotic/modules/settings/panes/AppearancePane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/AppearancePane.qml
@@ -1,8 +1,10 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Controls
 import QtQuick.Layouts
 import Quickshell
+import Quickshell.Io
 import qs.config
 import qs.components
 import qs.services
@@ -35,7 +37,76 @@ Item {
         id: landingComp
 
         ColumnLayout {
+            id: landing
+
             spacing: Tokens.spacing.largeIncreased
+
+            // Names of downloaded themes that came from the community
+            // index rather than shipping with Aphotic -- badges the grid
+            // below. Comes from `aphotic theme list --json`'s `core` field
+            // (cmd_theme.sh) rather than a second copy of
+            // APHOTIC_CORE_THEMES kept here, so the two never drift.
+            property var communityNames: []
+            // "Available to download" list, kept separate from the
+            // locally-scanned Themes.themes grid so an available entry is
+            // never indistinguishable from an already-downloaded theme.
+            property var communityAvailable: []
+            readonly property var communityFiltered: landing.communityAvailable.filter(t => !Themes.themes.some(th => th.name === t.name))
+
+            function refreshCommunity(): void {
+                installedCoreProc.running = true;
+                communityRemoteProc.running = true;
+            }
+
+            Process {
+                id: installedCoreProc
+                command: ["aphotic", "theme", "list", "--json"]
+                stdout: StdioCollector {
+                    onStreamFinished: {
+                        try {
+                            landing.communityNames = JSON.parse(text).filter(t => !t.core).map(t => t.name);
+                        } catch (e) {
+                            landing.communityNames = [];
+                        }
+                    }
+                }
+            }
+
+            Process {
+                id: communityRemoteProc
+                command: ["aphotic", "theme", "list", "--remote", "--json"]
+                stdout: StdioCollector {
+                    onStreamFinished: {
+                        try {
+                            landing.communityAvailable = JSON.parse(text);
+                        } catch (e) {
+                            landing.communityAvailable = [];
+                        }
+                    }
+                }
+            }
+
+            // No enable/disable, no category filter, no security-trust
+            // gate here -- those are plugin-specific concepts (see
+            // PluginsPane.qml) that don't apply to a directory of
+            // wallpapers. Downloading runs as a tracked Process (not a
+            // detached terminal like `aphotic plugin install`) since a
+            // `cp -r` never needs an interactive AUR prompt.
+            Process {
+                id: downloadProc
+                onExited: {
+                    // Themes.qml's own scan (scanProc) has no public
+                    // rescan() to call here -- a freshly downloaded theme
+                    // won't show in the grid above until the shell
+                    // restarts. Re-running the two Processes above at
+                    // least moves the entry out of "available to
+                    // download" and picks up its `core: false` badge once
+                    // Themes.themes does notice it.
+                    landing.refreshCommunity();
+                }
+            }
+
+            Component.onCompleted: landing.refreshCommunity()
 
             StyledText {
                 text: qsTr("Appearance")
@@ -65,6 +136,7 @@ Item {
 
                         required property var modelData
                         readonly property bool active: themeCard.modelData.name === Themes.activeTheme
+                        readonly property bool community: landing.communityNames.includes(themeCard.modelData.name)
 
                         Layout.fillWidth: true
                         Layout.fillHeight: true
@@ -89,6 +161,26 @@ Item {
                             font: Tokens.font.body.medium
                         }
 
+                        MaterialIcon {
+                            id: communityBadge
+
+                            visible: themeCard.community
+                            anchors.top: parent.top
+                            anchors.right: parent.right
+                            anchors.margins: Tokens.padding.small
+                            text: "public"
+                            color: Colours.palette.m3onSurfaceVariant
+                            fontStyle: Tokens.font.icon.small
+
+                            ToolTip.visible: badgeHover.hovered
+                            ToolTip.text: qsTr("Downloaded from the community theme index")
+                            ToolTip.delay: 500
+
+                            HoverHandler {
+                                id: badgeHover
+                            }
+                        }
+
                         StateLayer {
                             anchors.fill: parent
                             radius: parent.radius
@@ -107,6 +199,108 @@ Item {
             }
 
             StyledText {
+                Layout.topMargin: Tokens.spacing.small
+                text: qsTr("Community Themes")
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.label.medium
+            }
+
+            StyledText {
+                visible: landing.communityFiltered.length === 0
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                text: qsTr("Couldn't reach the aphotic-themes index (offline, or the repo isn't public yet).")
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.body.small
+            }
+
+            Flow {
+                Layout.fillWidth: true
+                visible: landing.communityFiltered.length > 0
+                spacing: Tokens.spacing.medium
+
+                Repeater {
+                    model: landing.communityFiltered
+
+                    StyledRect {
+                        id: communityCard
+
+                        required property var modelData
+
+                        width: 220
+                        implicitHeight: communityCol.implicitHeight + Tokens.padding.large * 2
+                        radius: Tokens.rounding.medium
+                        color: Colours.tPalette.m3surfaceContainer
+
+                        ColumnLayout {
+                            id: communityCol
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            anchors.margins: Tokens.padding.large
+                            spacing: Tokens.spacing.extraSmall
+
+                            StyledText {
+                                Layout.fillWidth: true
+                                elide: Text.ElideRight
+                                text: communityCard.modelData.display_name
+                                font: Tokens.font.body.medium
+                            }
+
+                            StyledText {
+                                visible: (communityCard.modelData.description ?? "").length > 0
+                                Layout.fillWidth: true
+                                wrapMode: Text.Wrap
+                                maximumLineCount: 2
+                                elide: Text.ElideRight
+                                text: communityCard.modelData.description ?? ""
+                                color: Colours.palette.m3onSurfaceVariant
+                                font: Tokens.font.label.small
+                            }
+
+                            StyledText {
+                                Layout.topMargin: Tokens.spacing.extraSmall
+                                text: qsTr("%1 wallpapers · %2").arg(communityCard.modelData.wallpaper_count ?? 0).arg(ModelStorage.formatBytes(communityCard.modelData.approx_size_bytes ?? 0))
+                                color: Colours.palette.m3onSurfaceVariant
+                                font: Tokens.font.label.small
+                            }
+
+                            StyledRect {
+                                Layout.topMargin: Tokens.spacing.small
+                                Layout.alignment: Qt.AlignLeft
+                                implicitWidth: downloadLabel.implicitWidth + Tokens.padding.large * 2
+                                implicitHeight: 28
+                                radius: Tokens.rounding.full
+                                color: Colours.palette.m3primary
+
+                                StyledText {
+                                    id: downloadLabel
+                                    anchors.centerIn: parent
+                                    text: qsTr("Download")
+                                    color: Colours.contrastOn(Colours.palette.m3primary)
+                                    font: Tokens.font.label.small
+                                }
+
+                                StateLayer {
+                                    anchors.fill: parent
+                                    radius: parent.radius
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        downloadProc.command = ["aphotic", "theme", "download", communityCard.modelData.name];
+                                        downloadProc.running = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            StyledText {
                 visible: Themes.wallpapersInActiveTheme.length > 1
                 Layout.topMargin: Tokens.spacing.small
                 text: qsTr("Wallpaper")
@@ -115,15 +309,12 @@ Item {
             }
 
             Flow {
-                // A theme can now hold a couple dozen wallpapers (see
-                // `aphotic wallpaper --fetch-extra`) rather than the single
-                // curated one every theme shipped with when this was
-                // written -- a RowLayout never wraps, so it just ran every
-                // pill off the right edge of the panel once a theme
-                // actually had more than a handful. Flow wraps onto more
-                // rows instead, and the pane's own Flickable (see
-                // SettingsPanel.qml) already scrolls for the height that
-                // adds.
+                // A theme can hold more than one curated wallpaper -- a
+                // RowLayout never wraps, so it just ran every pill off the
+                // right edge of the panel once a theme had more than a
+                // handful. Flow wraps onto more rows instead, and the
+                // pane's own Flickable (see SettingsPanel.qml) already
+                // scrolls for the height that adds.
                 visible: Themes.wallpapersInActiveTheme.length > 1
                 Layout.fillWidth: true
                 spacing: Tokens.spacing.small


### PR DESCRIPTION
## Summary
- `aphotic theme list --remote [--json]` / `download <name>` / `update <name>|--all` / `remove <name>` -- same clone-or-pull-a-repo shape as `aphotic plugin install` (`cmd_plugin.sh`), but not the plugin system: no hooks, no capabilities, no enable/disable state, no security-index gate. A theme is just a directory + `theme.toml`; "downloaded" means it exists under `APHOTIC_AWWW_DIR`.
- `globalcontrol.sh`: `APHOTIC_THEMES_REPO`/`GIT_URL`/`INDEX_URL`, mirroring the plugin env-var block immediately above it. The remote `aphotic-themes` repo doesn't exist with real content yet -- this is built to work once it does.
- `cmd_theme.sh`: `APHOTIC_CORE_THEMES` is read from the checked-out repo's own `Configs/awww/` at load time rather than hardcoded, so `remove`'s core-theme guard can't drift from the curated set. `list` gains `--remote` and `--json` (didn't exist before this PR). The installed `--json` shape gains a `core: true/false` field so Settings can badge community-downloaded themes without keeping a second copy of the core-theme list. `update` mirrors the plugin update's staged `.updating`/`.previous` rename dance -- never a naked `rm -rf` on the live directory.
- `AppearancePane.qml`: a "Community Themes" section below the existing theme grid, thin-view-over-the-CLI via `Process` + `--json` (same convention `PluginsPane.qml`'s own header comment documents), plus a small badge on downloaded community themes in the grid. Reuses `ModelStorage.formatBytes` for the size display rather than adding a second byte formatter.

## Known gap
`Themes.qml`'s scan (`scanProc`) has no public `rescan()` to call after a download completes, so a freshly downloaded theme won't show in the grid until the shell restarts. Flagged as out of scope here -- tracked as Prompt 4.

## Test plan
- [x] `aphotic theme list` / `list --json` / `list --remote` / `list --remote --json` exercised against a scratch `APHOTIC_AWWW_DIR` + fake local git repo + fake index.json -- core/community flagging, human-readable tables, and size formatting all verified.
- [x] `download` (fresh + already-downloaded + unknown-name), `update <name>` / `--all` (core themes correctly skipped by `--all`), and `remove` (core-theme refusal + active-theme fallback) all exercised the same way.
- [x] `bash -n` on both shell files; `qmllint` on `AppearancePane.qml` came back clean before a later edit (the tool became flaky in this sandbox on later reruns, including against an unedited baseline file, so treat as inconclusive rather than a finding).
- [x] No running Quickshell instance in this environment -- the new Settings UI hasn't been visually exercised. Worth a manual look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KM7cL9sDuiS2pWNf1Vzqie