### PR TITLE
plugin: refuse an install this shell has no host for

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -23,6 +23,107 @@
 
 _aphotic_plugin_dir() { printf '%s/%s' "$APHOTIC_PLUGINS_DIR" "$1"; }
 
+# ---------------------------------------------------------------------
+# What this shell build actually has a host for.
+#
+# The plugin catalogue is a separate repo on its own release cadence, so
+# it can offer a plugin whose only surface this shell cannot mount. That
+# install currently succeeds all the way through -- it copies the tree,
+# links the QML module, writes a registry entry -- and then renders
+# nothing, with no error anywhere to explain why. The gate belongs on
+# this side: a plugin cannot know which Aphotic it is being installed
+# into, and the shell already knows exactly which kinds it reads.
+#
+# Grow both lists in the same commit that adds the host. Anything absent
+# is reported as unhosted, which is the safe direction to fail -- a
+# surface silently dropped is the failure this exists to catch.
+# ---------------------------------------------------------------------
+APHOTIC_PLUGIN_HOSTED_SURFACES="dashboard"
+APHOTIC_PLUGIN_HOSTED_CAPABILITIES="ui-surface theme-hook project-hook workspace-hook harness-hook"
+
+# Exact word match against a space-separated list. Not `grep -w`: grep
+# counts `-` as a word boundary, so `-w profile` matches "profile-hook"
+# and a plugin declaring the unhosted `profile` capability would read as
+# hosted.
+_aphotic_plugin_in_list() {
+    local needle="$1" item
+    for item in $2; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+# The `[ui.<kind>]` sections a manifest declares, named as the registry
+# and index.json name them. Section headers are scanned directly rather
+# than asked for through _aphotic_plugin_ui_json, because the whole point
+# is to see kinds this build does not parse -- that function reads only
+# ui.dashboard_tab, so asking it would report every notch tile and
+# settings pane as simply absent.
+_aphotic_plugin_manifest_surfaces() {
+    local manifest="$1"
+    [[ -f "$manifest" ]] || return 0
+    sed -n 's/^[[:space:]]*\[ui\.\([a-z_]*\)\][[:space:]]*$/\1/p' "$manifest" \
+        | sed -e 's/^dashboard_tab$/dashboard/' \
+              -e 's/^notch_tile$/notch/' \
+              -e 's/^settings_pane$/settings/' \
+        | sort -u
+}
+
+# Verdict on a plugin's declared capabilities and surfaces, given as two
+# newline-separated lists. Prints `ok`, or `partial:<parts>` /
+# `inert:<parts>` with a human list of what has no host.
+#
+# partial and inert are a real distinction, not a severity gradient.
+# agent-graph declares a dashboard tab this build renders *and* a
+# settings pane it does not, so refusing it would remove a working
+# plugin; llm-fit declares only a settings pane and would install to
+# nothing at all. The question is therefore "does any of it work", not
+# "is all of it supported".
+#
+# `ui-surface` never counts as working on its own -- it is the tag that
+# says surfaces exist, and the surfaces themselves decide.
+_aphotic_plugin_host_verdict() {
+    local caps="$1" surfaces="$2"
+    local item working=0 unhosted=""
+
+    while IFS= read -r item; do
+        [[ -n "$item" ]] || continue
+        if ! _aphotic_plugin_in_list "$item" "$APHOTIC_PLUGIN_HOSTED_CAPABILITIES"; then
+            unhosted+="${unhosted:+, }${item} capability"
+            continue
+        fi
+        [[ "$item" == "ui-surface" ]] || working=$((working + 1))
+    done <<<"$caps"
+
+    while IFS= read -r item; do
+        [[ -n "$item" ]] || continue
+        if _aphotic_plugin_in_list "$item" "$APHOTIC_PLUGIN_HOSTED_SURFACES"; then
+            working=$((working + 1))
+        else
+            unhosted+="${unhosted:+, }${item} surface"
+        fi
+    done <<<"$surfaces"
+
+    if [[ -z "$unhosted" ]]; then
+        echo "ok"
+    elif [[ "$working" -gt 0 ]]; then
+        echo "partial:${unhosted}"
+    else
+        echo "inert:${unhosted}"
+    fi
+}
+
+# Same verdict for a catalogue entry rather than an on-disk manifest.
+# index.json already carries the normalized ui.surfaces[].surface names,
+# including kinds this build never parses out of a manifest, so the
+# remote listing can answer this without fetching anything.
+_aphotic_plugin_entry_verdict() {
+    local entry="$1"
+    _aphotic_plugin_host_verdict \
+        "$(jq -r '(.capabilities // [])[]' <<<"$entry")" \
+        "$(jq -r '((.ui.surfaces // [])[].surface) // empty' <<<"$entry" | sort -u)"
+}
+
 # Manifest v3 additions (see docs/archive/PLUGIN_SYSTEM.md): [owns] and
 # [ui.<surface-kind>] -- only `dashboard_tab` is shipped so far, the
 # natural extension point for a second UI-surface kind (a bar module, a
@@ -135,6 +236,24 @@ _aphotic_plugin_list_remote_json() {
     else
         echo "$main_data"
     fi
+}
+
+# Fold each catalogue entry's host verdict into the entry itself, as
+# `host_support: {verdict, unhosted}`. Additive on purpose: Settings ->
+# Plugins reads this same `list --remote --json` and ignores fields it
+# does not know, so an older pane keeps working against a newer CLI.
+_aphotic_plugin_annotate_remote_json() {
+    local data="$1" entry verdict annotated=()
+
+    while IFS= read -r entry; do
+        [[ -n "$entry" ]] || continue
+        verdict="$(_aphotic_plugin_entry_verdict "$entry")"
+        annotated+=("$(jq --arg v "${verdict%%:*}" --arg u "${verdict#*:}" \
+            '. + {host_support: {verdict: $v, unhosted: (if $v == "ok" then "" else $u end)}}' \
+            <<<"$entry")")
+    done < <(jq -c '(.plugins // [])[]' <<<"$data")
+
+    printf '%s\n' "${annotated[@]:-}" | jq -s 'map(select(. != null))'
 }
 
 # Fire every enabled theme-hook plugin's on_theme_change script, piping
@@ -574,6 +693,24 @@ _aphotic_plugin_install() {
         return 1
     fi
 
+    # Read off the manifest rather than the catalogue: --link installs a
+    # local working tree that is not in index.json at all, and the
+    # manifest is the source of truth for what the plugin declares.
+    local verdict
+    verdict="$(_aphotic_plugin_host_verdict \
+        "$(aphotic_toml_get_array "${src}/plugin.toml" plugin capabilities)" \
+        "$(_aphotic_plugin_manifest_surfaces "${src}/plugin.toml")")"
+    case "$verdict" in
+        inert:*)
+            aphotic_err "'${name}' needs a newer Aphotic: no host here for its ${verdict#inert:}"
+            aphotic_log "everything it ships would be inert on ${APHOTIC_VERSION}, so this is a refusal rather than a warning -- 'aphotic update' first"
+            return 1
+            ;;
+        partial:*)
+            aphotic_warn "'${name}' installs, but this Aphotic has no host for its ${verdict#partial:} -- that part stays dark until you update"
+            ;;
+    esac
+
     if [[ "$link" == "true" ]]; then
         ln -s "$src" "$dest"
         echo "Linked ${name} -> ${src}"
@@ -745,8 +882,20 @@ aphotic_cmd_plugin() {
                 if [[ -n "$category" ]]; then
                     data="$(echo "$data" | jq --arg c "$category" '{plugins: ((.plugins // []) | map(select(.category == $c)))}')"
                 fi
-                [[ "$as_json" == "true" ]] && { echo "$data" | jq '.plugins // []'; return 0; }
-                echo "$data" | jq -r '(.plugins // [])[] | "\(.name)\t\(.display_name)\t\(.version)\t\(.description)"' | column -t -s $'\t'
+                data="$(_aphotic_plugin_annotate_remote_json "$data")"
+                [[ "$as_json" == "true" ]] && { echo "$data"; return 0; }
+                echo "$data" | jq -r '.[] | "\(.name)\t\(.display_name)\t\(.version)\t\(if .host_support.verdict == "inert" then "NOT SUPPORTED" elif .host_support.verdict == "partial" then "partly supported" else "" end)\t\(.description)"' | column -t -s $'\t'
+
+                # Named rather than only marked in the table: "NOT
+                # SUPPORTED" with no reason reads as a broken plugin
+                # rather than an Aphotic that is behind its catalogue.
+                local unhosted
+                unhosted="$(echo "$data" | jq -r '.[] | select(.host_support.verdict != "ok") | "  \(.name): \(.host_support.unhosted)"')"
+                if [[ -n "$unhosted" ]]; then
+                    aphotic_warn "this Aphotic (${APHOTIC_VERSION}) has no host for parts of:"
+                    echo "$unhosted" >&2
+                    aphotic_log "'NOT SUPPORTED' plugins would install and do nothing, so 'aphotic plugin install' refuses them; update Aphotic to pick them up"
+                fi
             else
                 data="$(_aphotic_plugin_list_installed_json)"
                 [[ "$as_json" == "true" ]] && { echo "$data"; return 0; }

--- a/Configs/quickshell/aphotic/modules/settings/panes/PluginsPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PluginsPane.qml
@@ -190,6 +190,8 @@ ColumnLayout {
         property var dashboardTab: null
         property var configKeys: []
         property var externalConfig: []
+        property string hostVerdict: "ok"
+        property string unhosted: ""
 
         property bool first: true
         property bool last: true
@@ -315,6 +317,28 @@ ColumnLayout {
                     text: qsTr("Wires: %1").arg(pluginRow.externalConfig.join(", "))
                     color: Colours.palette.m3onSurfaceVariant
                     font: Tokens.font.label.small
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.topMargin: Tokens.spacing.extraSmall
+                    visible: pluginRow.hostVerdict !== "ok"
+                    spacing: Tokens.spacing.extraSmall
+
+                    MaterialIcon {
+                        text: pluginRow.hostVerdict === "inert" ? "error" : "warning"
+                        color: pluginRow.hostVerdict === "inert" ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.small
+                        fill: 1
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        wrapMode: Text.WordWrap
+                        text: pluginRow.hostVerdict === "inert" ? qsTr("Needs a newer Aphotic — no host here for its %1").arg(pluginRow.unhosted) : qsTr("Installs, but this Aphotic has no host for its %1").arg(pluginRow.unhosted)
+                        color: pluginRow.hostVerdict === "inert" ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                        font: Tokens.font.label.small
+                    }
                 }
             }
 
@@ -615,37 +639,48 @@ ColumnLayout {
 
                             required property var modelData
                             readonly property bool isInstalled: root.installedNames().includes(availableRow.modelData.name)
+                            readonly property bool isUnhosted: availableRow.hostVerdict === "inert"
 
                             icon: "extension"
                             label: `${availableRow.modelData.display_name}  ·  v${availableRow.modelData.version}`
                             description: availableRow.modelData.description
                             capabilities: availableRow.modelData.capabilities ?? []
                             dashboardTab: availableRow.modelData.ui?.dashboard_tab ?? null
+                            // Absent reads as "ok": an older CLI's --json
+                            // carries no host_support at all, and defaulting
+                            // the other way would mark every plugin
+                            // unavailable rather than none.
+                            hostVerdict: availableRow.modelData.host_support?.verdict ?? "ok"
+                            unhosted: availableRow.modelData.host_support?.unhosted ?? ""
 
                             StyledRect {
+                                id: installButton
+
+                                readonly property bool actionable: !availableRow.isInstalled && !availableRow.isUnhosted
+
                                 implicitWidth: installLabel.implicitWidth + Tokens.padding.large * 2
                                 implicitHeight: 32
                                 radius: Tokens.rounding.full
-                                color: availableRow.isInstalled ? Colours.layer(Colours.tPalette.m3surfaceContainer, 2) : Colours.palette.m3primary
+                                color: installButton.actionable ? Colours.palette.m3primary : Colours.layer(Colours.tPalette.m3surfaceContainer, 2)
 
                                 StyledText {
                                     id: installLabel
                                     anchors.centerIn: parent
-                                    text: availableRow.isInstalled ? qsTr("Installed") : qsTr("Install")
-                                    color: availableRow.isInstalled ? Colours.palette.m3onSurfaceVariant : Colours.contrastOn(Colours.palette.m3primary)
+                                    text: availableRow.isInstalled ? qsTr("Installed") : availableRow.isUnhosted ? qsTr("Unavailable") : qsTr("Install")
+                                    color: installButton.actionable ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurfaceVariant
                                     font: Tokens.font.label.small
                                 }
 
                                 StateLayer {
                                     anchors.fill: parent
                                     radius: parent.radius
-                                    disabled: availableRow.isInstalled
+                                    disabled: !installButton.actionable
                                 }
 
                                 MouseArea {
                                     anchors.fill: parent
-                                    enabled: !availableRow.isInstalled
-                                    cursorShape: availableRow.isInstalled ? Qt.ArrowCursor : Qt.PointingHandCursor
+                                    enabled: installButton.actionable
+                                    cursorShape: installButton.actionable ? Qt.PointingHandCursor : Qt.ArrowCursor
                                     onClicked: {
                                         // Install used to run silently through
                                         // actionProc (no stdout/stderr capture at

--- a/tests/test_plugin_host_gate.sh
+++ b/tests/test_plugin_host_gate.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# tests/test_plugin_host_gate.sh
+# The catalogue repo ships on its own cadence, so it can offer a plugin
+# whose only surface this shell has no host for. Before this gate that
+# install succeeded and rendered nothing. Covers the verdict rule, the
+# manifest section scan, and the install refusal.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+COMMANDS_DIR="$ROOT/Configs/.local/lib/aphotic/commands"
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_plugin.sh"
+
+# --- _aphotic_plugin_in_list: the grep -w trap ------------------------
+# `grep -w profile` matches "profile-hook", which would have read an
+# unhosted capability as hosted. This is the regression that check exists
+# for, so it is asserted directly rather than only through a verdict.
+_aphotic_plugin_in_list "theme-hook" "$APHOTIC_PLUGIN_HOSTED_CAPABILITIES" \
+    || fail "expected theme-hook to be hosted"
+_aphotic_plugin_in_list "profile" "profile-hook agent-event-hook" \
+    && fail "expected 'profile' NOT to match inside 'profile-hook'"
+
+# --- verdicts ---------------------------------------------------------
+
+v="$(_aphotic_plugin_host_verdict "harness-hook" "")"
+[[ "$v" == "ok" ]] || fail "hook-only plugin should be ok, got '$v'"
+
+# ui-surface alone never counts as working -- the surfaces decide.
+v="$(_aphotic_plugin_host_verdict "ui-surface" "notch")"
+[[ "$v" == inert:* ]] || fail "notch-only plugin should be inert, got '$v'"
+[[ "$v" == *"notch surface"* ]] || fail "verdict should name the notch surface, got '$v'"
+
+v="$(_aphotic_plugin_host_verdict "ui-surface" "settings")"
+[[ "$v" == inert:* ]] || fail "settings-pane-only plugin should be inert, got '$v'"
+
+# The case a blanket hide would get wrong: a dashboard tab that works
+# alongside a settings pane that does not.
+v="$(_aphotic_plugin_host_verdict "ui-surface" "dashboard
+settings")"
+[[ "$v" == partial:* ]] || fail "dashboard+settings plugin should be partial, got '$v'"
+[[ "$v" != *"dashboard"* ]] || fail "partial verdict should not name the hosted dashboard surface, got '$v'"
+
+v="$(_aphotic_plugin_host_verdict "profile" "")"
+[[ "$v" == inert:* ]] || fail "profile-capability plugin should be inert, got '$v'"
+
+# openrgb's real shape: one hosted hook, two that no branch fires yet.
+v="$(_aphotic_plugin_host_verdict "theme-hook
+profile-hook
+agent-event-hook" "")"
+[[ "$v" == partial:* ]] || fail "openrgb-shaped plugin should be partial, got '$v'"
+
+# --- manifest section scan -------------------------------------------
+
+MANIFEST="$TESTHOME/plugin.toml"
+cat > "$MANIFEST" <<'EOF'
+[plugin]
+name = "scratch"
+capabilities = ["ui-surface"]
+
+[ui.dashboard_tab]
+id = "a"
+
+[ui.settings_pane]
+id = "b"
+parent = "ai"
+
+[ui.notch_tile]
+id = "c"
+EOF
+
+got="$(_aphotic_plugin_manifest_surfaces "$MANIFEST" | tr '\n' ' ')"
+[[ "$got" == "dashboard notch settings " ]] \
+    || fail "expected normalized 'dashboard notch settings ', got '$got'"
+
+# A v1 manifest with no [ui] sections at all must scan clean, not error.
+printf '[plugin]\nname = "old"\n' > "$TESTHOME/old.toml"
+[[ -z "$(_aphotic_plugin_manifest_surfaces "$TESTHOME/old.toml")" ]] \
+    || fail "expected no surfaces from a manifest with no [ui] sections"
+
+# --- install refusal --------------------------------------------------
+
+export APHOTIC_PLUGINS_REPO="$TESTHOME/repo"
+mkdir -p "$APHOTIC_PLUGINS_REPO/inert-plug/qml"
+cat > "$APHOTIC_PLUGINS_REPO/inert-plug/plugin.toml" <<'EOF'
+[plugin]
+name = "inert-plug"
+display_name = "Inert"
+version = "1.0.0"
+capabilities = ["ui-surface"]
+
+[ui.settings_pane]
+id = "inert"
+component = "qml/Pane.qml"
+parent = "ai"
+EOF
+echo "// placeholder" > "$APHOTIC_PLUGINS_REPO/inert-plug/qml/Pane.qml"
+
+# _aphotic_plugin_sync_repo would try to git-pull a directory that is not
+# a checkout; the gate under test runs after it, so stub it out.
+_aphotic_plugin_sync_repo() { return 0; }
+
+if _aphotic_plugin_install "inert-plug" "false" >/dev/null 2>&1; then
+    fail "expected install of a fully-unhosted plugin to be refused"
+fi
+[[ -e "$(_aphotic_plugin_dir inert-plug)" ]] \
+    && fail "a refused install must not leave the plugin on disk"
+
+# The partial case still installs -- refusing it would remove a working
+# dashboard tab.
+mkdir -p "$APHOTIC_PLUGINS_REPO/partial-plug/qml"
+cat > "$APHOTIC_PLUGINS_REPO/partial-plug/plugin.toml" <<'EOF'
+[plugin]
+name = "partial-plug"
+display_name = "Partial"
+version = "1.0.0"
+capabilities = ["ui-surface"]
+
+[ui.dashboard_tab]
+id = "partial"
+component = "qml/Tab.qml"
+
+[ui.settings_pane]
+id = "partial"
+component = "qml/Pane.qml"
+parent = "ai"
+EOF
+echo "// placeholder" > "$APHOTIC_PLUGINS_REPO/partial-plug/qml/Tab.qml"
+echo "// placeholder" > "$APHOTIC_PLUGINS_REPO/partial-plug/qml/Pane.qml"
+
+_aphotic_plugin_install "partial-plug" "false" >/dev/null 2>&1 \
+    || fail "expected a partially-hosted plugin to still install"
+[[ -d "$(_aphotic_plugin_dir partial-plug)" ]] \
+    || fail "expected partial-plug on disk after install"
+
+# --- catalogue annotation --------------------------------------------
+
+annotated="$(_aphotic_plugin_annotate_remote_json '{"plugins":[
+  {"name":"agent-graph","capabilities":["ui-surface"],
+   "ui":{"surfaces":[{"surface":"dashboard"},{"surface":"settings"}]}},
+  {"name":"llm-fit","capabilities":["ui-surface"],
+   "ui":{"surfaces":[{"surface":"settings"}]}},
+  {"name":"gaming","capabilities":["profile"],"ui":{"surfaces":[]}},
+  {"name":"claude-hooks","capabilities":["harness-hook"],"ui":{"surfaces":[]}}
+]}')"
+
+check_verdict() {
+    local n="$1" want="$2" got
+    got="$(jq -r --arg n "$n" '.[] | select(.name == $n) | .host_support.verdict' <<<"$annotated")"
+    [[ "$got" == "$want" ]] || fail "catalogue verdict for ${n}: expected ${want}, got '${got}'"
+}
+check_verdict agent-graph  partial
+check_verdict llm-fit      inert
+check_verdict gaming       inert
+check_verdict claude-hooks ok
+
+echo "PASS: plugin host gate (verdict rule, manifest surface scan, install refusal, catalogue annotation)"


### PR DESCRIPTION
## The problem

The plugin catalogue is a separate repo on its own release cadence, so it can offer a plugin whose only surface this shell cannot mount. Against `main` (2.0.0), six of the eleven published plugins are in that state:

| plugin | declares | on 2.0.0 |
|---|---|---|
| `llm-fit` | settings pane | installs to nothing |
| `agent-notch-tile` | notch tile | installs to nothing |
| `dev-notch-tile` | notch tile | installs to nothing |
| `gaming` | `profile` capability | installs to nothing |
| `agent-graph` | dashboard tab **+** settings pane | tab works, pane is dark |
| `openrgb` | theme-hook **+** profile-hook + agent-event-hook | theme works, other two fired by no branch |

Every one of those installs succeeds today — copies the tree, links the QML module, writes a registry entry — and then renders nothing, with no error anywhere explaining why.

`profile-hook` and `agent-event-hook` are worth calling out separately: they are declared by the shipped `openrgb` plugin but fired by **no branch**, not just this one. This PR does not implement them; it makes them visible instead of silently dead.

## The fix

`cmd_plugin.sh` declares what this build hosts and answers three questions off it:

- `list --remote` marks each entry and names what has no host
- `--json` carries it as `host_support: {verdict, unhosted}` for Settings → Plugins
- `install` refuses a plugin whose every declared part is unhosted

`PluginsPane` shows the same verdict and renders the Install button as *Unavailable* rather than letting a click fail in a terminal.

### Two decisions worth reviewing

**`partial` vs `inert` is a real distinction, not a severity gradient.** Refusing `agent-graph` would remove a working dashboard tab. The rule is "does any of it work", not "is all of it supported" — a partial install warns and proceeds. `ui-surface` never counts as working on its own; it is the tag saying surfaces exist, and the surfaces decide.

**The gate reads section headers straight out of the manifest**, not through `_aphotic_plugin_ui_json` — that function parses only `ui.dashboard_tab`, so asking it would report every notch tile and settings pane as simply absent, which is the exact blindness this exists to fix.

Both hosted lists grow in the same commit that adds a host. Anything missing reads as unhosted, which is the safe direction to fail.

## What this looks like

```
agent-graph       Agent Graph       1.7.0  partly supported  Live tool-call graph and run replay…
agent-notch-tile  Agent Notch Tile  1.0.0  NOT SUPPORTED     Notch tile for AI coding harnesses…
llm-fit           Hardware Advisor  1.0.0  NOT SUPPORTED     Recommends local models your GPU…
direnv            direnv Notice     0.1.0                    Notifies you when a project…

[warn] this Aphotic (2.0.0) has no host for parts of:
  agent-graph: settings surface
  agent-notch-tile: notch surface
  llm-fit: settings surface
  gaming: profile capability
  openrgb: profile-hook capability, agent-event-hook capability
```

```
$ aphotic plugin install llm-fit
[fail] 'llm-fit' needs a newer Aphotic: no host here for its settings surface
```

## Verification

- New `tests/test_plugin_host_gate.sh` — the verdict rule, the `grep -w` trap that would read `profile` as hosted inside `profile-hook`, the manifest section scan, the install refusal leaving nothing on disk, the partial case still installing, and catalogue annotation.
- Ran the gate against all six real published manifests: refusals, warnings and passes all land where intended.
- Full suite green: 28 shell tests + 5 python.
- `PluginsPane.qml` compiles **and instantiates** clean under a headless `qs -p` probe (`qmllint` is not trusted here — it exits non-zero with no output on untouched files).

`VERSION` is deliberately untouched: this repo bumps in its own separate release-prep commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wgqq93t8xbD9rN8MHd9qKN