### PR TITLE
dashboard: stop clicks inside the border from dismissing it

### DIFF
--- a/Configs/quickshell/aphotic/modules/dashboard/DashboardWindow.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/DashboardWindow.qml
@@ -36,7 +36,22 @@ PanelWindow {
         Keys.onEscapePressed: root.screenState.dashboard = false
     }
 
+    // Declared before the content so it sits under it: children of
+    // DashboardContent still take their own clicks, and this only catches
+    // what falls through the gaps between them. Without it any click that
+    // misses an interactive control -- card padding, the run strip's
+    // overflow indicator -- reaches the dismiss handler above and closes
+    // the dashboard from inside its own border.
+    MouseArea {
+        anchors.centerIn: parent
+        width: content.width
+        height: content.height
+        acceptedButtons: Qt.AllButtons
+    }
+
     DashboardContent {
+        id: content
+
         anchors.centerIn: parent
         screenState: root.screenState
     }


### PR DESCRIPTION
Clicking inside the dashboard's own rendered border could close it. The dismiss handler is a full-screen `MouseArea` in `DashboardWindow.qml` sitting *under* `DashboardContent`, so it caught every click that missed an interactive control — card padding, the gap around the agent-graph run strip, the overflow indicator. Only the widgets themselves ever absorbed a press; the frame around them did not, so a click a few pixels off a control read as "clicked the scrim" and dismissed.

Adds a click-absorbing `MouseArea` covering the content bounds, declared **before** `DashboardContent` so it sits under it: the real controls still take their own clicks and this only catches what falls through the gaps. `acceptedButtons: Qt.AllButtons` so a stray right/middle click inside the panel is inert too.

- Clicking anywhere within the dashboard is now inert.
- Clicking the surrounding scrim still dismisses.
- Escape is untouched.
- `MouseArea` does not handle wheel events, so this does not interfere with scrolling inside the panel.

The absorber covers the whole `DashboardContent` bounds, which is slightly more than the drawn border — it also spans the tab-bar row above the frame. That is deliberate: a click on the tab bar's background dismissing the panel was the same bug in a less obvious place.

## Testing

Shell reloaded via `aphotic reload`; it restarts clean with no QML errors from `DashboardWindow.qml` in the journal. Visual behavior left for @T-Crypt to confirm on the live desktop.

Note for anyone reproducing locally: `~/.config/quickshell/aphotic` is a one-shot copy, not a symlink to the repo, so the file has to be copied in before reloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)