### PR TITLE
install: skip and report an optional package failure instead of aborting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -294,9 +294,15 @@ main() {
     layer_args=$(IFS=,; echo "${layer_paths[*]}")
   fi
 
-  local main_pkgs prep_pkgs
+  local main_pkgs prep_pkgs base_main_pkgs base_prep_pkgs
   main_pkgs=$("$PYTHON_BIN" "$ROOT_DIR/lib/toml/merge.py" --base "$ROOT_DIR/profiles/base/$PROFILE.toml" --layers "$layer_args" --custom-apps "$ROOT_DIR/profiles/custom_apps.lst" --field main) || { echo -e "$CER - Failed to resolve package list (check --profile/--with values)"; exit 1; }
   prep_pkgs=$("$PYTHON_BIN" "$ROOT_DIR/lib/toml/merge.py" --base "$ROOT_DIR/profiles/base/$PROFILE.toml" --layers "$layer_args" --field prep) || { echo -e "$CER - Failed to resolve package list (check --profile/--with values)"; exit 1; }
+  # The same two fields resolved from the base profile alone -- no layers,
+  # no custom_apps.lst. That set is the shell itself, and a failure in it
+  # still aborts; everything the merged lists add on top of it is an opt-in
+  # extra whose failure is reported and skipped (install_package_list).
+  base_main_pkgs=$("$PYTHON_BIN" "$ROOT_DIR/lib/toml/merge.py" --base "$ROOT_DIR/profiles/base/$PROFILE.toml" --field main) || { echo -e "$CER - Failed to resolve the base package list for $PROFILE"; exit 1; }
+  base_prep_pkgs=$("$PYTHON_BIN" "$ROOT_DIR/lib/toml/merge.py" --base "$ROOT_DIR/profiles/base/$PROFILE.toml" --field prep) || { echo -e "$CER - Failed to resolve the base package list for $PROFILE"; exit 1; }
 
   if [[ "$DRY_RUN" == "1" ]]; then
     echo -e "$CNT - [dry-run] plan:"
@@ -315,9 +321,9 @@ main() {
     fi
     echo "  would run: sudo pacman -Syu --noconfirm"
     echo "  prep packages:"
-    echo "$prep_pkgs" | sed 's/^/    - /'
+    print_package_plan "$prep_pkgs" "$base_prep_pkgs"
     echo "  main packages:"
-    echo "$main_pkgs" | sed 's/^/    - /'
+    print_package_plan "$main_pkgs" "$base_main_pkgs"
     if [[ "$ISNVIDIA" == "true" ]]; then
       echo "  would install Nvidia driver: matching kernel headers + nvidia-open-dkms"
       echo "  would regenerate initramfs/UKI (mkinitcpio -P)"
@@ -402,7 +408,7 @@ main() {
   echo -e "$CNT - Syncing package databases and upgrading the system..."
   sudo pacman -Syu --noconfirm &>> "$INSTLOG" || { echo -e "$CER - Failed to sync/upgrade the system package database. Re-run 'sudo pacman -Syu' by hand, resolve whatever it reports, then re-run install.sh."; exit 1; }
 
-  install_package_list "$prep_pkgs"
+  install_package_list "$prep_pkgs" "$base_prep_pkgs"
 
   setup_nvidia
   # Nvidia support has been built into the mainline "hyprland" package for a
@@ -410,7 +416,7 @@ main() {
   # patches is gone, so both paths install the same package.
   install_software hyprland
 
-  install_package_list "$main_pkgs"
+  install_package_list "$main_pkgs" "$base_main_pkgs"
 
   if [[ "$ASSISTANT" == "true" ]]; then
     setup_assistant || echo -e "$CWR - Aphotic Assistant setup did not finish; see $INSTLOG. The rest of the install continues."
@@ -457,10 +463,14 @@ main() {
   echo -e "  Assistant:     $ASSISTANT"
   echo -e "  Configs copied: $([[ "$CFG_COPIED" == "1" ]] && echo yes || echo no)"
   echo -e "  Config saved:  $APHOTIC_TOML"
+  if ((${#FAILED_OPTIONAL_PACKAGES[@]} > 0)); then
+    echo -e "  Failed (optional): ${#FAILED_OPTIONAL_PACKAGES[@]} -- listed below"
+  fi
   if [[ ",$LAYERS," == *",exploit-"* ]]; then
     echo -e "  Exploit disclaimer: $([[ -f "$EXPLOIT_ACK_FILE" ]] && echo "acknowledged, see $EXPLOIT_ACK_FILE" || echo "not recorded")"
   fi
   echo -e "$COK - Install complete."
+  report_failed_optional_packages
 
   "$HOME/.local/bin/aphotic" whatsnew &>> "$INSTLOG" || true
 
@@ -472,6 +482,10 @@ main() {
   offer_start_hyprland
 }
 
+# Without this, Ctrl+C mid-install lands on whichever package is running
+# and -- now that an optional failure is skipped rather than fatal -- the
+# run would just walk on to the next package.
+trap 'echo -e "\n$CWR - Interrupted -- stopping the install. Nothing further will be installed."; exit 130' INT
 trap 'exit_code=$?; notice_exploit_failure "$exit_code"; exit "$exit_code"' EXIT
 
 main "$@"

--- a/lib/install/exploit_disclaimer.sh
+++ b/lib/install/exploit_disclaimer.sh
@@ -22,7 +22,7 @@ layer_in_csv() {
   [[ ",$csv," == *",$name,"* ]]
 }
 
-EXPLOIT_ISSUES_URL="https://github.com/T-Crypt/Aphotic-Hypr/issues"
+EXPLOIT_ISSUES_URL="${APHOTIC_ISSUES_URL:-https://github.com/T-Crypt/Aphotic-Hypr/issues}"
 
 # Installed as an EXIT trap in install.sh, right before main() runs. BlackArch
 # (its repo strap.sh and the AUR builds behind exploit-* packages) is by far
@@ -38,6 +38,9 @@ EXPLOIT_ISSUES_URL="https://github.com/T-Crypt/Aphotic-Hypr/issues"
 notice_exploit_failure() {
   local exit_code="$1"
   [[ "$exit_code" -ne 0 ]] || return 0
+  # 130 is the user's own Ctrl+C (install.sh's INT trap), not BlackArch
+  # breaking -- pointing them at a BlackArch issue for it is just noise.
+  [[ "$exit_code" -ne 130 ]] || return 0
   if any_layer_is_exploit_family "${LAYERS:-}" || [[ "${BLACKARCH_CONSENT_GIVEN:-0}" == "1" ]]; then
     echo -e "\n${CER:-[ERROR]} - PLEASE RE-RUN WITH N SWITCH FOR EXPLOIT + SUBMIT ISSUE FOR BLACKARCH (COMMON)" >&2
     echo -e "  This install failed while the exploit-* layer (BlackArch repo / its AUR packages) was active --" >&2

--- a/lib/install/packages.sh
+++ b/lib/install/packages.sh
@@ -57,32 +57,115 @@ show_progress() {
   fi
 }
 
+# Layer/custom-apps packages that failed and were skipped. Reported once
+# at the end of the run so the list doesn't scroll away behind the rest of
+# the install.
+FAILED_OPTIONAL_PACKAGES=()
+
+_issue_url_for() {
+  local pkg="${1//+/%2B}"
+  printf '%s/new?title=Install%%20package%%20failed:%%20%s' "$APHOTIC_ISSUES_URL" "$pkg"
+}
+
+_package_in_list() {
+  [[ $'\n'"$2"$'\n' == *$'\n'"$1"$'\n'* ]]
+}
+
+# install_software <package> [required|optional]
+#
+# Defaults to "required" -- every direct caller (hyprland, the NVIDIA
+# driver) is something the desktop cannot come up without, and those still
+# abort the run. "optional" is for packages a layer or custom_apps.lst
+# added: those are reported with an issue link and skipped.
 install_software() {
-  if "$AUR_HELPER" -Q "$1" &>> /dev/null ; then
-    echo -e "$COK - $1 is already installed."
+  local pkg="$1" requirement="${2:-required}"
+  if "$AUR_HELPER" -Q "$pkg" &>> /dev/null ; then
+    echo -e "$COK - $pkg is already installed."
     return 0
   fi
   if [[ "$DRY_RUN" == "1" ]]; then
-    echo -e "$CNT - [dry-run] would install $1"
+    echo -e "$CNT - [dry-run] would install $pkg"
     return 0
   fi
   # On a terminal the spinner line carries the name itself; only the
   # non-TTY branch (no spinner) needs it printed up front.
-  [[ -t 1 ]] || echo -en "$CNT - Now installing $1 "
-  "$AUR_HELPER" -S --noconfirm "$1" &>> "$INSTLOG" &
-  show_progress $! "installing $1"
-  if "$AUR_HELPER" -Q "$1" &>> /dev/null ; then
-    echo -e "$COK - $1 was installed."
-  else
-    echo -e "$CER - $1 install had failed, please check the install.log"
-    exit 1
+  [[ -t 1 ]] || echo -en "$CNT - Now installing $pkg "
+  "$AUR_HELPER" -S --noconfirm "$pkg" &>> "$INSTLOG" &
+  local pkg_pid=$!
+  show_progress "$pkg_pid" "installing $pkg"
+  local rc=0
+  wait "$pkg_pid" 2>/dev/null || rc=$?
+
+  if "$AUR_HELPER" -Q "$pkg" &>> /dev/null ; then
+    echo -e "$COK - $pkg was installed."
+    return 0
   fi
+
+  # 130/143: the helper died from the user's Ctrl+C or a TERM, not from
+  # anything wrong with the package. Now that an optional failure no
+  # longer aborts, skipping on a signal would make an interrupt
+  # unstoppable -- it would just walk to the next package.
+  if ((rc == 130 || rc == 143)); then
+    echo -e "$CER - Interrupted while installing $pkg -- stopping here. Nothing further will be installed."
+    exit "$rc"
+  fi
+
+  if [[ "$requirement" == "optional" ]]; then
+    FAILED_OPTIONAL_PACKAGES+=("$pkg")
+    echo -e "$CER - Error installing -- $pkg -- Submit issue request for install package -- $pkg"
+    echo -e "$CWR   Skipped, the install continues. Output: $INSTLOG"
+    echo -e "$CWR   $(_issue_url_for "$pkg")"
+    return 0
+  fi
+
+  echo -e "$CER - $pkg install had failed, please check the install.log"
+  echo -e "$CER   $pkg is required, so the install can't continue without it."
+  echo -e "$CER   Submit issue request for install package -- $pkg"
+  echo -e "$CER   $(_issue_url_for "$pkg")"
+  exit 1
 }
 
-# Installs each newline-separated package name in $1, skipping blank lines.
+report_failed_optional_packages() {
+  ((${#FAILED_OPTIONAL_PACKAGES[@]} > 0)) || return 0
+  local pkg
+  echo -e "\n\e[1;31m── ${#FAILED_OPTIONAL_PACKAGES[@]} optional package(s) failed to install ──\e[0m"
+  echo -e "  None of these are part of the shell itself, so the install finished without them."
+  for pkg in "${FAILED_OPTIONAL_PACKAGES[@]}"; do
+    echo -e "  Error installing -- $pkg -- Submit issue request for install package -- $pkg"
+    echo -e "    $(_issue_url_for "$pkg")"
+  done
+  echo -e "  Full output for each failure: $INSTLOG"
+  echo -e "  To retry them after a fix: re-run ./install.sh with the same --with layers."
+}
+
+# install_package_list <newline-separated packages> [required-subset]
+#
+# Anything in <required-subset> is fatal on failure; everything else in
+# the list came from a layer or custom_apps.lst and is reported-and-
+# skipped. Omitting the subset makes every package required, which is
+# what the pre-existing single-argument behavior was.
 install_package_list() {
-  local pkgs="$1"
+  local pkgs="$1" required="${2-}" pkg requirement
   while IFS= read -r pkg; do
-    [[ -n "$pkg" ]] && install_software "$pkg"
+    [[ -n "$pkg" ]] || continue
+    if [[ -z "$required" ]] || _package_in_list "$pkg" "$required"; then
+      requirement="required"
+    else
+      requirement="optional"
+    fi
+    install_software "$pkg" "$requirement"
+  done <<< "$pkgs"
+}
+
+# Dry-run plan rendering, so the plan says which failures would be fatal.
+print_package_plan() {
+  local pkgs="$1" required="${2-}" pkg
+  while IFS= read -r pkg; do
+    [[ -n "$pkg" ]] || continue
+    if [[ -z "$required" ]] || _package_in_list "$pkg" "$required"; then
+      echo "    - $pkg"
+    else
+      echo "    - $pkg (optional: a failure is reported, not fatal)"
+    fi
   done <<< "$pkgs"
 }

--- a/lib/install/ui.sh
+++ b/lib/install/ui.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 # argument -- unlike `echo -e` -- never interprets `\e` itself.
 _ui_action_tag() { printf '%b' "${CAC:-[ACTION]}"; }
 
+# Where every "please report this" path in the installer points.
+APHOTIC_ISSUES_URL="${APHOTIC_ISSUES_URL:-https://github.com/T-Crypt/Aphotic-Hypr/issues}"
+
 # Keep every <prompt> here to one short line and echo any explanation
 # above the call instead: `read -e` hands the prompt to readline, which
 # redraws a prompt longer than the terminal width as a truncated "<...end


### PR DESCRIPTION
> Stacked on #98 — base is `fix/install-progress-feedback`, and GitHub will retarget this to `main` when #98 merges. Review only the second commit.

Follows directly from #98's closing note: one failing package aborted the whole run at stage 5, **before** configs were ever deployed. An interrupted 1 GB optional security tool cost the entire install, and a typo'd name in someone's own `custom_apps.lst` could do the same.

## What counts as required

`install_software` takes a second argument, `required` (default) or `optional`. `install_package_list` takes the required subset and classifies each package against it. `install.sh` resolves that subset by running `merge.py` a second time against the base profile **alone** — no `--layers`, no `--custom-apps`.

| | Fatal? | What's in it |
|---|---|---|
| **required** | yes | `profiles/base/<profile>.toml`, plus the direct `install_software` callers — `hyprland`, `nvidia.sh`'s driver + kernel headers. Those pass no second argument, so they keep the pre-existing behavior byte-for-byte. |
| **optional** | no | every package a layer added, **and** everything in `profiles/custom_apps.lst` |

Custom apps land in the optional bucket deliberately: they're the user's own extras, frequently AUR, and never something the shell needs to come up.

## The message

Uses the requested phrasing, so it reads as a call to action rather than a silent skip:

```
[ERROR] - Error installing -- burpsuite -- Submit issue request for install package -- burpsuite
[WARNING]   Skipped, the install continues. Output: install.log
[WARNING]   https://github.com/T-Crypt/Aphotic-Hypr/issues/new?title=Install%20package%20failed:%20burpsuite
```

Repeated in a block after `Install complete.` (plus a count in the summary fields) so a failure 40 packages back hasn't scrolled off. The issues URL moved to `APHOTIC_ISSUES_URL` in `ui.sh` (sourced first) instead of being hardcoded a second time; `EXPLOIT_ISSUES_URL` now reads from it.

## Interrupt handling — not optional

Non-fatal failures make Ctrl+C **unstoppable** on their own: the interrupt kills the current AUR helper, that reads as a package failure, and the loop walks to the next package. Two guards:

- `install_software` captures the helper's real exit status (`wait` on the pid, which #98 already had in hand) and treats **130/143 as a signal, not a package fault** — it exits.
- `install.sh` gained an `INT` trap that ends the run outright, and `notice_exploit_failure` now skips exit code 130, so a deliberate Ctrl+C is no longer blamed on BlackArch.

## Testing

Driven through a stub AUR helper, all five cases:

| Case | Result |
|---|---|
| Two optional packages fail | Both reported + collected, later packages still installed, run exits 0 |
| A base-profile package fails | Exits 1, as before |
| Interrupt (rc 130) mid-package | Exits 130, nothing further installed |
| `install_package_list` with no subset | Everything required — back-compat holds |
| Dry-run plan annotation | Optional packages marked |

Plus the real `./install.sh --dry-run --profile full --with dev`: 9 packages marked optional — dev's 7 plus `spotify`/`youtube-app-bin` from `custom_apps.lst` — and no base package misclassified.

The `INT` trap needed a foreground self-signal to test: a backgrounded non-interactive job inherits SIGINT ignored and bash cannot trap a signal ignored on entry, which made the first attempt a false negative.

## Not changed

A run that finished with skipped packages still exits **0** — the desktop is installed and working. If CI wants to distinguish "installed, with N optional packages skipped", that's a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)