### PR TITLE
notch: base-shell dynamic island with per-layer opt-in tabs

### DIFF
--- a/Configs/quickshell/aphotic/components/ProcessUsageWatch.qml
+++ b/Configs/quickshell/aphotic/components/ProcessUsageWatch.qml
@@ -1,0 +1,10 @@
+import QtQuick
+import qs.services
+
+// Mount this for as long as a surface showing per-process usage is on
+// screen. Object lifetime is the registration, so a surface behind a
+// Loader cannot leak a watch by missing an unpaired call.
+QtObject {
+    Component.onCompleted: ProcessUsage.beginSampling()
+    Component.onDestruction: ProcessUsage.endSampling()
+}

--- a/Configs/quickshell/aphotic/components/SystemUsageWatch.qml
+++ b/Configs/quickshell/aphotic/components/SystemUsageWatch.qml
@@ -6,6 +6,26 @@ import qs.services
 // Object lifetime is the registration, so a surface behind a Loader
 // cannot leak a watch by missing an unpaired call.
 QtObject {
-    Component.onCompleted: SystemUsage.beginDetailedMonitoring()
-    Component.onDestruction: SystemUsage.endDetailedMonitoring()
+    id: root
+
+    // Set at construction and never read live again: the registration is
+    // latched at completion so a later write cannot leave an unpaired
+    // end call behind, which is the whole reason this is an object
+    // lifetime rather than a pair of calls in the first place.
+    property bool fast: false
+
+    property bool _fastLatched: false
+
+    Component.onCompleted: {
+        SystemUsage.beginDetailedMonitoring();
+        root._fastLatched = root.fast;
+        if (root._fastLatched)
+            SystemUsage.beginFastMonitoring();
+    }
+
+    Component.onDestruction: {
+        SystemUsage.endDetailedMonitoring();
+        if (root._fastLatched)
+            SystemUsage.endFastMonitoring();
+    }
 }

--- a/Configs/quickshell/aphotic/components/qmldir
+++ b/Configs/quickshell/aphotic/components/qmldir
@@ -9,6 +9,7 @@ DepthLayer 1.0 DepthLayer.qml
 KbCodeField 1.0 KbCodeField.qml
 Logo 1.0 Logo.qml
 MaterialIcon 1.0 MaterialIcon.qml
+ProcessUsageWatch 1.0 ProcessUsageWatch.qml
 ScreenState 1.0 ScreenState.qml
 SettingsGroup 1.0 SettingsGroup.qml
 SettingsPresetRow 1.0 SettingsPresetRow.qml

--- a/Configs/quickshell/aphotic/config/Config.qml
+++ b/Configs/quickshell/aphotic/config/Config.qml
@@ -175,6 +175,24 @@ QtObject {
         }
     }
 
+    readonly property QtObject notch: QtObject {
+        readonly property bool enabled: true
+
+        // Collapsed/expanded are the notch's own inner sizes;
+        // expandedWidth and maxHeight also bound the STATIC layer-shell
+        // surface it draws into (see modules/notch/NotchWindow.qml).
+        // Content wanting more than that is clipped by the compositor
+        // rather than growing the window, so a new tile needing room
+        // raises these, not just its own size.
+        readonly property int collapsedWidth: 132
+        readonly property int collapsedHeight: 26
+        readonly property int expandedWidth: 420
+        readonly property int maxHeight: 340
+
+        readonly property int processUpdateInterval: 1500
+        readonly property int processCount: 6
+    }
+
     readonly property QtObject launcher: QtObject {
         readonly property string emojiListPath: `${Quickshell.env("HOME")}/.config/quickshell/aphotic/data/emoji.txt`
         readonly property string wallpaperDir: `${Quickshell.env("HOME")}/.config/awww`

--- a/Configs/quickshell/aphotic/config/Config.qml
+++ b/Configs/quickshell/aphotic/config/Config.qml
@@ -164,6 +164,12 @@ QtObject {
     readonly property QtObject dashboard: QtObject {
         readonly property bool enabled: true
         readonly property int resourceUpdateInterval: 2000
+        readonly property int detailUpdateInterval: 30000
+        // What a surface asking for fast GPU sampling gets instead. Only
+        // the GPU poll moves -- CPU temperature genuinely does not need
+        // this, and `sensors -j` costs more per call than nvidia-smi's
+        // utilisation query does (42ms vs 26ms, measured).
+        readonly property int detailFastUpdateInterval: 2000
 
         readonly property QtObject performance: QtObject {
             readonly property bool showBattery: true

--- a/Configs/quickshell/aphotic/config/Config.qml
+++ b/Configs/quickshell/aphotic/config/Config.qml
@@ -190,6 +190,7 @@ QtObject {
         readonly property int maxHeight: 340
 
         readonly property int processUpdateInterval: 1500
+        readonly property int gpuUpdateInterval: 3000
         readonly property int processCount: 6
     }
 

--- a/Configs/quickshell/aphotic/modules/notch/Notch.qml
+++ b/Configs/quickshell/aphotic/modules/notch/Notch.qml
@@ -14,9 +14,15 @@ StyledRect {
     enum Tile {
         Idle = 0,
         Processes,
-        Placeholder
+        Slot2,
+        Slot3,
+        Slot4
     }
 
+    // Three reserved slots, named for what they are rather than for
+    // content nobody has written: identical "Reserved" labels would make
+    // the one thing this strip exists to demonstrate -- that you can tell
+    // where you are and move between four of them -- impossible to see.
     readonly property var tiles: [
         {
             tile: Notch.Processes,
@@ -24,11 +30,24 @@ StyledRect {
             label: qsTr("Processes")
         },
         {
-            tile: Notch.Placeholder,
+            tile: Notch.Slot2,
+            icon: "terminal",
+            label: qsTr("Slot 2")
+        },
+        {
+            tile: Notch.Slot3,
+            icon: "hub",
+            label: qsTr("Slot 3")
+        },
+        {
+            tile: Notch.Slot4,
             icon: "extension",
-            label: qsTr("Reserved")
+            label: qsTr("Slot 4")
         }
     ]
+
+    readonly property var activeTile: root.tiles.find(t => t.tile === root.shownTile) ?? null
+    readonly property bool processesLive: root.expanded && root.shownTile === Notch.Processes
 
     property int tile: Notch.Idle
     readonly property bool expanded: root.tile !== Notch.Idle
@@ -92,9 +111,22 @@ StyledRect {
     }
 
     LazyLoader {
-        active: root.expanded && root.shownTile === Notch.Processes
+        active: root.processesLive
 
         ProcessUsageWatch {}
+    }
+
+    // Gated here rather than mounted inside NotchProcessTile: the tile
+    // outlives a collapse (shownTile latches so the body still reports a
+    // height through the shrink), so a watch owned by the tile would keep
+    // polling for as long as Processes was the last tile visited. Both
+    // watches hang off the same gate for that reason.
+    LazyLoader {
+        active: root.processesLive
+
+        SystemUsageWatch {
+            fast: true
+        }
     }
 
     // The body is laid out at a constant contentWidth (see above) while the
@@ -243,7 +275,7 @@ StyledRect {
                         spacing: Tokens.spacing.small
 
                         MaterialIcon {
-                            text: root.tiles.find(t => t.tile === root.shownTile)?.icon ?? "monitoring"
+                            text: root.activeTile?.icon ?? "monitoring"
                             color: Colours.palette.m3primaryOnSurface
                             fontStyle: Tokens.font.icon.small
                             fill: 1
@@ -252,7 +284,7 @@ StyledRect {
                         StyledText {
                             id: title
 
-                            text: root.tiles.find(t => t.tile === root.shownTile)?.label ?? ""
+                            text: root.activeTile?.label ?? ""
                             font: Tokens.font.title.builders.medium.weight(Font.Medium).build()
                         }
                     }
@@ -285,7 +317,7 @@ StyledRect {
                 Layout.fillWidth: true
                 Layout.preferredHeight: tileLoader.item?.implicitHeight ?? 0
 
-                sourceComponent: root.shownTile === Notch.Placeholder ? placeholderComp : processComp
+                sourceComponent: root.shownTile === Notch.Processes ? processComp : placeholderComp
             }
 
             RowLayout {
@@ -302,7 +334,7 @@ StyledRect {
                         required property var modelData
                         readonly property bool active: chip.modelData.tile === root.shownTile
 
-                        implicitWidth: chipLabel.implicitWidth + chipIcon.implicitWidth + Tokens.padding.medium * 2 + Tokens.spacing.extraSmall
+                        implicitWidth: chipLabel.implicitWidth + chipIcon.implicitWidth + Tokens.padding.small * 2 + Tokens.spacing.extraSmall
                         implicitHeight: 26
                         radius: Tokens.rounding.full
                         color: chip.active ? Colours.palette.m3primary : Colours.layer(Colours.palette.m3surfaceContainerHigh, 2)
@@ -354,6 +386,9 @@ StyledRect {
     }
     Component {
         id: placeholderComp
-        NotchPlaceholderTile {}
+        NotchPlaceholderTile {
+            slotLabel: root.activeTile?.label ?? ""
+            slotIcon: root.activeTile?.icon ?? "extension"
+        }
     }
 }

--- a/Configs/quickshell/aphotic/modules/notch/Notch.qml
+++ b/Configs/quickshell/aphotic/modules/notch/Notch.qml
@@ -63,7 +63,13 @@ StyledRect {
     // PanelWindow's geometry.
     width: root.expanded ? Config.notch.expandedWidth : Config.notch.collapsedWidth
     height: root.expanded ? Math.min(body.implicitHeight + Tokens.padding.medium * 2, Config.notch.maxHeight) : Config.notch.collapsedHeight
-    radius: root.expanded ? Tokens.rounding.large : Tokens.rounding.full
+    // NOT Tokens.rounding.full for the collapsed pill: that is 999999, and
+    // animating it down to a real radius keeps the value above width/2
+    // (where every value renders identically) until the last few frames,
+    // then drops through the whole visible range at once -- a snap at the
+    // end of an otherwise smooth grow. Half the collapsed height is the
+    // same pill, expressed as a number the Behavior can actually traverse.
+    radius: root.expanded ? Tokens.rounding.large : Config.notch.collapsedHeight / 2
     color: Colours.palette.m3surfaceContainerHigh
 
     Behavior on width {
@@ -91,11 +97,49 @@ StyledRect {
         ProcessUsageWatch {}
     }
 
+    // The body is laid out at a constant contentWidth (see above) while the
+    // surface around it animates from the collapsed pill's 132px -- so for
+    // the first part of every open it is a 388px-wide layout being drawn
+    // into a box a third that size. Fading it in on its own short curve
+    // meant it arrived at full opacity while still mostly clipped, which
+    // is the "glitchy on the open" it read as. Holding the reveal until
+    // the geometry has covered most of the distance means content only
+    // appears once there is room for it. 150ms is measured, not guessed:
+    // Anim.Emphasized front-loads hard enough that a nominally 500ms run
+    // is already at ~400 of its 420px by then. Collapse takes
+    // the other path: revealed goes false immediately, so the body is gone
+    // before the box starts shrinking under it.
+    property bool revealed: false
+
+    Timer {
+        id: revealTimer
+        interval: 150
+        onTriggered: root.revealed = true
+    }
+
+    onExpandedChanged: {
+        if (root.expanded) {
+            revealTimer.restart();
+        } else {
+            revealTimer.stop();
+            root.revealed = false;
+        }
+    }
+
+    // Faded rather than flipped straight to invisible: the click that
+    // opens the notch starts a ripple that runs 600ms, longer than the
+    // 500ms expand, so hiding this the instant `expanded` flips cut the
+    // ripple off mid-sweep and read as a flash under the growing box.
     StateLayer {
         radius: root.radius
         disabled: root.expanded
-        visible: !root.expanded
+        visible: opacity > 0
+        opacity: root.expanded ? 0 : 1
         onClicked: root.cycle()
+
+        Behavior on opacity {
+            Anim { type: Anim.FastEffects }
+        }
     }
 
     component MicroBar: StyledRect {
@@ -162,12 +206,16 @@ StyledRect {
         ColumnLayout {
             id: body
 
-            x: Tokens.padding.large
-            y: Tokens.padding.medium
+            // Centred, not pinned at the padding origin: while the surface
+            // is still growing the clip has to cut something off, and
+            // taking it evenly off both edges reads as the box opening
+            // around the content rather than the content sliding in from
+            // one side.
+            anchors.centerIn: parent
             width: root.contentWidth
             spacing: Tokens.spacing.small
             visible: opacity > 0
-            opacity: root.expanded ? 1 : 0
+            opacity: root.revealed ? 1 : 0
 
             Behavior on opacity {
                 Anim { type: Anim.DefaultEffects }

--- a/Configs/quickshell/aphotic/modules/notch/Notch.qml
+++ b/Configs/quickshell/aphotic/modules/notch/Notch.qml
@@ -14,39 +14,60 @@ StyledRect {
     enum Tile {
         Idle = 0,
         Processes,
-        Slot2,
-        Slot3,
-        Slot4
+        Dev,
+        Security,
+        Agents
     }
 
-    // Three reserved slots, named for what they are rather than for
-    // content nobody has written: identical "Reserved" labels would make
-    // the one thing this strip exists to demonstrate -- that you can tell
-    // where you are and move between four of them -- impossible to see.
-    readonly property var tiles: [
-        {
-            tile: Notch.Processes,
-            icon: "monitoring",
-            label: qsTr("Processes")
-        },
-        {
-            tile: Notch.Slot2,
-            icon: "terminal",
-            label: qsTr("Slot 2")
-        },
-        {
-            tile: Notch.Slot3,
-            icon: "hub",
-            label: qsTr("Slot 3")
-        },
-        {
-            tile: Notch.Slot4,
-            icon: "extension",
-            label: qsTr("Slot 4")
-        }
-    ]
+    // Processes is the base shell's tile and is never gated -- the notch
+    // itself ships with the base layer, so a plain install has exactly one
+    // tile and no switcher at all (see `switchable`). Every other tile is
+    // an opt-in that docks itself here when its own layer is installed,
+    // and is absent -- not present-and-empty -- when it is not. Gaming is
+    // deliberately not among them: it is a transient state around a
+    // running game, not a surface to sit and read.
+    readonly property var tiles: {
+        const list = [
+            {
+                tile: Notch.Processes,
+                icon: "monitoring",
+                label: qsTr("Processes")
+            }
+        ];
+        if (InstallProfile.devEnabled)
+            list.push({
+                tile: Notch.Dev,
+                icon: "code",
+                label: qsTr("Dev")
+            });
+        if (InstallProfile.securityEnabled)
+            list.push({
+                tile: Notch.Security,
+                icon: "shield",
+                label: qsTr("Security")
+            });
+        if (InstallProfile.aiEnabled)
+            list.push({
+                tile: Notch.Agents,
+                icon: "smart_toy",
+                label: qsTr("Agents")
+            });
+        return list;
+    }
+
+    // A base install has one tile, so there is nothing to switch between:
+    // the name stops being a button and the chip strip is gone entirely
+    // rather than sitting there as a single dead chip.
+    readonly property bool switchable: root.tiles.length > 1
 
     readonly property var activeTile: root.tiles.find(t => t.tile === root.shownTile) ?? null
+
+    onTilesChanged: {
+        if (!root.tiles.some(t => t.tile === root.shownTile))
+            root.shownTile = Notch.Processes;
+        if (root.tile !== Notch.Idle && !root.tiles.some(t => t.tile === root.tile))
+            root.tile = Notch.Processes;
+    }
     readonly property bool processesLive: root.expanded && root.shownTile === Notch.Processes
 
     property int tile: Notch.Idle
@@ -63,6 +84,8 @@ StyledRect {
     readonly property real contentWidth: Config.notch.expandedWidth - Tokens.padding.large * 2
 
     function cycle(): void {
+        if (root.expanded && !root.switchable)
+            return;
         const i = root.tiles.findIndex(t => t.tile === root.tile);
         root.tile = root.tiles[(i + 1) % root.tiles.length].tile;
     }
@@ -265,7 +288,7 @@ StyledRect {
 
                     StateLayer {
                         radius: parent.radius
-                        disabled: !root.expanded
+                        disabled: !root.expanded || !root.switchable
                         onClicked: root.cycle()
                     }
 
@@ -317,16 +340,17 @@ StyledRect {
                 Layout.fillWidth: true
                 Layout.preferredHeight: tileLoader.item?.implicitHeight ?? 0
 
-                sourceComponent: root.shownTile === Notch.Processes ? processComp : placeholderComp
+                sourceComponent: root.shownTile === Notch.Processes ? processComp : stubComp
             }
 
             RowLayout {
                 Layout.fillWidth: true
                 Layout.topMargin: Tokens.spacing.extraSmall
                 spacing: Tokens.spacing.extraSmall
+                visible: root.switchable
 
                 Repeater {
-                    model: root.tiles
+                    model: root.switchable ? root.tiles : []
 
                     StyledRect {
                         id: chip
@@ -385,8 +409,8 @@ StyledRect {
         NotchProcessTile {}
     }
     Component {
-        id: placeholderComp
-        NotchPlaceholderTile {
+        id: stubComp
+        NotchProfileStub {
             slotLabel: root.activeTile?.label ?? ""
             slotIcon: root.activeTile?.icon ?? "extension"
         }

--- a/Configs/quickshell/aphotic/modules/notch/Notch.qml
+++ b/Configs/quickshell/aphotic/modules/notch/Notch.qml
@@ -1,0 +1,311 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Effects
+import Quickshell
+import qs.config
+import qs.components
+import qs.services
+
+StyledRect {
+    id: root
+
+    enum Tile {
+        Idle = 0,
+        Processes,
+        Placeholder
+    }
+
+    readonly property var tiles: [
+        {
+            tile: Notch.Processes,
+            icon: "monitoring",
+            label: qsTr("Processes")
+        },
+        {
+            tile: Notch.Placeholder,
+            icon: "extension",
+            label: qsTr("Reserved")
+        }
+    ]
+
+    property int tile: Notch.Idle
+    readonly property bool expanded: root.tile !== Notch.Idle
+
+    // Which tile the expanded body is BUILT for, kept latched past a
+    // collapse so the body still reports a real implicitHeight while the
+    // height animation plays -- reading it off `tile` instead would
+    // collapse the target to zero on the first frame and cut the
+    // animation short. Same reasoning as popouts/Wrapper.qml's
+    // showContent.
+    property int shownTile: Notch.Processes
+
+    readonly property real contentWidth: Config.notch.expandedWidth - Tokens.padding.large * 2
+
+    function cycle(): void {
+        const i = root.tiles.findIndex(t => t.tile === root.tile);
+        root.tile = root.tiles[(i + 1) % root.tiles.length].tile;
+    }
+
+    function collapse(): void {
+        root.tile = Notch.Idle;
+    }
+
+    onTileChanged: {
+        if (root.tile !== Notch.Idle)
+            root.shownTile = root.tile;
+    }
+
+    // Only the inner surface moves. Every dimension here is either a
+    // constant or driven by content that is itself laid out at a constant
+    // width (see contentWidth), so nothing feeds back into the enclosing
+    // PanelWindow's geometry.
+    width: root.expanded ? Config.notch.expandedWidth : Config.notch.collapsedWidth
+    height: root.expanded ? Math.min(body.implicitHeight + Tokens.padding.medium * 2, Config.notch.maxHeight) : Config.notch.collapsedHeight
+    radius: root.expanded ? Tokens.rounding.large : Tokens.rounding.full
+    color: Colours.palette.m3surfaceContainerHigh
+
+    Behavior on width {
+        Anim { type: Anim.Emphasized }
+    }
+    Behavior on height {
+        Anim { type: Anim.Emphasized }
+    }
+    Behavior on radius {
+        Anim { type: Anim.Emphasized }
+    }
+
+    layer.enabled: true
+    layer.effect: MultiEffect {
+        shadowEnabled: true
+        shadowColor: Colours.palette.m3shadow
+        shadowOpacity: 0.5
+        shadowBlur: 0.5
+        shadowVerticalOffset: 2
+    }
+
+    LazyLoader {
+        active: root.expanded && root.shownTile === Notch.Processes
+
+        ProcessUsageWatch {}
+    }
+
+    StateLayer {
+        radius: root.radius
+        disabled: root.expanded
+        visible: !root.expanded
+        onClicked: root.cycle()
+    }
+
+    component MicroBar: StyledRect {
+        id: microBar
+
+        property real perc: 0
+        property color barColour: Colours.palette.m3primary
+
+        implicitWidth: 34
+        implicitHeight: 4
+        radius: Tokens.rounding.full
+        color: Colours.layer(Colours.palette.m3surfaceContainerHigh, 2)
+
+        StyledRect {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: parent.width * Math.max(0, Math.min(1, microBar.perc))
+            radius: Tokens.rounding.full
+            color: microBar.barColour
+        }
+    }
+
+    Item {
+        anchors.fill: parent
+        clip: true
+
+        // Idle deliberately carries no clock: the bar already owns one in
+        // every style that shows the time (Bar/TaskbarBar/DockBar's Clock,
+        // MinimalBar's inline string), and a second one two centimetres
+        // away is just a duplicate. What is left is the smallest useful
+        // affordance -- live CPU and memory, off SystemUsage's
+        // always-running base poll, so idle costs nothing extra.
+        RowLayout {
+            id: idle
+
+            anchors.centerIn: parent
+            spacing: Tokens.spacing.small
+            visible: opacity > 0
+            opacity: root.expanded ? 0 : 1
+
+            Behavior on opacity {
+                Anim { type: Anim.FastEffects }
+            }
+
+            MaterialIcon {
+                text: "monitoring"
+                color: Colours.palette.m3primaryOnSurface
+                fontStyle: Tokens.font.icon.small
+                fill: 1
+            }
+
+            MicroBar {
+                perc: SystemUsage.cpuPerc
+                barColour: Colours.palette.m3primary
+            }
+
+            MicroBar {
+                perc: SystemUsage.memPerc
+                barColour: Colours.palette.m3tertiary
+            }
+        }
+
+        ColumnLayout {
+            id: body
+
+            x: Tokens.padding.large
+            y: Tokens.padding.medium
+            width: root.contentWidth
+            spacing: Tokens.spacing.small
+            visible: opacity > 0
+            opacity: root.expanded ? 1 : 0
+
+            Behavior on opacity {
+                Anim { type: Anim.DefaultEffects }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                StyledRect {
+                    Layout.fillWidth: true
+                    implicitHeight: title.implicitHeight + Tokens.padding.extraSmall * 2
+                    radius: Tokens.rounding.small
+                    color: "transparent"
+
+                    StateLayer {
+                        radius: parent.radius
+                        disabled: !root.expanded
+                        onClicked: root.cycle()
+                    }
+
+                    RowLayout {
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Tokens.spacing.small
+
+                        MaterialIcon {
+                            text: root.tiles.find(t => t.tile === root.shownTile)?.icon ?? "monitoring"
+                            color: Colours.palette.m3primaryOnSurface
+                            fontStyle: Tokens.font.icon.small
+                            fill: 1
+                        }
+
+                        StyledText {
+                            id: title
+
+                            text: root.tiles.find(t => t.tile === root.shownTile)?.label ?? ""
+                            font: Tokens.font.title.builders.medium.weight(Font.Medium).build()
+                        }
+                    }
+                }
+
+                StyledRect {
+                    implicitWidth: 24
+                    implicitHeight: 24
+                    radius: Tokens.rounding.full
+                    color: "transparent"
+
+                    StateLayer {
+                        radius: parent.radius
+                        disabled: !root.expanded
+                        onClicked: root.collapse()
+                    }
+
+                    MaterialIcon {
+                        anchors.centerIn: parent
+                        text: "keyboard_arrow_up"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.small
+                    }
+                }
+            }
+
+            Loader {
+                id: tileLoader
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: tileLoader.item?.implicitHeight ?? 0
+
+                sourceComponent: root.shownTile === Notch.Placeholder ? placeholderComp : processComp
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: Tokens.spacing.extraSmall
+                spacing: Tokens.spacing.extraSmall
+
+                Repeater {
+                    model: root.tiles
+
+                    StyledRect {
+                        id: chip
+
+                        required property var modelData
+                        readonly property bool active: chip.modelData.tile === root.shownTile
+
+                        implicitWidth: chipLabel.implicitWidth + chipIcon.implicitWidth + Tokens.padding.medium * 2 + Tokens.spacing.extraSmall
+                        implicitHeight: 26
+                        radius: Tokens.rounding.full
+                        color: chip.active ? Colours.palette.m3primary : Colours.layer(Colours.palette.m3surfaceContainerHigh, 2)
+
+                        Behavior on color {
+                            CAnim {}
+                        }
+
+                        StateLayer {
+                            radius: parent.radius
+                            disabled: !root.expanded
+                            onClicked: root.tile = chip.modelData.tile
+                        }
+
+                        RowLayout {
+                            anchors.centerIn: parent
+                            spacing: Tokens.spacing.extraSmall
+
+                            MaterialIcon {
+                                id: chipIcon
+
+                                text: chip.modelData.icon
+                                color: chip.active ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurfaceVariant
+                                fontStyle: Tokens.font.icon.small
+                                fill: chip.active ? 1 : 0
+                            }
+
+                            StyledText {
+                                id: chipLabel
+
+                                text: chip.modelData.label
+                                color: chip.active ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurfaceVariant
+                                font: Tokens.font.label.builders.small.weight(Font.Medium).build()
+                            }
+                        }
+                    }
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+            }
+        }
+    }
+
+    Component {
+        id: processComp
+        NotchProcessTile {}
+    }
+    Component {
+        id: placeholderComp
+        NotchPlaceholderTile {}
+    }
+}

--- a/Configs/quickshell/aphotic/modules/notch/NotchPlaceholderTile.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchPlaceholderTile.qml
@@ -1,0 +1,47 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.components
+import qs.services
+
+// Deliberately empty second tile. It exists to prove the tile switcher in
+// Notch.qml carries more than one tile (state, header, chip strip and the
+// height animation between differently-sized bodies) -- Dev Status and
+// Claude Status content are explicitly out of scope for this pass.
+ColumnLayout {
+    id: root
+
+    spacing: Tokens.spacing.small
+
+    Item {
+        Layout.fillWidth: true
+        Layout.preferredHeight: Tokens.spacing.medium
+    }
+
+    MaterialIcon {
+        Layout.alignment: Qt.AlignHCenter
+        text: "extension"
+        color: Colours.palette.m3onSurfaceVariant
+        fontStyle: Tokens.font.icon.extraLarge
+    }
+
+    StyledText {
+        Layout.alignment: Qt.AlignHCenter
+        text: qsTr("Tile slot reserved")
+        font: Tokens.font.title.medium
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        text: qsTr("Nothing is wired here yet — this slot only exists to prove the switcher holds more than one tile.")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.medium
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+    }
+
+    Item {
+        Layout.fillWidth: true
+        Layout.preferredHeight: Tokens.spacing.medium
+    }
+}

--- a/Configs/quickshell/aphotic/modules/notch/NotchPlaceholderTile.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchPlaceholderTile.qml
@@ -11,6 +11,9 @@ import qs.services
 ColumnLayout {
     id: root
 
+    required property string slotLabel
+    required property string slotIcon
+
     spacing: Tokens.spacing.small
 
     Item {
@@ -20,14 +23,14 @@ ColumnLayout {
 
     MaterialIcon {
         Layout.alignment: Qt.AlignHCenter
-        text: "extension"
+        text: root.slotIcon
         color: Colours.palette.m3onSurfaceVariant
         fontStyle: Tokens.font.icon.extraLarge
     }
 
     StyledText {
         Layout.alignment: Qt.AlignHCenter
-        text: qsTr("Tile slot reserved")
+        text: qsTr("%1 reserved").arg(root.slotLabel)
         font: Tokens.font.title.medium
     }
 

--- a/Configs/quickshell/aphotic/modules/notch/NotchProcessTile.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchProcessTile.qml
@@ -1,0 +1,171 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.components
+import qs.services
+
+ColumnLayout {
+    id: root
+
+    readonly property bool byMem: ProcessUsage.sortBy === "mem"
+
+    // Padded to a constant length so the tile's implicitHeight -- and
+    // therefore the notch's animated height -- does not twitch as
+    // processes come and go, or jump once the first real sample lands.
+    readonly property var rows: {
+        const list = ProcessUsage.processes.slice();
+        while (list.length < Config.notch.processCount)
+            list.push(null);
+        return list;
+    }
+
+    readonly property real peak: {
+        const first = ProcessUsage.processes[0];
+        if (!first)
+            return 0;
+        return root.byMem ? first.rssKib : first.cpu;
+    }
+
+    function metricOf(entry: var): real {
+        return root.byMem ? entry.rssKib : entry.cpu;
+    }
+
+    function labelFor(entry: var): string {
+        if (root.byMem) {
+            const fmt = SystemUsage.formatKib(entry.rssKib);
+            return `${fmt.value.toFixed(fmt.unit === "GiB" ? 1 : 0)} ${fmt.unit}`;
+        }
+        return `${entry.cpu.toFixed(entry.cpu >= 10 ? 0 : 1)}%`;
+    }
+
+    spacing: Tokens.spacing.extraSmall
+
+    component SortChip: StyledRect {
+        id: sortChip
+
+        required property string key
+        required property string label
+        readonly property bool active: ProcessUsage.sortBy === sortChip.key
+
+        implicitWidth: sortChipLabel.implicitWidth + Tokens.padding.small * 2
+        implicitHeight: 20
+        radius: Tokens.rounding.full
+        color: sortChip.active ? Colours.palette.m3secondaryContainer : "transparent"
+
+        Behavior on color {
+            CAnim {}
+        }
+
+        StateLayer {
+            radius: parent.radius
+            onClicked: ProcessUsage.sortBy = sortChip.key
+        }
+
+        StyledText {
+            id: sortChipLabel
+
+            anchors.centerIn: parent
+            text: sortChip.label
+            color: sortChip.active ? Colours.palette.m3onSecondaryContainer : Colours.palette.m3onSurfaceVariant
+            font: Tokens.font.label.builders.small.weight(Font.Medium).build()
+        }
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.bottomMargin: Tokens.spacing.extraSmall
+        spacing: Tokens.spacing.extraSmall
+
+        StyledText {
+            text: qsTr("CPU %1%  ·  RAM %2%").arg(Math.round(SystemUsage.cpuPerc * 100)).arg(Math.round(SystemUsage.memPerc * 100))
+            color: Colours.palette.m3onSurfaceVariant
+            font: Tokens.font.label.medium
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        SortChip {
+            key: "cpu"
+            label: qsTr("CPU")
+        }
+
+        SortChip {
+            key: "mem"
+            label: qsTr("Memory")
+        }
+    }
+
+    Repeater {
+        model: root.rows
+
+        StyledRect {
+            id: row
+
+            required property var modelData
+            required property int index
+
+            Layout.fillWidth: true
+            implicitHeight: 24
+            radius: Tokens.rounding.small
+            color: row.modelData ? Colours.layer(Colours.palette.m3surfaceContainerHigh, 2) : "transparent"
+
+            StyledRect {
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: row.modelData && root.peak > 0 ? parent.width * Math.min(1, root.metricOf(row.modelData) / root.peak) : 0
+                radius: parent.radius
+                color: Qt.alpha(root.byMem ? Colours.palette.m3tertiary : Colours.palette.m3primary, 0.28)
+
+                Behavior on width {
+                    Anim { type: Anim.DefaultEffects }
+                }
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: Tokens.padding.small
+                anchors.rightMargin: Tokens.padding.small
+                spacing: Tokens.spacing.small
+                visible: !!row.modelData
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: row.modelData?.name ?? ""
+                    elide: Text.ElideRight
+                    font: Tokens.font.body.medium
+                }
+
+                StyledText {
+                    text: row.modelData ? String(row.modelData.pid) : ""
+                    color: Colours.palette.m3onSurfaceVariant
+                    font: Tokens.font.mono.small
+                }
+
+                StyledText {
+                    text: row.modelData ? root.labelFor(row.modelData) : ""
+                    color: Colours.palette.m3onSurface
+                    font: Tokens.font.mono.builders.small.weight(Font.Medium).build()
+                    horizontalAlignment: Text.AlignRight
+
+                    // Fixed width so the right column stays a column: the
+                    // values change every tick and a mono face still
+                    // shifts the whole row when the digit count does.
+                    Layout.preferredWidth: 62
+                }
+            }
+
+            StyledText {
+                anchors.centerIn: parent
+                visible: row.index === 0 && !row.modelData && !ProcessUsage.primed
+                text: qsTr("sampling…")
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.label.small
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/notch/NotchProcessTile.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchProcessTile.qml
@@ -63,6 +63,32 @@ ColumnLayout {
 
     spacing: Tokens.spacing.extraSmall
 
+    // One cell width for all three, measured off the widest string any of
+    // them can ever hold, so a reading crossing 9%->10% cannot shove its
+    // neighbours sideways.
+    TextMetrics {
+        id: metricCell
+
+        font: Tokens.font.label.small
+        text: "GPU 100%"
+    }
+
+    component Metric: StyledText {
+        required property string label
+        required property real perc
+
+        // An equal share each, so the three sit flush to both margins and
+        // evenly apart. preferredWidth alongside fillWidth is what makes
+        // the shares equal rather than proportional to each string, which
+        // is also why a reading crossing 9%->10% cannot shove its
+        // neighbours sideways.
+        Layout.fillWidth: true
+        Layout.preferredWidth: metricCell.width
+        text: `${label} ${Math.round(perc * 100)}%`
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.small
+    }
+
     component SortChip: StyledRect {
         id: sortChip
 
@@ -94,16 +120,45 @@ ColumnLayout {
         }
     }
 
+    // Its own row rather than sharing one with the sort chips: three
+    // readings and three chips came to 445px against 388 of content, which
+    // is what was eliding "GPU 42%" down to "GP...". Splitting them costs
+    // one text line of height and leaves both rows with real slack.
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: Tokens.spacing.small
+
+        Metric {
+            label: qsTr("CPU")
+            perc: SystemUsage.cpuPerc
+            horizontalAlignment: Text.AlignLeft
+        }
+
+        Metric {
+            label: qsTr("RAM")
+            perc: SystemUsage.memPerc
+            horizontalAlignment: Text.AlignHCenter
+        }
+
+        // Only where there is a live figure: gpuStatsAvailable is false
+        // when no vendor tool is installed, and a hardcoded "GPU 0%" beside
+        // two real meters is worse than no segment at all. A layout skips
+        // an invisible item entirely, so the remaining two re-spread across
+        // the full width rather than leaving a hole. It ticks at
+        // SystemUsage's fast cadence, which Notch.qml opts into for exactly
+        // as long as this tile is up.
+        Metric {
+            visible: SystemUsage.gpuStatsAvailable
+            label: qsTr("GPU")
+            perc: SystemUsage.gpuPerc
+            horizontalAlignment: Text.AlignRight
+        }
+    }
+
     RowLayout {
         Layout.fillWidth: true
         Layout.bottomMargin: Tokens.spacing.extraSmall
         spacing: Tokens.spacing.extraSmall
-
-        StyledText {
-            text: qsTr("CPU %1%  ·  RAM %2%").arg(Math.round(SystemUsage.cpuPerc * 100)).arg(Math.round(SystemUsage.memPerc * 100))
-            color: Colours.palette.m3onSurfaceVariant
-            font: Tokens.font.label.medium
-        }
 
         Item {
             Layout.fillWidth: true

--- a/Configs/quickshell/aphotic/modules/notch/NotchProcessTile.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchProcessTile.qml
@@ -10,6 +10,8 @@ ColumnLayout {
     id: root
 
     readonly property bool byMem: ProcessUsage.sortBy === "mem"
+    readonly property bool byGpu: ProcessUsage.sortBy === "gpu"
+    readonly property color metricColour: root.byGpu ? Colours.palette.m3secondary : root.byMem ? Colours.palette.m3tertiary : Colours.palette.m3primary
 
     // Padded to a constant length so the tile's implicitHeight -- and
     // therefore the notch's animated height -- does not twitch as
@@ -25,14 +27,33 @@ ColumnLayout {
         const first = ProcessUsage.processes[0];
         if (!first)
             return 0;
-        return root.byMem ? first.rssKib : first.cpu;
+        return root.metricOf(first);
+    }
+
+    // Says which of the three empty states this is: unsupported hardware,
+    // a sweep that has not landed yet, or a supported GPU with nothing
+    // currently holding VRAM.
+    readonly property string emptyNote: {
+        if (ProcessUsage.processes.length > 0)
+            return "";
+        if (root.byGpu && !ProcessUsage.gpuSupported)
+            return qsTr("Per-process VRAM needs an NVIDIA GPU");
+        if (root.byGpu && !ProcessUsage.gpuAvailable)
+            return qsTr("reading VRAM…");
+        if (!ProcessUsage.primed)
+            return qsTr("sampling…");
+        return root.byGpu ? qsTr("nothing holding VRAM") : "";
     }
 
     function metricOf(entry: var): real {
+        if (root.byGpu)
+            return entry.gpuMib;
         return root.byMem ? entry.rssKib : entry.cpu;
     }
 
     function labelFor(entry: var): string {
+        if (root.byGpu)
+            return entry.gpuMib >= 1024 ? `${(entry.gpuMib / 1024).toFixed(1)} GiB` : `${entry.gpuMib} MiB`;
         if (root.byMem) {
             const fmt = SystemUsage.formatKib(entry.rssKib);
             return `${fmt.value.toFixed(fmt.unit === "GiB" ? 1 : 0)} ${fmt.unit}`;
@@ -97,6 +118,11 @@ ColumnLayout {
             key: "mem"
             label: qsTr("Memory")
         }
+
+        SortChip {
+            key: "gpu"
+            label: qsTr("GPU")
+        }
     }
 
     Repeater {
@@ -119,7 +145,7 @@ ColumnLayout {
                 anchors.bottom: parent.bottom
                 width: row.modelData && root.peak > 0 ? parent.width * Math.min(1, root.metricOf(row.modelData) / root.peak) : 0
                 radius: parent.radius
-                color: Qt.alpha(root.byMem ? Colours.palette.m3tertiary : Colours.palette.m3primary, 0.28)
+                color: Qt.alpha(root.metricColour, 0.28)
 
                 Behavior on width {
                     Anim { type: Anim.DefaultEffects }
@@ -161,8 +187,11 @@ ColumnLayout {
 
             StyledText {
                 anchors.centerIn: parent
-                visible: row.index === 0 && !row.modelData && !ProcessUsage.primed
-                text: qsTr("sampling…")
+                width: parent.width - Tokens.padding.small * 2
+                horizontalAlignment: Text.AlignHCenter
+                elide: Text.ElideRight
+                visible: row.index === 0 && !row.modelData && root.emptyNote.length > 0
+                text: root.emptyNote
                 color: Colours.palette.m3onSurfaceVariant
                 font: Tokens.font.label.small
             }

--- a/Configs/quickshell/aphotic/modules/notch/NotchProfileStub.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchProfileStub.qml
@@ -4,10 +4,10 @@ import qs.config
 import qs.components
 import qs.services
 
-// Deliberately empty second tile. It exists to prove the tile switcher in
-// Notch.qml carries more than one tile (state, header, chip strip and the
-// height animation between differently-sized bodies) -- Dev Status and
-// Claude Status content are explicitly out of scope for this pass.
+// Stands in for an opt-in layer that is installed and docked in the notch
+// but whose surface has not been built yet. It says exactly that rather
+// than inventing a status, because an empty-but-honest tab is the point:
+// the gating and the switcher are real now, the content lands per layer.
 ColumnLayout {
     id: root
 
@@ -30,13 +30,13 @@ ColumnLayout {
 
     StyledText {
         Layout.alignment: Qt.AlignHCenter
-        text: qsTr("%1 reserved").arg(root.slotLabel)
+        text: root.slotLabel
         font: Tokens.font.title.medium
     }
 
     StyledText {
         Layout.fillWidth: true
-        text: qsTr("Nothing is wired here yet — this slot only exists to prove the switcher holds more than one tile.")
+        text: qsTr("This layer is installed and docked here. Its surface hasn't been built yet.")
         color: Colours.palette.m3onSurfaceVariant
         font: Tokens.font.label.medium
         horizontalAlignment: Text.AlignHCenter

--- a/Configs/quickshell/aphotic/modules/notch/NotchWindow.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchWindow.qml
@@ -1,0 +1,58 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs.config
+
+PanelWindow {
+    id: root
+
+    required property var modelData
+    screen: modelData
+
+    readonly property Notch notch: notch
+
+    WlrLayershell.namespace: "aphotic-notch"
+    WlrLayershell.layer: WlrLayer.Top
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+    // Normal with a zero zone, NOT ExclusionMode.Ignore: zero reserves no
+    // desktop space of its own while still honouring everyone else's
+    // exclusive zone, so a top-docked bar pushes the notch below itself
+    // instead of being overlapped by it. Ignore would set -1, which means
+    // "ignore every other surface's zone" and lands the notch on top of
+    // the bar.
+    WlrLayershell.exclusionMode: ExclusionMode.Normal
+    WlrLayershell.exclusiveZone: 0
+    color: "transparent"
+
+    // Top edge only. With one axis anchored, layer-shell centres the
+    // surface on the other -- no width binding is involved in the
+    // centring, which is what keeps the surface geometry static below.
+    anchors.top: true
+
+    visible: Config.notch.enabled
+
+    // Content-INDEPENDENT surface size, sized once to the largest state
+    // the notch can reach plus shadow bleed. Every expand/contract
+    // happens inside `notch`; this window never resizes, so the
+    // compositor is never asked to renegotiate the layer surface on a
+    // state change. Same budgeting BarWindow does for its popout flyouts.
+    implicitWidth: Config.notch.expandedWidth + Tokens.spacing.extraLarge * 2
+    implicitHeight: Config.notch.maxHeight + Tokens.spacing.extraLarge * 2
+
+    // Without this the whole (mostly transparent) surface swallows clicks
+    // meant for whatever is underneath it, exactly as BarWindow documents.
+    // Region tracks `notch`'s animating bounds via set_input_region, a
+    // plain surface commit -- it does not resize the layer surface.
+    mask: Region {
+        item: notch
+    }
+
+    Notch {
+        id: notch
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        y: Tokens.spacing.extraSmall
+    }
+}

--- a/Configs/quickshell/aphotic/modules/notch/qmldir
+++ b/Configs/quickshell/aphotic/modules/notch/qmldir
@@ -2,4 +2,4 @@ module qs.modules.notch
 Notch 1.0 Notch.qml
 NotchWindow 1.0 NotchWindow.qml
 NotchProcessTile 1.0 NotchProcessTile.qml
-NotchPlaceholderTile 1.0 NotchPlaceholderTile.qml
+NotchProfileStub 1.0 NotchProfileStub.qml

--- a/Configs/quickshell/aphotic/modules/notch/qmldir
+++ b/Configs/quickshell/aphotic/modules/notch/qmldir
@@ -1,0 +1,5 @@
+module qs.modules.notch
+Notch 1.0 Notch.qml
+NotchWindow 1.0 NotchWindow.qml
+NotchProcessTile 1.0 NotchProcessTile.qml
+NotchPlaceholderTile 1.0 NotchPlaceholderTile.qml

--- a/Configs/quickshell/aphotic/notch-prototype.qml
+++ b/Configs/quickshell/aphotic/notch-prototype.qml
@@ -40,6 +40,16 @@ ShellRoot {
             return `tile=${w.notch.tile}`;
         }
 
+        function tabs(): string {
+            const n = windows.instances[0].notch;
+            return JSON.stringify({
+                layers: InstallProfile.layers,
+                known: InstallProfile.known,
+                tiles: n.tiles.map(t => t.label),
+                switchable: n.switchable
+            });
+        }
+
         function state(): string {
             const w = windows.instances[0];
             return JSON.stringify({

--- a/Configs/quickshell/aphotic/notch-prototype.qml
+++ b/Configs/quickshell/aphotic/notch-prototype.qml
@@ -52,6 +52,9 @@ ShellRoot {
                 sampling: ProcessUsage.sampling,
                 primed: ProcessUsage.primed,
                 sortBy: ProcessUsage.sortBy,
+                gpuPerc: Math.round(SystemUsage.gpuPerc * 100),
+                gpuStats: SystemUsage.gpuStatsAvailable,
+                fastMon: SystemUsage.fastMonitoring,
                 gpuSupported: ProcessUsage.gpuSupported,
                 gpuAvailable: ProcessUsage.gpuAvailable,
                 top: ProcessUsage.processes.slice(0, 6).map(p => `${p.name} cpu=${p.cpu.toFixed(1)}% rss=${Math.round(p.rssKib / 1024)}M vram=${p.gpuMib ?? "-"}`)

--- a/Configs/quickshell/aphotic/notch-prototype.qml
+++ b/Configs/quickshell/aphotic/notch-prototype.qml
@@ -52,7 +52,9 @@ ShellRoot {
                 sampling: ProcessUsage.sampling,
                 primed: ProcessUsage.primed,
                 sortBy: ProcessUsage.sortBy,
-                top: ProcessUsage.processes.slice(0, 3).map(p => `${p.name} ${p.cpu.toFixed(1)}% ${Math.round(p.rssKib / 1024)}M`)
+                gpuSupported: ProcessUsage.gpuSupported,
+                gpuAvailable: ProcessUsage.gpuAvailable,
+                top: ProcessUsage.processes.slice(0, 6).map(p => `${p.name} cpu=${p.cpu.toFixed(1)}% rss=${Math.round(p.rssKib / 1024)}M vram=${p.gpuMib ?? "-"}`)
             });
         }
 

--- a/Configs/quickshell/aphotic/notch-prototype.qml
+++ b/Configs/quickshell/aphotic/notch-prototype.qml
@@ -1,0 +1,64 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.modules.notch
+import qs.services
+
+// Isolated entry point for the notch prototype -- `qs -p
+// Configs/quickshell/aphotic/notch-prototype.qml` brings up the notch and
+// nothing else, so its behaviour can be driven and its log read without a
+// second full shell fighting the running one for the desktop. Not part of
+// shell.qml; delete with the branch.
+ShellRoot {
+    id: root
+
+    Variants {
+        id: windows
+        model: Quickshell.screens
+
+        NotchWindow {}
+    }
+
+    IpcHandler {
+        target: "notchtest"
+
+        function cycle(): string {
+            const w = windows.instances[0];
+            w.notch.cycle();
+            return `tile=${w.notch.tile}`;
+        }
+
+        function collapse(): string {
+            const w = windows.instances[0];
+            w.notch.collapse();
+            return `tile=${w.notch.tile}`;
+        }
+
+        function pick(t: int): string {
+            const w = windows.instances[0];
+            w.notch.tile = t;
+            return `tile=${w.notch.tile}`;
+        }
+
+        function state(): string {
+            const w = windows.instances[0];
+            return JSON.stringify({
+                tile: w.notch.tile,
+                shownTile: w.notch.shownTile,
+                notchW: Math.round(w.notch.width),
+                notchH: Math.round(w.notch.height),
+                winW: w.width,
+                winH: w.height,
+                sampling: ProcessUsage.sampling,
+                primed: ProcessUsage.primed,
+                sortBy: ProcessUsage.sortBy,
+                top: ProcessUsage.processes.slice(0, 3).map(p => `${p.name} ${p.cpu.toFixed(1)}% ${Math.round(p.rssKib / 1024)}M`)
+            });
+        }
+
+        function sort(key: string): string {
+            ProcessUsage.sortBy = key;
+            return key;
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/ProcessUsage.qml
+++ b/Configs/quickshell/aphotic/services/ProcessUsage.qml
@@ -1,0 +1,160 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.config
+
+// Per-process CPU/RSS sampling. SystemUsage covers the aggregate meters
+// (and is the only thing that should) -- this is strictly the per-PID
+// breakdown nothing else in the shell had a source for.
+//
+// Same "sleeping until seen" gate as SystemUsage.detailedMonitoring and
+// GpuVramSource.scanning: a full /proc sweep every couple of seconds is
+// not something to run for a surface nobody has open, so object lifetime
+// (ProcessUsageWatch) is the registration.
+Singleton {
+    id: root
+
+    // Top `count` entries, already ordered by whichever key sortBy names.
+    // Each entry: { pid, name, cpu, rssKib } -- cpu is percent of ONE
+    // core, the same scale top(1) reports, so a busy multithreaded
+    // process legitimately exceeds 100.
+    readonly property var processes: {
+        const key = root.sortBy === "mem" ? "rssKib" : "cpu";
+        return root._samples.slice().sort((a, b) => b[key] - a[key]).slice(0, root.count);
+    }
+
+    property string sortBy: "cpu"
+    readonly property int count: Config.notch.processCount
+    readonly property bool sampling: root._watchers > 0
+    // False for exactly one tick after sampling starts: a CPU percentage
+    // is a delta between two samples, so the first sweep can only prime.
+    readonly property bool primed: root._samples.length > 0
+
+    function beginSampling(): void {
+        root._watchers = root._watchers + 1;
+    }
+
+    function endSampling(): void {
+        root._watchers = Math.max(0, root._watchers - 1);
+        if (root._watchers === 0) {
+            root._prev = null;
+            root._samples = [];
+        }
+    }
+
+    property var _samples: []
+    property var _prev: null
+    property real _prevAt: 0
+    property int _watchers: 0
+    property int _clockTicks: 100
+    property real _pageKib: 4
+
+    function _ingest(text: string): void {
+        const now = Date.now();
+        const prev = root._prev;
+        const elapsed = prev ? (now - root._prevAt) / 1000 : 0;
+        const divisor = root._clockTicks * elapsed;
+        const next = {};
+        const out = [];
+        const rows = text.split("\n");
+
+        for (let i = 0; i < rows.length; i++) {
+            const parts = rows[i].split("\t");
+            if (parts.length < 4)
+                continue;
+            const pid = parseInt(parts[0], 10);
+            const jiffies = parseInt(parts[2], 10);
+            const pages = parseInt(parts[3], 10);
+            if (isNaN(pid) || isNaN(jiffies))
+                continue;
+
+            next[pid] = jiffies;
+            if (divisor <= 0)
+                continue;
+
+            const before = prev[pid];
+            out.push({
+                pid,
+                name: parts[1],
+                cpu: before === undefined ? 0 : Math.max(0, (jiffies - before) / divisor * 100),
+                rssKib: (isNaN(pages) ? 0 : pages) * root._pageKib
+            });
+        }
+
+        root._prev = next;
+        root._prevAt = now;
+        if (divisor > 0)
+            root._samples = out;
+    }
+
+    Process {
+        id: unitsProc
+        command: ["sh", "-c", "getconf CLK_TCK; getconf PAGESIZE"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const lines = text.trim().split("\n");
+                const ticks = parseInt(lines[0], 10);
+                const page = parseInt(lines[1], 10);
+                if (!isNaN(ticks) && ticks > 0)
+                    root._clockTicks = ticks;
+                if (!isNaN(page) && page > 0)
+                    root._pageKib = page / 1024;
+            }
+        }
+    }
+
+    Process {
+        id: sampleProc
+        // One awk over every /proc/<pid>/stat rather than ps(1): ps's
+        // %cpu is the process's lifetime average, not what it is doing
+        // now, so a long-lived idle process outranks a busy new one --
+        // useless for a live monitor. Cumulative jiffies differenced
+        // against the previous sweep gives the real instantaneous figure.
+        //
+        // comm is bracketed and may itself contain spaces or ')', so the
+        // line is split on the LAST ')' instead of by whitespace. Past
+        // that split the remaining fields start at `state`, i.e. two
+        // lower than the numbering in proc(5): utime 14 -> 12, stime
+        // 15 -> 13, rss 24 -> 22.
+        command: ["sh", "-c", "awk 'FNR==1{s=$0;i=index(s,\")\");pid=substr(s,1,index(s,\" \")-1);name=substr(s,index(s,\"(\")+1,i-index(s,\"(\")-1);rest=substr(s,i+2);split(rest,f,\" \");print pid\"\\t\"name\"\\t\"(f[12]+f[13])\"\\t\"f[22]}' /proc/[0-9]*/stat 2>/dev/null"]
+        stdout: StdioCollector {
+            onStreamFinished: root._ingest(text)
+        }
+    }
+
+    function _sweep(): void {
+        if (!sampleProc.running)
+            sampleProc.running = true;
+    }
+
+    Timer {
+        interval: Config.notch.processUpdateInterval
+        running: root.sampling
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: root._sweep()
+    }
+
+    // The steady-state timer above can only prime on its first tick, so
+    // without this the list stays empty for a full interval every time
+    // the tile is opened. One short follow-up sweep puts real numbers on
+    // screen immediately; its narrower window is coarser than a steady
+    // tick but is replaced by one a moment later.
+    Timer {
+        id: primeTimer
+        interval: 350
+        onTriggered: root._sweep()
+    }
+
+    onSamplingChanged: {
+        if (root.sampling)
+            primeTimer.restart();
+        else
+            primeTimer.stop();
+    }
+
+    Component.onCompleted: unitsProc.running = true
+}

--- a/Configs/quickshell/aphotic/services/ProcessUsage.qml
+++ b/Configs/quickshell/aphotic/services/ProcessUsage.qml
@@ -5,6 +5,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.config
+import qs.services
 
 // Per-process CPU/RSS sampling. SystemUsage covers the aggregate meters
 // (and is the only thing that should) -- this is strictly the per-PID
@@ -22,11 +23,46 @@ Singleton {
     // core, the same scale top(1) reports, so a busy multithreaded
     // process legitimately exceeds 100.
     readonly property var processes: {
+        // GPU is a join, not just a different sort key: only processes
+        // holding VRAM belong in that list at all, and a list mostly made
+        // of zeroes would say nothing. No object spread -- Quickshell's JS
+        // engine rejects it outright (see SystemUsage.qml).
+        if (root.sortBy === "gpu") {
+            const byPid = root._gpuByPid;
+            const held = [];
+            for (let i = 0; i < root._samples.length; i++) {
+                const sample = root._samples[i];
+                const mib = byPid[sample.pid];
+                if (mib === undefined)
+                    continue;
+                held.push({
+                    pid: sample.pid,
+                    name: sample.name,
+                    cpu: sample.cpu,
+                    rssKib: sample.rssKib,
+                    gpuMib: mib
+                });
+            }
+            return held.sort((a, b) => b.gpuMib - a.gpuMib).slice(0, root.count);
+        }
+
         const key = root.sortBy === "mem" ? "rssKib" : "cpu";
         return root._samples.slice().sort((a, b) => b[key] - a[key]).slice(0, root.count);
     }
 
+    // "cpu" | "mem" | "gpu"
     property string sortBy: "cpu"
+
+    // Per-process VRAM has exactly one source that works here: nvidia-smi.
+    // The NVIDIA driver publishes no DRM fdinfo (verified on this box --
+    // only the i915 iGPU's clients carry drm-* keys), and AMD's
+    // drm-resident-vram path is the one GpuVramSource.qml already declines
+    // to trust without real hardware to verify against. So rather than
+    // hide the tab on unsupported hardware and reflow the tile, this is
+    // surfaced as a capability the tile explains -- the same call
+    // SystemUsage makes for GPU stats generally.
+    readonly property bool gpuSupported: (SystemUsage.selectedGpu?.vendor ?? "") === "nvidia"
+    readonly property bool gpuAvailable: root.gpuSupported && root._gpuSeen
     readonly property int count: Config.notch.processCount
     readonly property bool sampling: root._watchers > 0
     // False for exactly one tick after sampling starts: a CPU percentage
@@ -42,10 +78,13 @@ Singleton {
         if (root._watchers === 0) {
             root._prev = null;
             root._samples = [];
+            root._gpuByPid = ({});
         }
     }
 
     property var _samples: []
+    property var _gpuByPid: ({})
+    property bool _gpuSeen: false
     property var _prev: null
     property real _prevAt: 0
     property int _watchers: 0
@@ -125,9 +164,47 @@ Singleton {
         }
     }
 
+    function _ingestGpu(xml: string): void {
+        const byPid = {};
+        for (const block of xml.match(/<process_info>[\s\S]*?<\/process_info>/g) ?? []) {
+            const field = tag => {
+                const m = block.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+                return m ? m[1].trim() : "";
+            };
+            const pid = field("pid");
+            // used_memory carries its unit ("214 MiB"); parseInt stops at
+            // the space and an "N/A" entry becomes NaN and is dropped.
+            const mib = parseInt(field("used_memory"), 10);
+            if (!pid || isNaN(mib) || mib <= 0)
+                continue;
+            byPid[pid] = mib;
+        }
+        root._gpuByPid = byPid;
+        if (Object.keys(byPid).length > 0)
+            root._gpuSeen = true;
+    }
+
+    Process {
+        id: gpuProc
+        // Same invocation GpuVramSource.qml settled on, and for the same
+        // reason: the --query-compute-apps CSV only ever reports C-type
+        // processes, so everything holding VRAM for rendering -- which on
+        // a desktop is nearly all of it -- is invisible to it. The XML is
+        // the only structured source covering every type.
+        command: ["sh", "-c", "command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -q -x"]
+        stdout: StdioCollector {
+            onStreamFinished: root._ingestGpu(text)
+        }
+    }
+
     function _sweep(): void {
         if (!sampleProc.running)
             sampleProc.running = true;
+    }
+
+    function _sweepGpu(): void {
+        if (!gpuProc.running)
+            gpuProc.running = true;
     }
 
     Timer {
@@ -143,6 +220,18 @@ Singleton {
     // the tile is opened. One short follow-up sweep puts real numbers on
     // screen immediately; its narrower window is coarser than a steady
     // tick but is replaced by one a moment later.
+    // Its own, slower cadence, and only while the GPU column is the one
+    // being shown: one nvidia-smi -q -x costs ~120ms of subprocess here,
+    // far too much to hang off the 1.5s /proc tick, and VRAM allocations
+    // do not move at anything like that rate anyway.
+    Timer {
+        interval: Config.notch.gpuUpdateInterval
+        running: root.sampling && root.sortBy === "gpu" && root.gpuSupported
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: root._sweepGpu()
+    }
+
     Timer {
         id: primeTimer
         interval: 350

--- a/Configs/quickshell/aphotic/services/SystemUsage.qml
+++ b/Configs/quickshell/aphotic/services/SystemUsage.qml
@@ -60,6 +60,23 @@ Singleton {
         root._watchers = Math.max(0, root._watchers - 1);
     }
 
+    // A second level on top of detailed monitoring, for a surface showing
+    // GPU utilisation as a live meter next to cpuPerc/memPerc -- those
+    // come off the 2s base poll, and a GPU figure a full 30s stale
+    // standing beside them does not read as slow, it reads as broken.
+    // Opt-in so the surfaces that were happy with 30s (the Command
+    // Centre's performance tab, Settings' System pane, the bar's
+    // resources popout) keep paying exactly what they paid before.
+    readonly property bool fastMonitoring: root._fastWatchers > 0
+
+    function beginFastMonitoring(): void {
+        root._fastWatchers = root._fastWatchers + 1;
+    }
+
+    function endFastMonitoring(): void {
+        root._fastWatchers = Math.max(0, root._fastWatchers - 1);
+    }
+
     // Only the selected GPU. Polling every detected controller kept a
     // second card's reading warm for the moment the user cycles the
     // selector, at the cost of a process per card on every tick forever
@@ -88,6 +105,7 @@ Singleton {
     property real _memTotal: 0
     property var _disks: []
     property int _watchers: 0
+    property int _fastWatchers: 0
 
     property var _prevCpu: null
 
@@ -387,14 +405,23 @@ Singleton {
     // gate going true fires a tick immediately rather than leaving the
     // card blank for up to 30s.
     Timer {
-        interval: 30000
+        interval: Config.dashboard.detailUpdateInterval
         running: root.detailedMonitoring
         repeat: true
         triggeredOnStart: true
-        onTriggered: {
-            tempProc.running = true;
-            root._pollGpu();
-        }
+        onTriggered: tempProc.running = true
+    }
+
+    // Split out of the timer above rather than sharing it: the two used to
+    // tick together, so making the GPU poll fast enough to sit beside a 2s
+    // CPU meter would have dragged `sensors -j` along at the same rate for
+    // a reading that moves in single degrees over minutes.
+    Timer {
+        interval: root.fastMonitoring ? Config.dashboard.detailFastUpdateInterval : Config.dashboard.detailUpdateInterval
+        running: root.detailedMonitoring
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: root._pollGpu()
     }
 
     Component.onCompleted: {

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -21,6 +21,7 @@ singleton PinnedSnippets 1.0 PinnedSnippets.qml
 singleton PkgSearch 1.0 PkgSearch.qml
 singleton PluginRegistry 1.0 PluginRegistry.qml
 singleton Pomodoro 1.0 Pomodoro.qml
+singleton ProcessUsage 1.0 ProcessUsage.qml
 singleton SessionLockState 1.0 SessionLockState.qml
 singleton Settings 1.0 Settings.qml
 singleton SystemUsage 1.0 SystemUsage.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -5,6 +5,7 @@ import qs.components
 import qs.config
 import qs.modules.bar
 import qs.modules.launcher
+import qs.modules.notch
 import qs.modules.notifications
 import qs.modules.osd
 import qs.modules.lock
@@ -100,6 +101,12 @@ ShellRoot {
         DockWindow {
             screenState: root.screenStateFor(modelData)
         }
+    }
+
+    Variants {
+        model: Quickshell.screens
+
+        NotchWindow {}
     }
 
     Variants {

--- a/profiles/base/full.toml
+++ b/profiles/base/full.toml
@@ -3,7 +3,7 @@ name = "full"
 description = "Full install: today's complete package set"
 
 [packages]
-prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "procps-ng", "util-linux"]
+prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "procps-ng", "util-linux", "gawk"]
 # tumbler and the three format helpers after `thunar` are Thunar's
 # thumbnailing stack, not extras: Thunar renders no thumbnails itself, it
 # asks the Tumbler D-Bus service, so without tumbler installed every file

--- a/profiles/base/minimal.toml
+++ b/profiles/base/minimal.toml
@@ -3,5 +3,5 @@ name = "minimal"
 description = "Bare Hyprland + Quickshell bar, no extras"
 
 [packages]
-prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "procps-ng", "util-linux"]
+prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "procps-ng", "util-linux", "gawk"]
 main = ["quickshell", "kitty", "awww", "xdg-desktop-portal-hyprland", "wallust-git", "matugen", "openvpn", "swappy", "grim", "slurp", "brightnessctl", "swaylock-effects"]


### PR DESCRIPTION
A top-centre "dynamic island" surface. **The notch and its Processes tile are base shell**; every tab past the first is an opt-in that docks itself here when its own layer is installed.

## Tab gating

| Tile | Gate | Content |
|---|---|---|
| Processes | **none — base shell** | System process monitor, live |
| Dev | `dev` layer | stub here; real tile in #102 |
| Security | `exploit*` layers | stub — surface undecided, plumbing real |
| Agents | `ai` layer | stub — context-window/AI surfaces planned |

Gaming deliberately has no tile: it is a transient state around a running game, not a surface to sit and read.

Nothing in `install.sh` gates quickshell by layer — the shell always deploys whole and gating is runtime via `InstallProfile` — so the notch is base by construction with no installer change. A base install therefore has **exactly one tile**, which means nothing to switch between: the title stops being a button and the chip strip is gone outright rather than sitting there as one dead chip. That reclaims its row too, 280px against 318 with the strip up.

`gawk` is added to both base profiles. `ProcessUsage` shells out to `awk`, and the project rule is that every binary the shell shells out to is in `full.toml` **and** `minimal.toml` — being in Arch's own `base` meta-package is not the bar; `procps-ng` and `util-linux` are already listed on the same reasoning. `sh` and `getconf` come from bash and glibc, which cannot be absent; `nvidia-smi`'s `nvidia-utils` was already there.

## Geometry — reused, not reinvented

The bar's hover popouts already solve expand/contract over the wallpaper without breaking layer-shell, so this uses that mechanism verbatim: the `PanelWindow` is sized **once** to the largest reachable state and never resizes, all motion is an inner `Item`'s `Behavior`-animated `width`/`height`/`radius`, and a `mask: Region` keeps input passthrough everywhere the notch isn't drawn.

Verified against Hyprland: the `aphotic-notch` layer surface stays **476×396** through every state change including rapid mid-animation cycling, so the compositor is never asked to renegotiate.

`exclusionMode: Normal` with `exclusiveZone: 0`, **not** `Ignore` — zero reserves no desktop space while still honouring the bar's own zone, so a top-docked bar pushes the notch below it instead of being overlapped.

Idle carries **no clock** — the bar already owns one in every style that shows the time — just live CPU/RAM micro-bars off `SystemUsage`'s always-running base poll.

## The one new sampler

Nothing in the codebase sampled per-process anything, so `services/ProcessUsage.qml` is new and deliberately minimal: it differences cumulative jiffies from `/proc/<pid>/stat` between sweeps, because `ps`'s `%cpu` is a lifetime average and ranks idle old processes above busy new ones. Watcher-gated like `SystemUsage.detailedMonitoring`, so nothing polls while the tile is closed. Aggregate meters still come from `SystemUsage`.

**GPU** per-process VRAM uses `nvidia-smi -q -x` — the same invocation `GpuVramSource.qml` settled on, for the same reason (the `--query-compute-apps` CSV only reports C-type processes). Not routed *through* `GpuVramSource`: that file's scan only wakes for live arbitration conflicts and polls at 12s, and hanging a display surface off it would keep it awake for reasons it doesn't exist to serve. Verified row-for-row against `nvidia-smi` ground truth.

`SystemUsage` gains an **opt-in** second watch level for the header's live GPU%: `SystemUsageWatch { fast: true }` drops the GPU poll to 2s, and its temperature poll splits onto its own timer so it stays at 30s. Every existing surface keeps the cadence it had.

## Verified

Six layer sets, each in an isolated environment: base → `[Processes]`, not switchable; `dev` / `exploit-recon` / `ai` each → their own tile only; `gaming` alone → still just `[Processes]`; all four → `[Processes, Dev, Security, Agents]`. Base install opens to Processes and stays there across repeated title clicks. Layer surface unchanged throughout; log clean beyond startup.

Also deployed to a real machine via `install.sh --config-only` and confirmed live.

`notch-prototype.qml` is a standalone entry point for driving the notch in isolation. It goes away with the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wgqq93t8xbD9rN8MHd9qKN