### PR TITLE
install: make a large package install distinguishable from a hang

### DIFF
--- a/lib/install/packages.sh
+++ b/lib/install/packages.sh
@@ -2,19 +2,55 @@
 # lib/install/packages.sh
 set -euo pipefail
 
+_elapsed_str() {
+  local s="$1"
+  if ((s < 60)); then
+    printf '%ds' "$s"
+  else
+    printf '%dm%02ds' $((s / 60)) $((s % 60))
+  fi
+}
+
+# Last thing the detached install actually wrote, normalized for a single
+# status line: pacman/makepkg redraw with bare CRs and color escapes, and
+# the tail of the log is the only place the current activity ("burpsuite-...
+# downloading...") is visible at all.
+_install_activity_line() {
+  [[ -n "${INSTLOG:-}" && -r "${INSTLOG:-}" ]] || return 0
+  tail -c 4096 "$INSTLOG" 2>/dev/null \
+    | tr '\r' '\n' \
+    | sed $'s/\033\\[[0-9;?]*[a-zA-Z]//g' \
+    | grep -v '^[[:space:]]*$' \
+    | tail -n 1 \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+# The install runs detached with all of its output in $INSTLOG, so without
+# the package name, an elapsed clock and that log tail on the spinner line
+# there is nothing on screen to distinguish a slow package from a hang --
+# and some are very slow (burpsuite pulls a ~1 GB transaction with its
+# JDK). Liveness is `kill -0`, not `ps | grep "$pid"`: that matched the pid
+# digits anywhere in ps's output, including inside another process's pid or
+# its TIME column.
 show_progress() {
-  local pid="$1"
+  local pid="$1" label="${2:-}"
+  local start=$SECONDS
   if [[ -t 1 ]]; then
     local frames='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
-    local i=0
-    while ps | grep "$pid" &> /dev/null; do
-      printf "\r\e[K%s" "${frames:i++%${#frames}:1}"
+    local i=0 detail="" width elapsed line
+    width=$(tput cols 2>/dev/null) || width=80
+    [[ "$width" =~ ^[0-9]+$ ]] && ((width > 20)) || width=80
+    while kill -0 "$pid" 2>/dev/null; do
+      ((i % 10 == 0)) && detail=$(_install_activity_line || true)
+      elapsed=$(_elapsed_str $((SECONDS - start)))
+      line="${frames:i++%${#frames}:1} ${label:+$label }[$elapsed]${detail:+ -- $detail}"
+      printf '\r\e[K%s' "${line:0:width - 1}"
       sleep 0.1
     done
-    printf "\r\e[K"
+    printf '\r\e[K'
   else
     echo -n "working..."
-    while ps | grep "$pid" &> /dev/null; do
+    while kill -0 "$pid" 2>/dev/null; do
       sleep 2
     done
     echo ""
@@ -30,13 +66,15 @@ install_software() {
     echo -e "$CNT - [dry-run] would install $1"
     return 0
   fi
-  echo -en "$CNT - Now installing $1 "
+  # On a terminal the spinner line carries the name itself; only the
+  # non-TTY branch (no spinner) needs it printed up front.
+  [[ -t 1 ]] || echo -en "$CNT - Now installing $1 "
   "$AUR_HELPER" -S --noconfirm "$1" &>> "$INSTLOG" &
-  show_progress $!
+  show_progress $! "installing $1"
   if "$AUR_HELPER" -Q "$1" &>> /dev/null ; then
-    echo -e "\e[1A\e[K$COK - $1 was installed."
+    echo -e "$COK - $1 was installed."
   else
-    echo -e "\e[1A\e[K$CER - $1 install had failed, please check the install.log"
+    echo -e "$CER - $1 install had failed, please check the install.log"
     exit 1
   fi
 }


### PR DESCRIPTION
## What happened

A `./install.sh --with exploit-*` run looked stalled "on installing recon-ng" and was Ctrl+C'd. It wasn't stalled:

- `recon-ng` had installed fine. The next package, `burpsuite`, pulls a **1063.32 MiB** transaction (`jdk-openjdk` + `java-*-common` + `libnet`) from BlackArch.
- The `.part` file in `/var/cache/pacman/pkg/` was **374 MB and still growing** when the interrupt landed. The download was healthy.

Nothing on screen said so, for two reasons in `lib/install/packages.sh`:

1. `install_software` printed `Now installing $1` with no newline, and `show_progress`'s very first `\r\e[K` **erased it**. What remained was a bare spinner glyph sitting under the *previous* package's `[OK]` line — so the last readable text was `recon-ng was installed`, which is what read as "stalled on recon-ng".
2. All install output is redirected to `$INSTLOG`, and pacman prints no progress bars when stdout isn't a TTY. A ~1 GB download is therefore several minutes of a mute spinner: no size, no clock, no bytes.

## Fix

`show_progress` takes a label and renders:

```
⠹ installing burpsuite [2m14s] -- burpsuite-1:2026.7.3-1-any downloading...
```

package name + elapsed clock + the last non-empty line of `$INSTLOG` (CRs collapsed, ANSI stripped, refreshed ~1/s, truncated to `tput cols`). The name is no longer printed-then-erased. The non-TTY branch keeps its existing `working...` output byte-for-byte.

Liveness is now `kill -0 "$pid"` instead of `ps | grep "$pid"`, which matched the pid's digits anywhere in `ps` output — another process's pid, or the TIME column.

## Testing

- `bash -n` on `packages.sh` and `install.sh`.
- `show_progress` driven against a stub background job under a pty (`script -qec`): spinner animates, clock advances, log tail tracks a synthetic pacman log with embedded CRs/ANSI, loop exits cleanly with no hang on the reaped child.
- Same run at `stty cols 40`: line truncates to 39 chars, no wrapping.
- Non-TTY invocation: unchanged `working...` path.

## Not changed

`install_software` still `exit 1`s on any package failure, so one interrupted optional security tool aborts the run before stage 6/7 (config deploy, shell activation). Re-running is safe and resumes. Making per-package failures non-fatal for optional layers is a separate behavior change, not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)