### PR TITLE
themes: clamp dynamic palette drift to each theme's own margins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ CLAUDE.md
 
 aphotic.toml
 install.log
+
+# Clamped live palettes (themes/THEME_SPEC.md's "Clamped palettes") --
+# regenerated on every theme apply from the current wallpaper, and landing
+# inside the repo only because ~/.config/wallust symlinks here.
+Configs/wallust/colorschemes/*-live.json
 __pycache__/
 .DS_Store
 Thumbs.db

--- a/Configs/.local/lib/aphotic/commands/cmd_theme.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_theme.sh
@@ -62,6 +62,55 @@ _aphotic_theme_write_state() {
     jq -n --arg t "$theme" --arg w "$wallpaper" '{theme: $t, wallpaper: $w}' > "$tmp" && mv "$tmp" "$APHOTIC_THEME_STATE_FILE"
 }
 
+# Palette clamp (theme.toml's [palette] table -- see themes/THEME_SPEC.md).
+# `wallust run` derives every slot from the image alone, so one odd colour
+# in a wallpaper can drag a theme's accent well outside its own look. This
+# pulls the raw derived palette back toward the theme's anchor palette by
+# at most the declared per-theme margins and re-runs every template from
+# the clamped result via `wallust cs` -- the same path [engine].colorscheme
+# already uses, so nothing downstream knows clamping happened. Opt-in:
+# themes with no [palette].anchor never reach here.
+_aphotic_theme_clamp_palette() {
+    local theme_name="$1" dir="$2"
+    local anchor; anchor="$(_aphotic_toml_get "${dir}/theme.toml" palette anchor)"
+    [[ -n "$anchor" ]] || return 0
+
+    command -v python3 >/dev/null 2>&1 || {
+        aphotic_warn "python3 not found, skipping palette clamp for '${theme_name}'"
+        return 0
+    }
+
+    local schemes_dir="${XDG_CONFIG_HOME:-$HOME/.config}/wallust/colorschemes"
+    local anchor_file="${schemes_dir}/${anchor}.json"
+    if [[ ! -f "$anchor_file" ]]; then
+        aphotic_warn "theme '${theme_name}' pins [palette].anchor = '${anchor}' but ${anchor_file} is missing -- applying unclamped palette"
+        return 0
+    fi
+
+    local raw="${XDG_CACHE_HOME:-$HOME/.cache}/wal/colors.json"
+    if [[ ! -f "$raw" ]]; then
+        aphotic_warn "no derived palette at ${raw} -- applying unclamped palette"
+        return 0
+    fi
+
+    local max_hue max_sat max_light
+    max_hue="$(_aphotic_toml_get "${dir}/theme.toml" palette max_hue_shift)"
+    max_sat="$(_aphotic_toml_get "${dir}/theme.toml" palette max_sat_shift)"
+    max_light="$(_aphotic_toml_get "${dir}/theme.toml" palette max_light_shift)"
+
+    local live="${schemes_dir}/${theme_name}-live.json"
+    local clamp_cmd=(python3 "${LIB_DIR}/palette_clamp.py" "$raw" "$anchor_file" -o "$live")
+    [[ -n "$max_hue" ]] && clamp_cmd+=(--max-hue-shift "$max_hue")
+    [[ -n "$max_sat" ]] && clamp_cmd+=(--max-sat-shift "$max_sat")
+    [[ -n "$max_light" ]] && clamp_cmd+=(--max-light-shift "$max_light")
+
+    if "${clamp_cmd[@]}"; then
+        wallust cs "${theme_name}-live" --format pywal
+    else
+        aphotic_warn "palette clamp failed for '${theme_name}' -- applying unclamped palette"
+    fi
+}
+
 # Apply theme_name/wallpaper_file: run awww + wallust with any engine
 # pins from theme.toml, then persist state. wallpaper_file may be
 # empty to fall back to the theme's declared default (or its first
@@ -104,6 +153,12 @@ _aphotic_theme_apply() {
         aphotic_warn "theme '${theme_name}' pins unknown [engine].name = '${engine_name}' -- using wallust"
     fi
 
+    # [engine].colorscheme is a fixed palette with no image derivation at
+    # all, so there's no raw palette for [palette].anchor to clamp.
+    if [[ -n "$colorscheme" ]] && [[ -n "$(_aphotic_toml_get "${dir}/theme.toml" palette anchor)" ]]; then
+        aphotic_warn "theme '${theme_name}' sets both [engine].colorscheme and [palette].anchor -- using the fixed colorscheme, skipping the clamp"
+    fi
+
     aphotic_require awww || return 1
     awww img "$image_path" --transition-type wipe --transition-angle 30 --transition-step 90
 
@@ -126,6 +181,7 @@ _aphotic_theme_apply() {
             [[ -n "$palette" ]] && wallust_cmd+=(-p "$palette")
             [[ -n "$style" ]] && wallust_cmd+=(-S "$style")
             "${wallust_cmd[@]}"
+            _aphotic_theme_clamp_palette "$theme_name" "$dir"
         fi
     else
         aphotic_warn "wallust not found, skipping palette regeneration"

--- a/Configs/.local/lib/aphotic/palette_clamp.py
+++ b/Configs/.local/lib/aphotic/palette_clamp.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Clamp a wallpaper-derived pywal palette to a theme's own anchor palette.
+
+`wallust run <image>` derives every ANSI slot purely from the image's
+pixels, so a wallpaper that happens to contain an off-palette colour can
+push a theme's accent well outside what that theme is supposed to look
+like (a pink sign in a photo turning Gruvbox neon-pink). This reads the
+raw derived palette and the theme's anchor palette -- both pywal JSON --
+and pulls each slot back toward the anchor only as far as the declared
+per-theme ceilings, so every wallpaper still generates its own distinct
+palette within a bounded neighbourhood of the theme's look.
+
+Opted into per theme via theme.toml's [palette] table; see
+themes/THEME_SPEC.md. The clamped result is written back out as pywal
+JSON so `wallust cs <name> --format pywal` can re-run every template
+from it -- the exact path [engine].colorscheme already uses.
+"""
+
+import argparse
+import colorsys
+import json
+import sys
+
+# Slots whose lightness carries wallust's check_contrast guarantees --
+# background/foreground separation and readable dim-grey `ls` output.
+# Clamping their lightness toward an anchor would fight that check on a
+# very dark or very light wallpaper, so only their saturation is bounded.
+LIGHTNESS_EXEMPT = frozenset({
+    "background", "foreground", "cursor",
+    "color0", "color7", "color8", "color15",
+})
+
+DEFAULT_MAX_HUE_SHIFT = 20.0
+DEFAULT_MAX_SAT_SHIFT = 15.0
+DEFAULT_MAX_LIGHT_SHIFT = 12.0
+
+SPECIAL_KEYS = ("background", "foreground", "cursor")
+COLOR_KEYS = tuple(f"color{i}" for i in range(16))
+
+
+def hex_to_hls(value):
+    """#rrggbb -> (hue degrees 0-360, lightness 0-100, saturation 0-100)."""
+    text = value.strip().lstrip("#")
+    if len(text) != 6:
+        raise ValueError(f"not a #rrggbb colour: {value!r}")
+    r, g, b = (int(text[i:i + 2], 16) / 255.0 for i in (0, 2, 4))
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    return h * 360.0, l * 100.0, s * 100.0
+
+
+def hls_to_hex(h, l, s):
+    r, g, b = colorsys.hls_to_rgb((h % 360.0) / 360.0, l / 100.0, s / 100.0)
+    return "#{:02x}{:02x}{:02x}".format(
+        round(max(0.0, min(1.0, r)) * 255),
+        round(max(0.0, min(1.0, g)) * 255),
+        round(max(0.0, min(1.0, b)) * 255),
+    )
+
+
+def clamp_hue(raw, anchor, limit):
+    """Rotate `raw` toward `anchor` by at most `limit` degrees.
+
+    Rotating to the limit rather than snapping to the anchor is the whole
+    point: a wallpaper past the ceiling still keeps its own direction of
+    drift, it just stops at the theme's margin.
+    """
+    delta = ((raw - anchor + 180.0) % 360.0) - 180.0
+    if abs(delta) <= limit:
+        return raw % 360.0
+    return (anchor + (limit if delta > 0 else -limit)) % 360.0
+
+
+def clamp_linear(raw, anchor, limit):
+    return max(0.0, min(100.0, max(anchor - limit, min(anchor + limit, raw))))
+
+
+def clamp_color(raw_hex, anchor_hex, key, max_hue, max_sat, max_light):
+    raw_h, raw_l, raw_s = hex_to_hls(raw_hex)
+    anchor_h, anchor_l, anchor_s = hex_to_hls(anchor_hex)
+
+    sat = clamp_linear(raw_s, anchor_s, max_sat)
+    if key in LIGHTNESS_EXEMPT:
+        return hls_to_hex(raw_h, raw_l, sat)
+
+    hue = clamp_hue(raw_h, anchor_h, max_hue)
+    light = clamp_linear(raw_l, anchor_l, max_light)
+    return hls_to_hex(hue, light, sat)
+
+
+def clamp_palette(raw, anchor,
+                  max_hue=DEFAULT_MAX_HUE_SHIFT,
+                  max_sat=DEFAULT_MAX_SAT_SHIFT,
+                  max_light=DEFAULT_MAX_LIGHT_SHIFT):
+    """Return a copy of `raw` with every slot clamped against `anchor`.
+
+    The raw palette's exact key structure is preserved (including any keys
+    the anchor doesn't carry, which pass through untouched) so the result
+    stays a valid pywal colorscheme for `wallust cs --format pywal`.
+    """
+    out = json.loads(json.dumps(raw))
+    for section, keys in (("special", SPECIAL_KEYS), ("colors", COLOR_KEYS)):
+        raw_section = raw.get(section) or {}
+        anchor_section = anchor.get(section) or {}
+        for key in keys:
+            if key not in raw_section or key not in anchor_section:
+                continue
+            out[section][key] = clamp_color(
+                raw_section[key], anchor_section[key], key,
+                max_hue, max_sat, max_light,
+            )
+    return out
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("raw", help="path to the wallust-derived pywal JSON (~/.cache/wal/colors.json)")
+    parser.add_argument("anchor", help="path to the theme's anchor pywal JSON")
+    parser.add_argument("-o", "--output", help="write here instead of stdout")
+    parser.add_argument("--max-hue-shift", type=float, default=DEFAULT_MAX_HUE_SHIFT)
+    parser.add_argument("--max-sat-shift", type=float, default=DEFAULT_MAX_SAT_SHIFT)
+    parser.add_argument("--max-light-shift", type=float, default=DEFAULT_MAX_LIGHT_SHIFT)
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.raw) as f:
+            raw = json.load(f)
+        with open(args.anchor) as f:
+            anchor = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"palette_clamp: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        clamped = clamp_palette(raw, anchor,
+                                args.max_hue_shift, args.max_sat_shift, args.max_light_shift)
+    except ValueError as exc:
+        print(f"palette_clamp: {exc}", file=sys.stderr)
+        return 1
+
+    text = json.dumps(clamped, indent=2) + "\n"
+    if args.output:
+        try:
+            with open(args.output, "w") as f:
+                f.write(text)
+        except OSError as exc:
+            print(f"palette_clamp: {exc}", file=sys.stderr)
+            return 1
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Configs/awww/gruvbox/theme.toml
+++ b/Configs/awww/gruvbox/theme.toml
@@ -2,6 +2,12 @@
 display_name = "Gruvbox"
 description = "Warm retro earth tones."
 
+[palette]
+anchor = "gruvbox-anchor"
+max_hue_shift = 20
+max_sat_shift = 15
+max_light_shift = 12
+
 [icons]
 papirus_color = "orange"
 

--- a/Configs/awww/hackthebox/theme.toml
+++ b/Configs/awww/hackthebox/theme.toml
@@ -6,6 +6,12 @@ description = "Dark, tech/sci-fi accents."
 backend = "fastresize"
 palette = "kmeans"
 
+[palette]
+anchor = "hackthebox-anchor"
+max_hue_shift = 20
+max_sat_shift = 15
+max_light_shift = 12
+
 [icons]
 papirus_color = "green"
 

--- a/Configs/awww/latte/theme.toml
+++ b/Configs/awww/latte/theme.toml
@@ -5,6 +5,12 @@ description = "Light theme, soft cream tones with a latte-art motif."
 [engine]
 style = "light"
 
+[palette]
+anchor = "latte-anchor"
+max_hue_shift = 25
+max_sat_shift = 15
+max_light_shift = 12
+
 [icons]
 papirus_color = "brown"
 

--- a/Configs/awww/lofi/theme.toml
+++ b/Configs/awww/lofi/theme.toml
@@ -2,6 +2,12 @@
 display_name = "Lofi"
 description = "Soft glowing pastels, cozy low-fi art."
 
+[palette]
+anchor = "lofi-anchor"
+max_hue_shift = 35
+max_sat_shift = 20
+max_light_shift = 15
+
 [icons]
 papirus_color = "pink"
 

--- a/Configs/awww/nordic/theme.toml
+++ b/Configs/awww/nordic/theme.toml
@@ -5,6 +5,12 @@ description = "Cool blue-gray tones."
 [engine]
 palette = "ansi"
 
+[palette]
+anchor = "nordic-anchor"
+max_hue_shift = 20
+max_sat_shift = 15
+max_light_shift = 12
+
 [icons]
 papirus_color = "nordic"
 

--- a/Configs/awww/rosepine/theme.toml
+++ b/Configs/awww/rosepine/theme.toml
@@ -2,6 +2,12 @@
 display_name = "Rose Pine"
 description = "Muted rose, gold, and pine-green."
 
+[palette]
+anchor = "rosepine-anchor"
+max_hue_shift = 30
+max_sat_shift = 20
+max_light_shift = 15
+
 [icons]
 papirus_color = "magenta"
 

--- a/Configs/awww/tokyonight/theme.toml
+++ b/Configs/awww/tokyonight/theme.toml
@@ -2,6 +2,12 @@
 display_name = "Tokyo Night"
 description = "Neon purples and blues, city-at-night palette."
 
+[palette]
+anchor = "tokyonight-anchor"
+max_hue_shift = 25
+max_sat_shift = 15
+max_light_shift = 12
+
 [icons]
 papirus_color = "indigo"
 

--- a/Configs/awww/windows11/theme.toml
+++ b/Configs/awww/windows11/theme.toml
@@ -2,6 +2,12 @@
 display_name = "Windows 11"
 description = "Minimal, muted, high-contrast."
 
+[palette]
+anchor = "windows11-anchor"
+max_hue_shift = 30
+max_sat_shift = 20
+max_light_shift = 15
+
 [icons]
 papirus_color = "blue"
 

--- a/Configs/hypr/scripts/wallswitcher.py
+++ b/Configs/hypr/scripts/wallswitcher.py
@@ -182,6 +182,74 @@ def parse_engine_pin(theme):
     return backend, palette, colorscheme, style, papirus_color, icon_theme, cursor_theme, gtk_theme, engine_name, scheme, contrast
 
 
+def parse_palette_pin(theme):
+    """Return a theme's [palette] clamp pins as a dict of strings.
+
+    Kept separate from parse_engine_pin's tuple because this table is
+    optional and self-contained: an empty "anchor" means the theme never
+    opted into clamping and the derived palette is used as-is.
+    """
+    toml_path = os.path.join(awww_dir, theme, "theme.toml")
+    pins = {"anchor": "", "max_hue_shift": "", "max_sat_shift": "", "max_light_shift": ""}
+    if not os.path.isfile(toml_path):
+        return pins
+    section = ""
+    with open(toml_path) as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("[") and line.endswith("]"):
+                section = line[1:-1]
+                continue
+            if section != "palette" or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            if key in pins:
+                pins[key] = value.strip().strip('"')
+    return pins
+
+
+# Mirrors cmd_theme.sh's _aphotic_theme_clamp_palette -- see that function
+# and themes/THEME_SPEC.md's "Clamped palettes" section. Rewrites the raw
+# image-derived palette wallust just cached into a clamped colorscheme
+# file, then re-runs every template from it via `wallust cs`.
+def apply_palette_clamp(theme, pins):
+    """Clamp the freshly derived palette toward the theme's anchor."""
+    if not pins["anchor"]:
+        return
+    schemes_dir = os.path.expanduser("~/.config/wallust/colorschemes")
+    anchor_file = os.path.join(schemes_dir, f"{pins['anchor']}.json")
+    raw_file = os.path.expanduser("~/.cache/wal/colors.json")
+    if not os.path.isfile(anchor_file):
+        print(f"theme '{theme}' pins [palette].anchor = '{pins['anchor']}' but {anchor_file} is missing — applying unclamped palette")
+        return
+    if not os.path.isfile(raw_file):
+        return
+
+    # The CLI's lib/ lives in the dots checkout, not under ~/.local --
+    # install.sh only symlinks ~/.local/bin/aphotic.
+    dots_dir = os.environ.get("APHOTIC_DOTS_DIR") or os.path.expanduser("~/Aphotic-Hypr")
+    live = os.path.join(schemes_dir, f"{theme}-live.json")
+    cmd = [
+        "python3", os.path.join(dots_dir, "Configs/.local/lib/aphotic/palette_clamp.py"),
+        raw_file, anchor_file, "-o", live,
+    ]
+    for flag, key in (("--max-hue-shift", "max_hue_shift"),
+                      ("--max-sat-shift", "max_sat_shift"),
+                      ("--max-light-shift", "max_light_shift")):
+        if pins[key]:
+            cmd += [flag, pins[key]]
+
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        print(f"palette clamp failed for '{theme}' — applying unclamped palette")
+        return
+    run_optional(["wallust", "cs", f"{theme}-live", "--format", "pywal"])
+
+
 settings_path = os.path.expanduser("~/.local/state/aphotic/settings.json")
 qtct_paths = (
     os.path.expanduser("~/.config/qt5ct/qt5ct.conf"),
@@ -274,9 +342,14 @@ def apply_wallpaper(theme, wallpaper):
     run_optional(["awww", "img", "--transition-type", "fade", "--transition-duration", "0.45", "--transition-fps", "60", image_path])
 
     backend, palette, colorscheme, style, papirus_color, icon_theme, cursor_theme, gtk_theme, engine_name, scheme, contrast = parse_engine_pin(theme)
+    palette_pins = parse_palette_pin(theme)
 
     if engine_name and engine_name not in ("wallust", "matugen"):
         print(f"theme '{theme}' pins unknown engine '{engine_name}' — using wallust")
+    if colorscheme and palette_pins["anchor"]:
+        # A fixed colorscheme derives nothing from the image, so there's
+        # no raw palette for the clamp to bound.
+        print(f"theme '{theme}' sets both [engine].colorscheme and [palette].anchor — using the fixed colorscheme, skipping the clamp")
 
     if engine_name == "matugen":
         # --prefer is not optional: matugen refuses to choose between an
@@ -303,7 +376,8 @@ def apply_wallpaper(theme, wallpaper):
         if style:
             wallust_cmd += ["-S", style]
         run_optional(wallust_cmd)
-    
+        apply_palette_clamp(theme, palette_pins)
+
     # In-process copy -- cheaper than spawning `cp` for what's just a
     # few-MB file, and nothing after this depends on it landing first.
     try:

--- a/Configs/quickshell/aphotic/services/Themes.qml
+++ b/Configs/quickshell/aphotic/services/Themes.qml
@@ -119,7 +119,14 @@ Singleton {
                 return;
             root._pendingApply = null;
             const fullPath = `${root.awwwDir}/${p.themeName}/${p.file}`;
-            Wallpapers.setWallpaper(fullPath, p.info.backend ?? "", p.info.palette ?? "", p.info.colorscheme ?? "", p.info.style ?? "", p.info.papirusColor ?? "", p.info.iconTheme ?? "", p.info.cursorTheme ?? "", p.info.gtkTheme ?? "", p.info.engineName ?? "", p.info.scheme ?? "", p.info.contrast ?? "");
+            const paletteClamp = p.info.paletteAnchor ? {
+                theme: p.themeName,
+                anchor: p.info.paletteAnchor,
+                maxHueShift: p.info.paletteMaxHueShift ?? "",
+                maxSatShift: p.info.paletteMaxSatShift ?? "",
+                maxLightShift: p.info.paletteMaxLightShift ?? ""
+            } : null;
+            Wallpapers.setWallpaper(fullPath, p.info.backend ?? "", p.info.palette ?? "", p.info.colorscheme ?? "", p.info.style ?? "", p.info.papirusColor ?? "", p.info.iconTheme ?? "", p.info.cursorTheme ?? "", p.info.gtkTheme ?? "", p.info.engineName ?? "", p.info.scheme ?? "", p.info.contrast ?? "", paletteClamp);
         }
     }
 
@@ -301,6 +308,10 @@ Singleton {
                         palette: toml.engine?.palette ?? "",
                         colorscheme: toml.engine?.colorscheme ?? "",
                         style: toml.engine?.style ?? "",
+                        paletteAnchor: toml.palette?.anchor ?? "",
+                        paletteMaxHueShift: toml.palette?.max_hue_shift ?? "",
+                        paletteMaxSatShift: toml.palette?.max_sat_shift ?? "",
+                        paletteMaxLightShift: toml.palette?.max_light_shift ?? "",
                         papirusColor: toml.icons?.papirus_color ?? "",
                         iconTheme: toml.icons?.icon_theme ?? "",
                         cursorTheme: toml.icons?.cursor_theme ?? "",

--- a/Configs/quickshell/aphotic/services/Wallpapers.qml
+++ b/Configs/quickshell/aphotic/services/Wallpapers.qml
@@ -32,6 +32,10 @@ Singleton {
     // right before each exec() -- see the onExited guard below for why.
     property int _generation: 0
 
+    // theme.toml's [palette] table for the run currently in flight, or
+    // null when this theme doesn't opt into clamping -- see _startClamp.
+    property var _pendingClamp: null
+
     // engineName picks which colour engine renders the palette; the rest
     // of these are that engine's own knobs (scheme/contrast are matugen's,
     // backend/palette/colorscheme are wallust's) -- see
@@ -66,7 +70,11 @@ Singleton {
     // relied on by Settings.qml's cursorApplyProc), so only the
     // most-recently-clicked theme's processes ever survive to write
     // anything or animate anything.
-    function setWallpaper(path: string, backend: var, palette: var, colorscheme: var, style: var, papirusColor: var, iconTheme: var, cursorTheme: var, gtkTheme: var, engineName: var, scheme: var, contrast: var): void {
+    // paletteClamp is theme.toml's [palette] table, or null/undefined when
+    // the theme doesn't opt in: { theme, anchor, maxHueShift, maxSatShift,
+    // maxLightShift }. Passed as one object rather than five more
+    // positional arguments purely because this signature is already long.
+    function setWallpaper(path: string, backend: var, palette: var, colorscheme: var, style: var, papirusColor: var, iconTheme: var, cursorTheme: var, gtkTheme: var, engineName: var, scheme: var, contrast: var, paletteClamp: var): void {
         root._generation++;
 
         // Toaster.qml's toast() is a dead no-op stub left over from an
@@ -76,6 +84,18 @@ Singleton {
 
         awwwProc.exec(["awww", "img", path, "--transition-type", "wipe", "--transition-angle", "30", "--transition-step", "90"]);
         cpProc.exec(["cp", path, root.path]);
+
+        // Only the image-derived wallust path has a raw palette to clamp:
+        // [engine].colorscheme is already a fixed palette, and matugen
+        // would need its seed colour clamped pre-generation instead (see
+        // themes/THEME_SPEC.md).
+        root._pendingClamp = null;
+        if (paletteClamp && paletteClamp.anchor && engineName !== "matugen") {
+            if (colorscheme)
+                Quickshell.execDetached(["notify-send", "-u", "low", "Aphotic", "theme sets both [engine].colorscheme and [palette].anchor — using the fixed colorscheme"]);
+            else
+                root._pendingClamp = paletteClamp;
+        }
 
         let engineCmd;
         if (engineName === "matugen") {
@@ -153,8 +173,80 @@ Singleton {
         onExited: exitCode => {
             if (engineProc.taggedGeneration !== root._generation)
                 return;
-            if (exitCode === 0)
+            if (exitCode !== 0)
+                return;
+            if (root._pendingClamp)
+                root._startClamp(root._pendingClamp);
+            else
                 Quickshell.execDetached(["aphotic", "plugin", "run-theme-hooks"]);
+        }
+    }
+
+    // Palette clamp (theme.toml's [palette] table -- see
+    // themes/THEME_SPEC.md). Mirrors cmd_theme.sh's
+    // _aphotic_theme_clamp_palette: rewrite the raw image-derived palette
+    // wallust just cached into a clamped colorscheme file, then re-run
+    // every template from it with `wallust cs`, the same path
+    // [engine].colorscheme already takes.
+    //
+    // Two more Processes chained off engineProc's onExited rather than one
+    // `sh -c` line, for the same reason engineProc itself exists: each step
+    // carries the generation tag, so a theme picked mid-clamp preempts this
+    // one instead of racing it into the shared template output files. The
+    // theme hooks stay the last link in the chain either way -- a failed
+    // clamp leaves the unclamped palette applied, which is still a
+    // complete, valid palette for the hooks to read.
+    function _startClamp(clamp: var): void {
+        const home = Quickshell.env("HOME");
+        // The CLI's lib/ lives in the dots checkout, not under ~/.local
+        // (install.sh only symlinks ~/.local/bin/aphotic) -- same env-var-
+        // with-default resolution AboutPane.qml uses to read VERSION.
+        const dotsDir = Quickshell.env("APHOTIC_DOTS_DIR") || `${home}/Aphotic-Hypr`;
+        const cmd = [
+            "python3", `${dotsDir}/Configs/.local/lib/aphotic/palette_clamp.py`,
+            `${home}/.cache/wal/colors.json`,
+            `${home}/.config/wallust/colorschemes/${clamp.anchor}.json`,
+            "-o", `${home}/.config/wallust/colorschemes/${clamp.theme}-live.json`
+        ];
+        if (clamp.maxHueShift)
+            cmd.push("--max-hue-shift", `${clamp.maxHueShift}`);
+        if (clamp.maxSatShift)
+            cmd.push("--max-sat-shift", `${clamp.maxSatShift}`);
+        if (clamp.maxLightShift)
+            cmd.push("--max-light-shift", `${clamp.maxLightShift}`);
+
+        clampProc.liveScheme = `${clamp.theme}-live`;
+        clampProc.taggedGeneration = root._generation;
+        clampProc.exec(cmd);
+    }
+
+    Process {
+        id: clampProc
+
+        property int taggedGeneration: 0
+        property string liveScheme: ""
+
+        onExited: exitCode => {
+            if (clampProc.taggedGeneration !== root._generation)
+                return;
+            if (exitCode !== 0) {
+                Quickshell.execDetached(["aphotic", "plugin", "run-theme-hooks"]);
+                return;
+            }
+            csProc.taggedGeneration = root._generation;
+            csProc.exec(["wallust", "cs", clampProc.liveScheme, "--format", "pywal"]);
+        }
+    }
+
+    Process {
+        id: csProc
+
+        property int taggedGeneration: 0
+
+        onExited: {
+            if (csProc.taggedGeneration !== root._generation)
+                return;
+            Quickshell.execDetached(["aphotic", "plugin", "run-theme-hooks"]);
         }
     }
 }

--- a/Configs/wallust/colorschemes/gruvbox-anchor.json
+++ b/Configs/wallust/colorschemes/gruvbox-anchor.json
@@ -1,0 +1,25 @@
+{
+  "special": {
+    "background": "#151310",
+    "foreground": "#E9E4DE",
+    "cursor": "#E9E4DE"
+  },
+  "colors": {
+    "color0": "#191612",
+    "color1": "#5D584F",
+    "color2": "#6A6958",
+    "color3": "#817D69",
+    "color4": "#868263",
+    "color5": "#AA937E",
+    "color6": "#BBAEA7",
+    "color7": "#E9E4DE",
+    "color8": "#2D2A27",
+    "color9": "#5D584F",
+    "color10": "#6A6958",
+    "color11": "#817D69",
+    "color12": "#868263",
+    "color13": "#AA937E",
+    "color14": "#BBAEA7",
+    "color15": "#E9E4DE"
+  }
+}

--- a/Configs/wallust/colorschemes/hackthebox-anchor.json
+++ b/Configs/wallust/colorschemes/hackthebox-anchor.json
@@ -1,0 +1,25 @@
+{
+  "special": {
+    "background": "#050706",
+    "foreground": "#669B04",
+    "cursor": "#669B04"
+  },
+  "colors": {
+    "color0": "#060907",
+    "color1": "#3E403F",
+    "color2": "#474E42",
+    "color3": "#4C5742",
+    "color4": "#4A5A53",
+    "color5": "#505B41",
+    "color6": "#63814E",
+    "color7": "#669B04",
+    "color8": "#1F201F",
+    "color9": "#3E403F",
+    "color10": "#474E42",
+    "color11": "#4C5742",
+    "color12": "#4A5A53",
+    "color13": "#505B41",
+    "color14": "#63814E",
+    "color15": "#669B04"
+  }
+}

--- a/Configs/wallust/colorschemes/latte-anchor.json
+++ b/Configs/wallust/colorschemes/latte-anchor.json
@@ -1,0 +1,25 @@
+{
+  "special": {
+    "background": "#242831",
+    "foreground": "#8BA6C3",
+    "cursor": "#8BA6C3"
+  },
+  "colors": {
+    "color0": "#2A2F3A",
+    "color1": "#5B5E66",
+    "color2": "#6A707D",
+    "color3": "#6A707D",
+    "color4": "#778497",
+    "color5": "#778497",
+    "color6": "#7F95B2",
+    "color7": "#7696B9",
+    "color8": "#414551",
+    "color9": "#5B5E66",
+    "color10": "#6A707D",
+    "color11": "#6A707D",
+    "color12": "#778497",
+    "color13": "#778497",
+    "color14": "#7F95B2",
+    "color15": "#7696B9"
+  }
+}

--- a/Configs/wallust/colorschemes/lofi-anchor.json
+++ b/Configs/wallust/colorschemes/lofi-anchor.json
@@ -1,0 +1,25 @@
+{
+  "special": {
+    "background": "#0D1A1C",
+    "foreground": "#F5E6A8",
+    "cursor": "#F5E6A8"
+  },
+  "colors": {
+    "color0": "#101F21",
+    "color1": "#6C5168",
+    "color2": "#5D6B64",
+    "color3": "#99656A",
+    "color4": "#77808F",
+    "color5": "#CF6454",
+    "color6": "#5992C8",
+    "color7": "#F5E6A8",
+    "color8": "#253437",
+    "color9": "#6C5168",
+    "color10": "#5D6B64",
+    "color11": "#99656A",
+    "color12": "#77808F",
+    "color13": "#CF6454",
+    "color14": "#5992C8",
+    "color15": "#F5E6A8"
+  }
+}

--- a/Configs/wallust/colorschemes/nordic-anchor.json
+++ b/Configs/wallust/colorschemes/nordic-anchor.json
@@ -1,0 +1,25 @@
+{
+  "special": {
+    "background": "#000000",
+    "foreground": "#F2F4F6",
+    "cursor": "#F2F4F6"
+  },
+  "colors": {
+    "color0": "#2D2E2F",
+    "color1": "#AA631C",
+    "color2": "#21A663",
+    "color3": "#69BF13",
+    "color4": "#5C638E",
+    "color5": "#C14C9A",
+    "color6": "#467D96",
+    "color7": "#F2F4F6",
+    "color8": "#535455",
+    "color9": "#AA631C",
+    "color10": "#21A663",
+    "color11": "#69BF13",
+    "color12": "#5C638E",
+    "color13": "#C14C9A",
+    "color14": "#467D96",
+    "color15": "#F2F4F6"
+  }
+}

--- a/Configs/wallust/colorschemes/rosepine-anchor.json
+++ b/Configs/wallust/colorschemes/rosepine-anchor.json
@@ -1,0 +1,25 @@
+{
+  "special": {
+    "background": "#211F1E",
+    "foreground": "#E1D7CC",
+    "cursor": "#E1D7CC"
+  },
+  "colors": {
+    "color0": "#262424",
+    "color1": "#727170",
+    "color2": "#CA6E87",
+    "color3": "#B78E9C",
+    "color4": "#F390A0",
+    "color5": "#E3AB9E",
+    "color6": "#EEA5D0",
+    "color7": "#E1D7CC",
+    "color8": "#3C3A39",
+    "color9": "#727170",
+    "color10": "#CA6E87",
+    "color11": "#B78E9C",
+    "color12": "#F390A0",
+    "color13": "#E3AB9E",
+    "color14": "#EEA5D0",
+    "color15": "#E1D7CC"
+  }
+}

--- a/Configs/wallust/colorschemes/tokyonight-anchor.json
+++ b/Configs/wallust/colorschemes/tokyonight-anchor.json
@@ -1,0 +1,25 @@
+{
+  "special": {
+    "background": "#161720",
+    "foreground": "#9FCE6A",
+    "cursor": "#9FCE6A"
+  },
+  "colors": {
+    "color0": "#1A1B26",
+    "color1": "#777992",
+    "color2": "#A37C7B",
+    "color3": "#779466",
+    "color4": "#E7887E",
+    "color5": "#D39572",
+    "color6": "#C8A1AA",
+    "color7": "#9FCE6A",
+    "color8": "#2F303C",
+    "color9": "#777992",
+    "color10": "#A37C7B",
+    "color11": "#779466",
+    "color12": "#E7887E",
+    "color13": "#D39572",
+    "color14": "#C8A1AA",
+    "color15": "#9FCE6A"
+  }
+}

--- a/Configs/wallust/colorschemes/windows11-anchor.json
+++ b/Configs/wallust/colorschemes/windows11-anchor.json
@@ -1,0 +1,25 @@
+{
+  "special": {
+    "background": "#010F19",
+    "foreground": "#818BB2",
+    "cursor": "#818BB2"
+  },
+  "colors": {
+    "color0": "#021422",
+    "color1": "#3D5668",
+    "color2": "#446176",
+    "color3": "#3E6979",
+    "color4": "#486E88",
+    "color5": "#417789",
+    "color6": "#3C7CA4",
+    "color7": "#515F94",
+    "color8": "#192938",
+    "color9": "#3D5668",
+    "color10": "#446176",
+    "color11": "#3E6979",
+    "color12": "#486E88",
+    "color13": "#417789",
+    "color14": "#3C7CA4",
+    "color15": "#515F94"
+  }
+}

--- a/scripts/generate-theme-anchors.sh
+++ b/scripts/generate-theme-anchors.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/generate-theme-anchors.sh
+#
+# One-time (re-runnable) bootstrap for the palette-clamp anchors: for each
+# theme under Configs/awww/, derive the palette of that theme's
+# [wallpaper].default image and save it as
+# Configs/wallust/colorschemes/<theme>-anchor.json (pywal format) -- the
+# reference palette theme.toml's [palette].anchor points at. See
+# themes/THEME_SPEC.md's "Clamped palettes" section.
+#
+# Generating an anchor does NOT opt a theme into clamping; that's a
+# separate, deliberate edit to that theme's theme.toml.
+#
+# Every wallust invocation here runs against a throwaway config dir with
+# exactly one template and a redirected XDG_CACHE_HOME, so running this
+# never touches ~/.cache/wal/colors.json or re-themes the live session.
+#
+# Usage: scripts/generate-theme-anchors.sh [theme ...]   (default: all)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AWWW_DIR="$ROOT/Configs/awww"
+SCHEMES_DIR="$ROOT/Configs/wallust/colorschemes"
+TEMPLATES_DIR="$ROOT/Configs/wallust/templates"
+
+command -v wallust >/dev/null 2>&1 || { echo "wallust not found"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cp -r "$TEMPLATES_DIR" "$TMP/templates"
+OUT="$TMP/anchor.json"
+
+toml_get() {
+    # section, key -- same flat single-section-scan shape the other
+    # theme.toml readers in this repo use.
+    local file="$1" section="$2" key="$3"
+    [[ -f "$file" ]] || return 0
+    awk -v section="[$section]" -v key="$key" '
+        /^[[:space:]]*\[/ { in_section = ($0 ~ "^[[:space:]]*\\" section) ; next }
+        in_section && $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+            sub(/^[^=]*=[[:space:]]*/, "")
+            sub(/[[:space:]]*(#.*)?$/, "")
+            gsub(/^"|"$/, "")
+            print; exit
+        }
+    ' "$file"
+}
+
+mkdir -p "$SCHEMES_DIR"
+
+themes=("$@")
+if [[ ${#themes[@]} -eq 0 ]]; then
+    themes=()
+    for dir in "$AWWW_DIR"/*/; do
+        [[ -d "$dir" ]] && themes+=("$(basename "$dir")")
+    done
+fi
+
+for theme in "${themes[@]}"; do
+    dir="$AWWW_DIR/$theme"
+    toml="$dir/theme.toml"
+    if [[ ! -d "$dir" ]]; then
+        echo "skip ${theme}: no such theme"
+        continue
+    fi
+
+    engine_name="$(toml_get "$toml" engine name)"
+    colorscheme="$(toml_get "$toml" engine colorscheme)"
+    if [[ "$engine_name" == "matugen" ]]; then
+        echo "skip ${theme}: pins matugen (clamping is wallust-only)"
+        continue
+    fi
+    if [[ -n "$colorscheme" ]]; then
+        echo "skip ${theme}: pins [engine].colorscheme (nothing is derived to clamp)"
+        continue
+    fi
+
+    wallpaper="$(toml_get "$toml" wallpaper default)"
+    if [[ -z "$wallpaper" || ! -f "$dir/$wallpaper" ]]; then
+        wallpaper="$(find "$dir" -maxdepth 1 -type f \
+            \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' \) \
+            -printf '%f\n' 2>/dev/null | sort | head -n1)"
+    fi
+    if [[ -z "$wallpaper" ]]; then
+        echo "skip ${theme}: no wallpapers"
+        continue
+    fi
+
+    backend="$(toml_get "$toml" engine backend)"
+    palette="$(toml_get "$toml" engine palette)"
+    style="$(toml_get "$toml" engine style)"
+
+    # Same generation knobs as Configs/wallust/wallust.toml, but with a
+    # single template so this run writes exactly one file, in $TMP.
+    cat > "$TMP/wallust.toml" <<EOF
+backend = "${backend:-fastresize}"
+palette = "${palette:-kmeans}"
+check_contrast = true
+
+[templates]
+anchor = { template = "colors-wal.json", target = "${OUT}" }
+EOF
+
+    cmd=(wallust run "$dir/$wallpaper" -d "$TMP" -s -w -q)
+    [[ -n "$style" ]] && cmd+=(-S "$style")
+
+    rm -f "$OUT"
+    if XDG_CACHE_HOME="$TMP/cache" "${cmd[@]}" && [[ -f "$OUT" ]]; then
+        cp "$OUT" "$SCHEMES_DIR/${theme}-anchor.json"
+        echo "wrote Configs/wallust/colorschemes/${theme}-anchor.json  (from ${wallpaper})"
+    else
+        echo "FAILED ${theme}: wallust produced no palette for ${wallpaper}"
+    fi
+done

--- a/tests/test_palette_clamp.py
+++ b/tests/test_palette_clamp.py
@@ -1,0 +1,113 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "Configs" / ".local" / "lib" / "aphotic"))
+from palette_clamp import clamp_hue, clamp_palette, hex_to_hls
+
+
+def palette(**colors):
+    """Build a pywal palette, defaulting every unset slot to mid grey."""
+    base = {
+        "special": {"background": "#101010", "foreground": "#e0e0e0", "cursor": "#e0e0e0"},
+        "colors": {f"color{i}": "#808080" for i in range(16)},
+    }
+    for key, value in colors.items():
+        if key in base["special"]:
+            base["special"][key] = value
+        else:
+            base["colors"][key] = value
+    return base
+
+
+def test_hue_within_bound_passes_through():
+    # anchor 30 deg (orange), raw ~40 deg -- inside a 20 deg ceiling, so
+    # the wallpaper's own hue must survive untouched.
+    raw = palette(color1="#cc8833")
+    anchor = palette(color1="#cc6633")
+    raw_h, _, _ = hex_to_hls(raw["colors"]["color1"])
+
+    out = clamp_palette(raw, anchor, max_hue=20, max_sat=100, max_light=100)
+    out_h, _, _ = hex_to_hls(out["colors"]["color1"])
+
+    assert abs(out_h - raw_h) < 1.0
+
+
+def test_hue_past_bound_rotates_to_limit_not_to_anchor():
+    # Gruvbox-orange anchor vs. a neon-pink wallpaper accent: the result
+    # must land exactly max_hue_shift away from the anchor, still on the
+    # raw colour's side, rather than snapping onto the anchor itself.
+    raw = palette(color1="#ff33aa")
+    anchor = palette(color1="#cc6633")
+    anchor_h, _, _ = hex_to_hls(anchor["colors"]["color1"])
+    raw_h, _, _ = hex_to_hls(raw["colors"]["color1"])
+
+    out = clamp_palette(raw, anchor, max_hue=20, max_sat=100, max_light=100)
+    out_h, _, _ = hex_to_hls(out["colors"]["color1"])
+
+    delta = ((out_h - anchor_h + 180) % 360) - 180
+    raw_delta = ((raw_h - anchor_h + 180) % 360) - 180
+    assert abs(abs(delta) - 20) < 0.5
+    assert (delta > 0) == (raw_delta > 0)
+    assert abs(out_h - anchor_h) > 1.0
+
+
+def test_clamp_hue_takes_the_short_way_around_the_wheel():
+    assert abs(clamp_hue(350, 10, 5) - 5) < 1e-9
+    assert abs(clamp_hue(10, 350, 5) - 355) < 1e-9
+
+
+def test_exempt_slots_keep_their_lightness():
+    # background/foreground/cursor/color0/7/8/15 carry wallust's
+    # check_contrast guarantees -- a very dark or very light wallpaper
+    # must never have those pulled back toward the anchor's lightness.
+    exempt = {
+        "background": "#000000",
+        "foreground": "#ffffff",
+        "cursor": "#ffffff",
+        "color0": "#050505",
+        "color7": "#fafafa",
+        "color8": "#0a0a0a",
+        "color15": "#ffffff",
+    }
+    raw = palette(**exempt)
+    anchor = palette(**{k: "#808080" for k in exempt})
+
+    out = clamp_palette(raw, anchor, max_hue=20, max_sat=15, max_light=12)
+
+    for key, value in exempt.items():
+        got = out["special"].get(key) or out["colors"][key]
+        _, raw_l, _ = hex_to_hls(value)
+        _, out_l, _ = hex_to_hls(got)
+        assert abs(out_l - raw_l) < 0.5, f"{key} lightness was clamped"
+
+
+def test_non_exempt_slot_lightness_is_clamped():
+    raw = palette(color3="#ffffff")
+    anchor = palette(color3="#808080")
+
+    out = clamp_palette(raw, anchor, max_hue=20, max_sat=15, max_light=12)
+    _, out_l, _ = hex_to_hls(out["colors"]["color3"])
+    _, anchor_l, _ = hex_to_hls(anchor["colors"]["color3"])
+
+    assert abs(out_l - (anchor_l + 12)) < 0.5
+
+
+def test_saturation_is_clamped_on_exempt_slots_too():
+    raw = palette(background="#4b0082")
+    anchor = palette(background="#101010")
+
+    out = clamp_palette(raw, anchor, max_hue=20, max_sat=15, max_light=12)
+    _, _, out_s = hex_to_hls(out["special"]["background"])
+    _, _, anchor_s = hex_to_hls(anchor["special"]["background"])
+
+    assert out_s <= anchor_s + 15 + 0.5
+
+
+def test_key_structure_is_preserved():
+    raw = palette()
+    raw["alpha"] = "100"
+    out = clamp_palette(raw, palette())
+
+    assert set(out) == {"special", "colors", "alpha"}
+    assert set(out["special"]) == {"background", "foreground", "cursor"}
+    assert set(out["colors"]) == {f"color{i}" for i in range(16)}

--- a/themes/THEME_SPEC.md
+++ b/themes/THEME_SPEC.md
@@ -275,6 +275,39 @@ knows clamping happened. All three apply sites (`cmd_theme.sh`,
 `Wallpapers.qml`, `wallswitcher.py`) do this. A missing anchor file warns
 and leaves the unclamped palette applied rather than failing the switch.
 
+**The hue clamp assumes slot→hue stability, which only `palette = "ansi"`
+gives you.** The clamp compares slot to slot: raw `color6` against anchor
+`color6`. That is only meaningful if a slot holds the same *kind* of hue
+from one wallpaper to the next. Measured as circular hue spread across
+each theme's own shipped wallpapers:
+
+| theme | `[engine].palette` | spread of `color1`–`color6` |
+|---|---|---|
+| nordic | `ansi` | 1°–8° |
+| gruvbox | kmeans (default) | 13°–75° |
+| tokyonight | kmeans (default) | 52°–103° |
+| lofi | kmeans (default) | 74°–125° |
+
+`ansi` orders slots by the classic TTY convention (`color1` red-ish,
+`color2` green-ish, …), so a slot means the same thing every time and the
+clamp does exactly what it says: Nordic's `color1 #B77142` → `#C36F36`,
+a small push toward the theme's own orange. `kmeans` and `salience` order
+slots by cluster prominence instead, so `color6` can be neon blue in one
+wallpaper and dusty pink in another. Clamping *those* slot-to-slot rotates
+toward whatever hue happened to land in that slot for the anchor
+wallpaper, which is arbitrary — Tokyo Night's `color6 #2DB0F0` (neon blue)
+becomes `#C16BA3` (pink) for exactly this reason.
+
+So a theme that wants the hue ceiling to mean anything should pin
+`[engine].palette = "ansi"` alongside `[palette].anchor`. A theme that
+wants to keep kmeans should set `max_hue_shift = 180` (which disables the
+hue clamp; it can never exceed 180° of circular distance) and rely on the
+saturation and lightness ceilings alone — those are slot-order-independent
+and still stop a wallpaper from blowing out a theme's intensity. Matching
+raw colours to their *nearest* anchor hue instead of their same-numbered
+slot would remove this constraint, but that is a different algorithm from
+the one implemented here.
+
 **Mutually exclusive with `[engine].colorscheme`.** A fixed colorscheme
 derives nothing from the image, so there is no raw palette to clamp; a
 theme setting both warns and keeps the fixed colorscheme.

--- a/themes/THEME_SPEC.md
+++ b/themes/THEME_SPEC.md
@@ -39,6 +39,11 @@ contrast = "0.3"           # matugen --contrast: -1 (minimum) .. 0 (M3 spec) .. 
 # shared:
 style = "light"         # wallust -S / matugen -m: dark | light — omit for dark (the default for every theme but Latte)
 
+[palette]
+anchor = "some-name"    # bound how far a wallpaper's derived palette may
+                        # drift from the theme's own look. Optional, off
+                        # unless set — see "Clamped palettes" below.
+
 [icons]
 papirus_color = "green"     # one of `papirus-folders --list`, see below
 icon_theme = "Papirus-Dark" # optional, see "Icon/cursor/GTK theme pins" below
@@ -206,6 +211,81 @@ theme (`cmd_theme.sh`, `Wallpapers.qml`'s `setWallpaper`, and
 --format pywal` instead of `wallust run <image>` when it's set —
 `backend`/`palette` are ignored in that case, since they're
 image-generation-only knobs.
+
+### Clamped palettes (`[palette].anchor`)
+
+`[engine].colorscheme` above is the all-or-nothing answer to palette
+drift: no image derivation at all. `[palette]` is the middle setting.
+Every wallpaper still derives its own distinct palette — that
+individuality is the point — but how far that palette may drift from the
+theme's own look is bounded, tighter for a narrow, earthy theme like
+Gruvbox than for something with more range like Rosé Pine. Without it, a
+wallpaper that happens to contain an off-palette colour (a pink sign in a
+photo, a badly-chosen community download) can push the whole system's
+accent somewhere the theme was never meant to go.
+
+```toml
+[palette]
+anchor = "gruvbox-anchor"   # ref: Configs/wallust/colorschemes/<name>.json
+max_hue_shift = 20          # degrees, optional, default 20
+max_sat_shift = 15          # percentage points, optional, default 15
+max_light_shift = 12        # percentage points, optional, default 12
+```
+
+Like `[engine]`, this is a declared pin, not implicit behaviour: a theme
+with no `[palette].anchor` behaves exactly as it always has, and clamping
+rolls out theme by theme.
+
+`anchor` names a pywal-format file under
+`Configs/wallust/colorschemes/<name>.json` — the same directory and format
+`[engine].colorscheme` reads, holding the palette this theme's colours are
+measured against. `scripts/generate-theme-anchors.sh` bootstraps one per
+theme by deriving the palette of that theme's `[wallpaper].default` image
+(in an isolated wallust config/cache dir, so it never disturbs the live
+session), writing `<theme>-anchor.json`. Generating an anchor doesn't opt
+a theme in; that's the separate `[palette].anchor` edit.
+
+The clamp itself (`Configs/.local/lib/aphotic/palette_clamp.py`) runs
+after the normal `wallust run <image>`, which always leaves the raw,
+unclamped palette at `~/.cache/wal/colors.json` via wallust.toml's
+`wal_colors_json` template. Per slot, both the raw and anchor colour are
+converted to HSL and:
+
+- **Hue** is a circular clamp: within `max_hue_shift` of the anchor it
+  passes through untouched; past it, the raw hue is rotated *toward* the
+  anchor by exactly `max_hue_shift` rather than snapped onto it, so a
+  wallpaper at the ceiling still keeps its own direction of drift.
+- **Saturation** and **lightness** are clipped to `anchor ± max_sat_shift`
+  / `anchor ± max_light_shift`.
+- `background`, `foreground`, `cursor`, `color0`, `color7`, `color8` and
+  `color15` are **exempt from lightness clamping** — only their
+  saturation is bounded. Their lightness is what `check_contrast = true`
+  (see below) is already guaranteeing, and clamping it toward an anchor
+  would fight that check on a very dark or very light wallpaper. The
+  hue-bearing accent slots (`color1`–`color6`, `color9`–`color14`) get
+  the full treatment.
+
+The clamped result is written to
+`Configs/wallust/colorschemes/<theme>-live.json` (gitignored, regenerated
+on every apply) and applied with `wallust cs <theme>-live --format pywal`
+— literally the `[engine].colorscheme` code path, so every template
+(kitty, GTK, hyprland, cava, swaylock, the plugin palette snapshot) is
+re-rendered from the clamped colours and nothing downstream of wallust
+knows clamping happened. All three apply sites (`cmd_theme.sh`,
+`Wallpapers.qml`, `wallswitcher.py`) do this. A missing anchor file warns
+and leaves the unclamped palette applied rather than failing the switch.
+
+**Mutually exclusive with `[engine].colorscheme`.** A fixed colorscheme
+derives nothing from the image, so there is no raw palette to clamp; a
+theme setting both warns and keeps the fixed colorscheme.
+
+**matugen themes can't use this.** matugen doesn't derive a palette that
+can be post-processed the way ANSI slots can — it generates M3 roles from
+a single seed colour, and its `-s/--source-color` flag takes that seed
+explicitly. Clamping there would have to happen on the seed *before*
+generation, a different mechanism from this one. `[palette]` is ignored
+under `[engine].name = "matugen"`; none of the shipped themes pin matugen
+today.
 
 ### Readable contrast and light themes
 


### PR DESCRIPTION
Every wallpaper still themes the system dynamically — this puts a ceiling on how far that can drift. `wallust run` derives every ANSI slot from the image's pixels alone, so one off-palette colour in a wallpaper (or a badly-chosen community download) can push the whole system's accent well outside what the theme is supposed to look like. Each wallpaper should still generate its own distinct palette; it just shouldn't be able to leave the neighbourhood.

Opt-in per theme via a new `theme.toml` `[palette]` table, matching the existing `[engine]` pin philosophy — declared, not implicit. A theme with no `[palette].anchor` behaves exactly as it does today.

## Mechanism

Reuses the existing fixed-colorscheme plumbing rather than adding a new apply path. After the normal `wallust run`, `palette_clamp.py` reads the raw palette wallust always caches at `~/.cache/wal/colors.json`, pulls each slot back toward the theme's anchor palette by at most the declared margins, writes `colorschemes/<theme>-live.json`, and `wallust cs <theme>-live --format pywal` re-renders every template from it — kitty, GTK, hyprland, cava, swaylock, the plugin palette snapshot. That's the exact code path `[engine].colorscheme` already takes, so nothing downstream of wallust knows clamping happened.

Hue is a circular clamp: inside the ceiling it passes through untouched, past it the raw hue rotates *toward* the anchor by exactly `max_hue_shift` rather than snapping onto it, so a wallpaper at the ceiling keeps its own direction of drift. Saturation and lightness are clipped to `anchor ± limit`.

`background`, `foreground`, `cursor`, `color0`, `color7`, `color8`, `color15` are exempt from lightness clamping — their lightness is what `check_contrast = true` is already guaranteeing (readable `ls` output, background/foreground separation), and clamping it toward an anchor would fight that check on a very dark or very light wallpaper. Only their saturation is bounded.

## What's in here

- `Configs/.local/lib/aphotic/palette_clamp.py` — the clamp, stdlib only (`colorsys`).
- `scripts/generate-theme-anchors.sh` — bootstraps `<theme>-anchor.json` per theme from that theme's `[wallpaper].default`, honouring its `[engine]` pins. Runs wallust against an isolated config/cache dir, so it never disturbs the live session (verified: `~/.cache/wal/colors.json` byte-identical before and after).
- Anchors for all 8 shipped themes, and `[palette]` opt-ins for all 8, with limits sized per theme from measurements across all 100 shipped wallpapers.
- Wired into all three apply sites: `cmd_theme.sh`, `Wallpapers.qml`, and `wallswitcher.py` (SUPER+W). A missing anchor file warns and leaves the unclamped palette applied rather than failing the switch.
- `Configs/wallust/colorschemes/*-live.json` gitignored — `~/.config/wallust` symlinks into the repo on a dev checkout, so the regenerated file would otherwise land in the working tree.
- `tests/test_palette_clamp.py` — 7 tests: hue in bounds passes through, hue past bounds rotates exactly to the limit *and not onto the anchor*, wraparound takes the short way round, exempt slots keep their lightness, non-exempt slots don't, saturation still clamped on exempt slots, pywal key structure preserved.

In `Wallpapers.qml` the clamp is two more `Process`es chained off `engineProc.onExited`, each carrying the same generation tag the existing debounce relies on, so a theme picked mid-clamp preempts rather than races into the shared template outputs. Theme hooks stay the last link in every branch, including clamp failure.

## Known limitation, documented not hidden

**The hue clamp only means something under `[engine].palette = "ansi"`.** The clamp compares slot to slot, which assumes a slot holds the same kind of hue from wallpaper to wallpaper. Circular hue spread measured across each theme's own shipped wallpapers:

| theme | `[engine].palette` | spread of `color1`–`color6` |
|---|---|---|
| nordic | `ansi` | 1°–8° |
| gruvbox | kmeans (default) | 13°–75° |
| tokyonight | kmeans (default) | 52°–103° |
| lofi | kmeans (default) | 74°–125° |

`ansi` orders slots by the classic TTY convention, so the clamp does exactly what it says — Nordic's `color1 #B77142` → `#C36F36`, a small push toward the theme's own orange. `kmeans` orders by cluster prominence, so `color6` is neon blue in one wallpaper and dusty pink in the next, and clamping those slot-to-slot rotates toward whatever hue happened to sit in that slot for the anchor wallpaper. Tokyo Night's `color6 #2DB0F0` (neon blue) → `#C16BA3` (pink) is that, and it is a large change rather than a better one.

Three ways out, recorded in `THEME_SPEC.md` alongside the numbers: pin `palette = "ansi"` on themes that clamp; or set `max_hue_shift = 180` to disable the hue clamp and keep only the slot-order-independent saturation/lightness ceilings; or match raw colours to their nearest anchor hue instead of their same-numbered slot, which is a different algorithm from the one implemented here. Worth settling before this goes further than a review.

## matugen gap

matugen doesn't produce a post-processable palette — it generates M3 roles from a single seed, and `-s/--source-color` takes that seed explicitly, so clamping there would have to happen pre-generation. That's a different mechanism, not a variation of this one. `[palette]` is ignored under `[engine].name = "matugen"` at all three sites, the bootstrap skips matugen themes, and the gap is documented. No shipped theme pins matugen today.

## Testing

Full suite green (57 pytest). Verified against the real toolchain, not stubs: `wallust cs` reads the anchor JSON out of `~/.config/wallust/colorschemes/` cleanly, `_aphotic_theme_clamp_palette` writes the live file and invokes `wallust cs` with the right arguments, and the missing-anchor path warns and skips. Both TOML parsers (shell and the QML flat parser) read the new `[palette]` keys correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KM7cL9sDuiS2pWNf1Vzqie