### PR TITLE
settings: consume a jump-to-category while the panel is already open

### DIFF
--- a/Configs/quickshell/aphotic/modules/settings/SettingsPanel.qml
+++ b/Configs/quickshell/aphotic/modules/settings/SettingsPanel.qml
@@ -126,7 +126,7 @@ RowLayout {
             anchors.fill: parent
             anchors.margins: Tokens.padding.extraLarge
             contentWidth: width
-            contentHeight: paneColumn.implicitHeight
+            contentHeight: paneColumn.height
             boundsBehavior: Flickable.StopAtBounds
             clip: true
 
@@ -145,6 +145,13 @@ RowLayout {
                 id: paneColumn
 
                 width: paneFlick.width
+                // Takes the viewport's slack itself and lets paneLoader
+                // absorb it, so a self-centring pane keeps working when
+                // its category gains a plugin section. Reads its own
+                // implicitHeight, which is derived from children's
+                // implicit sizes and not from this height, so there is no
+                // cycle here.
+                height: Math.max(implicitHeight, paneFlick.height)
                 spacing: Tokens.spacing.small
                 opacity: 1
 
@@ -159,16 +166,16 @@ RowLayout {
                     id: paneLoader
 
                     Layout.fillWidth: true
-                    // Stretched to the viewport only while the category
-                    // owns no sections -- several panes (About, Launcher,
-                    // Appearance) distribute that slack with their own
-                    // fillHeight spacers. With sections below it the pane
-                    // has to end where its content ends, or the first
-                    // section header lands a screen further down.
-                    Layout.preferredHeight: {
-                        const natural = paneLoader.item?.implicitHeight ?? 0;
-                        return root.sections.length > 0 ? natural : Math.max(paneFlick.height, natural);
-                    }
+                    // The only fillHeight child, so it takes whatever the
+                    // sections below leave -- About, Launcher and
+                    // Appearance distribute that slack with their own
+                    // fillHeight spacers. Stretching the pane to the whole
+                    // viewport instead would push the first section header
+                    // a screen down; giving it only its natural height
+                    // collapsed those panes' centring the moment a plugin
+                    // docked a section into their category.
+                    Layout.fillHeight: true
+                    Layout.preferredHeight: paneLoader.item?.implicitHeight ?? 0
 
                     sourceComponent: {
                         switch (root.currentCategoryId) {

--- a/Configs/quickshell/aphotic/modules/settings/SettingsWindow.qml
+++ b/Configs/quickshell/aphotic/modules/settings/SettingsWindow.qml
@@ -32,10 +32,26 @@ PanelWindow {
     // mode (Launcher.qml/SettingsItem.qml) -- same one-shot
     // set-then-clear shape as Launcher.qml's own launcherPrefill
     // consumption.
-    onVisibleChanged: {
-        if (visible && screenState.settingsCategory !== "") {
-            settingsPanel.currentCategory = screenState.settingsCategory;
-            screenState.settingsCategory = "";
+    //
+    // Watched on both edges. SettingsItem sets the category and only then
+    // opens Settings, so a hit with the panel closed arrives as the
+    // visibility change; a second hit with the panel already open never
+    // changes `visible` at all and used to be dropped silently. Clearing
+    // the category re-enters the handler, which the empty check ends.
+    function consumeRequestedCategory(): void {
+        if (!root.visible || root.screenState.settingsCategory === "")
+            return;
+        settingsPanel.currentCategory = root.screenState.settingsCategory;
+        root.screenState.settingsCategory = "";
+    }
+
+    onVisibleChanged: root.consumeRequestedCategory()
+
+    Connections {
+        target: root.screenState
+
+        function onSettingsCategoryChanged(): void {
+            root.consumeRequestedCategory();
         }
     }
 


### PR DESCRIPTION
Two correctness follow-ups the fixed rail and docked sections (#104) left behind. Core-only, no plugin or manifest changes.

## 1. A jump-to-category was dropped when Settings was already open

`SettingsWindow` consumed `ScreenState.settingsCategory` from `onVisibleChanged` alone. `SettingsItem.execute()` sets the category *then* opens Settings, so that path works from closed — but a second search hit while Settings is open never changes `visible`, and the jump was silently discarded.

Now consumed on the category's own change too. Clearing it re-enters the handler, which the empty check terminates. Each screen owns its own `ScreenState` (`shell.qml`'s `screenStateFor`), so there is no cross-monitor race on the one-shot value.

## 2. Three panes' centring depended on their category owning no sections

`paneLoader` stretched to the viewport only while `root.sections.length === 0`:

```qml
Layout.preferredHeight: {
    const natural = paneLoader.item?.implicitHeight ?? 0;
    return root.sections.length > 0 ? natural : Math.max(paneFlick.height, natural);
}
```

`AboutPane`, `LauncherPane` and `AppearancePane` centre/distribute with their own `Layout.fillHeight` spacers and depend on that stretch. The first plugin to dock a section into any of those categories would have collapsed their layout — and that is reachable today, not hypothetical: `parent` is a free-form category id in the manifest, resolved against whatever categories exist.

`paneColumn` now takes the viewport's slack and `paneLoader` (its only `fillHeight` child) absorbs whatever the sections leave. **This is identical to the old behaviour wherever it currently works** — with no sections the Loader still gets the full viewport — and differs only in the case that was broken.

## Deliberately not done: splitting the `currentCategory` address

The plan called for a `screenState.settingsSection` property to replace the untyped `"<category>/<section>"` string. I read it and think that would make things worse, so I left it alone rather than churn it.

The address is load-bearing by design: `SettingsCategories.searchIndex` hands the launcher `"<category>/<section>"` *as the entry's id*, and that same string flows through the `ScreenState` handoff untouched (documented at `SettingsPanel.qml:33`). Splitting it means two one-shot values to keep in sync across a handoff instead of one, plus a second id shape in `searchIndex` — more coupling, not less, for a string that is parsed in exactly one place.

Happy to do it if you disagree; it's a small change either way.

## Also assessed, no change needed

`AiPane`'s 5s Ollama poll is already demand-gated (`running: ollamaModelsSection.visible`), so collapsing the section already stops it. The pane's size (1101 lines) is a real extraction candidate but a refactor rather than a correctness fix, so it stays out of this PR.

## Verification

Loaded `SettingsPanel` headlessly (`qs -p` probe) and cycled all sixteen categories plus the `"ai/agentGraph"` address form. Compiles, instantiates, and cycles clean. No new binding loops: the nineteen `ColorPickerField` loops in `ThemeCreatorPane.qml` (lines 243/267/291) reproduce **identically on the unmodified branch** — pre-existing, and worth their own fix.

Layout changes want your eyes rather than mine — specifically About/Launcher/Appearance centring, and the AI category (which has real docked sections) scrolling to its first section header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wgqq93t8xbD9rN8MHd9qKN