### PR TITLE
plugin: restore dependency installation, and let a manifest name its own installer

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -307,7 +307,16 @@ _aphotic_plugin_sync_repo() {
 # build scripts and this repo doesn't silently auto-confirm that anywhere
 # else either.
 _aphotic_plugin_install_deps() {
-    local dest="$1" manifest="${dest}/plugin.toml" bin pkg helper=""
+    # Two statements, not one: bash 5.3 changed `local` to expand every
+    # assignment word before creating any of the locals, so the old
+    # single-statement `local dest="$1" manifest="${dest}/plugin.toml"`
+    # read an unset `dest` and resolved manifest to literally
+    # "/plugin.toml". That file never exists, so this function hit its
+    # `[[ -f "$manifest" ]] || return 0` guard and returned immediately --
+    # plugin dependency installation has been silently dead on any bash
+    # 5.3+ system.
+    local dest="$1"
+    local manifest="${dest}/plugin.toml" bin pkg helper=""
     [[ -f "$manifest" ]] || return 0
 
     command -v yay >/dev/null 2>&1 && helper="yay"

--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -330,6 +330,28 @@ _aphotic_plugin_install_deps() {
 
     [[ ${#missing[@]} -eq 0 ]] && return 0
 
+    # `[requires] install_script = "hooks/x.sh"` -- an escape hatch for a
+    # dependency the AUR can't supply correctly. The fallback below maps a
+    # missing binary to a package of the same name, which is right for the
+    # common case but actively wrong when no such package exists: `codex`
+    # has no AUR package, so `yay -S codex` resolves to `codex-bin`, an
+    # unrelated Electron app that pulls a multi-GB chromium build. A
+    # plugin that knows its own dependency's real install path says so
+    # here and core runs that instead -- same trust model as [harness]
+    # wire/unwire, which already execute plugin-shipped scripts.
+    local install_script
+    install_script="$(aphotic_toml_get "$manifest" requires install_script)"
+    if [[ -n "$install_script" ]]; then
+        local script_path="${dest}/${install_script}"
+        if [[ -x "$script_path" ]]; then
+            echo "Installing dependencies (${missing[*]}) via the plugin's own ${install_script}"
+            "$script_path" || aphotic_warn "${install_script} exited non-zero -- install ${missing[*]} manually"
+        else
+            aphotic_warn "plugin.toml declares [requires].install_script = '${install_script}' but ${script_path} is not executable -- install ${missing[*]} manually"
+        fi
+        return 0
+    fi
+
     if [[ -z "$helper" ]]; then
         aphotic_warn "missing dependencies (${missing[*]}) but no AUR helper (yay/paru) found on PATH -- install manually"
         return 0

--- a/tests/test_plugin_install_deps.sh
+++ b/tests/test_plugin_install_deps.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# tests/test_plugin_install_deps.sh
+# _aphotic_plugin_install_deps: the AUR fallback, the [requires]
+# install_script escape hatch, and the bash-5.3 `local` scoping
+# regression that made the whole function a silent no-op.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+COMMANDS_DIR="$ROOT/Configs/.local/lib/aphotic/commands"
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_plugin.sh"
+
+# Fake AUR helper ahead of any real one -- this test must never invoke a
+# real package manager.
+mkdir -p "$TESTHOME/bin"
+cat > "$TESTHOME/bin/yay" <<'EOF'
+#!/bin/sh
+echo "yay-called: $*"
+EOF
+chmod +x "$TESTHOME/bin/yay"
+export PATH="$TESTHOME/bin:$PATH"
+
+MISSING_BIN="aphotic-test-binary-that-does-not-exist"
+
+new_plugin() {
+    local dir="$APHOTIC_PLUGINS_DIR/$1"
+    mkdir -p "$dir/hooks"
+    {
+        echo '[plugin]'
+        echo "name = \"$1\""
+        echo '[requires]'
+        echo "binaries = [\"${MISSING_BIN}\"]"
+        [[ -n "${2:-}" ]] && echo "install_script = \"$2\""
+    } > "$dir/plugin.toml"
+    printf '%s\n' "$dir"
+}
+
+# --- the bash 5.3 `local` regression -------------------------------------
+# `local dest="$1" manifest="${dest}/plugin.toml"` resolved manifest to
+# "/plugin.toml" on bash 5.3+, which never exists, so the function
+# returned at its own guard and no dependency was ever installed. Assert
+# it actually reaches its work now.
+
+dir="$(new_plugin no-script)"
+out="$(_aphotic_plugin_install_deps "$dir" 2>&1)"
+[[ "$out" == *"yay-called: -S ${MISSING_BIN}"* ]] \
+    || fail "AUR fallback did not run for a missing binary (got: ${out:-<nothing>})"
+
+# --- [requires] install_script replaces the AUR path ---------------------
+
+dir="$(new_plugin with-script hooks/deps.sh)"
+cat > "$dir/hooks/deps.sh" <<'EOF'
+#!/bin/sh
+echo "install-script-ran"
+EOF
+chmod +x "$dir/hooks/deps.sh"
+
+out="$(_aphotic_plugin_install_deps "$dir" 2>&1)"
+[[ "$out" == *"install-script-ran"* ]] || fail "install_script was not executed"
+[[ "$out" != *"yay-called"* ]] || fail "install_script did not replace the AUR path"
+
+# --- a declared-but-unusable install_script warns, never silently yays ---
+
+chmod -x "$dir/hooks/deps.sh"
+out="$(_aphotic_plugin_install_deps "$dir" 2>&1)"
+[[ "$out" == *"not executable"* ]] || fail "non-executable install_script did not warn"
+[[ "$out" != *"yay-called"* ]] || fail "non-executable install_script fell through to the AUR"
+
+# --- nothing missing means nothing runs ----------------------------------
+
+dir="$(new_plugin satisfied)"
+{
+    echo '[plugin]'
+    echo 'name = "satisfied"'
+    echo '[requires]'
+    echo 'binaries = ["sh"]'
+} > "$dir/plugin.toml"
+out="$(_aphotic_plugin_install_deps "$dir" 2>&1)"
+[[ -z "$out" ]] || fail "ran something for an already-satisfied dependency: $out"
+
+echo "PASS: plugin install deps"


### PR DESCRIPTION
Found while investigating why the Agent Graph was catching neither Codex nor OpenCode. Pairs with **T-Crypt/aphotic-plugins#4**, which carries the codex-hooks half.

## 1. Dependency installation has been dead since bash 5.3

`_aphotic_plugin_install_deps` opened with:

```bash
local dest="$1" manifest="${dest}/plugin.toml" bin pkg helper=""
```

Bash 5.3 changed `local` to expand every assignment word *before* creating any of the locals, so `${dest}` there resolves against the caller's scope — unset — and `manifest` became the literal string `/plugin.toml`. That path never exists, so the function's own guard:

```bash
[[ -f "$manifest" ]] || return 0
```

fired on every call and returned before reading a single dependency. No error, no warning: `aphotic plugin install` looked successful and simply never installed anything a plugin declared in `[requires]`.

Reproducible in isolation:

```
$ bash -c 'f(){ local a="$1" b="${a}/x"; echo "b=$b"; }; f HELLO'
b=/x                      # bash 5.3.15
```

Split into two statements, which behaves left-to-right on every bash version. A repo-wide scan for the same pattern found this one occurrence and no others.

## 2. `[requires] install_script` — an escape hatch for the AUR fallback

With #1 fixed, the fallback runs again, and it maps a missing binary to a package of the same name. Right for the common case; actively wrong when no such package exists. `codex-hooks` declares `[requires] binaries = ["codex"]`, there is no AUR package named `codex`, and the name resolves to `codex-bin` — an unrelated Electron note-taking app whose `electron32` dependency pulls a full chromium source tree. Roughly 18GB of `chromium-mirror`, for a plugin that wanted OpenAI's CLI.

`[requires] install_script = "hooks/x.sh"` lets a plugin that knows its dependency's real install path say so, and core runs that instead of the helper. Same trust model as `[harness]` wire/unwire, which already execute plugin-shipped scripts. A declared-but-non-executable script warns rather than falling through to the AUR — falling through is precisely what the plugin opted out of.

`[requires] packages` still covers the simpler "package name differs from binary name" case, and the existing path is unchanged when no `install_script` is declared.

## Testing

New `tests/test_plugin_install_deps.sh` covers four paths with a stubbed AUR helper (the test must never invoke a real package manager): AUR fallback runs for a missing binary; `install_script` runs and suppresses the helper; a non-executable `install_script` warns and does not fall through; an already-satisfied dependency runs nothing.

The first assertion is the regression guard for #1 — it fails if the one-line `local` is reintroduced, verified by doing exactly that. All six `tests/test_plugin_*.sh` pass.

## Note for reviewers

The two commits are independently revertible. The bash 5.3 fix stands on its own regardless of what happens to the `install_script` design.