### PR TITLE
dev: environment drift as the layer's own baseline

### DIFF
--- a/Configs/quickshell/aphotic/services/profile/DevDrift.qml
+++ b/Configs/quickshell/aphotic/services/profile/DevDrift.qml
@@ -1,0 +1,151 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+
+// Environment drift for the open project (APHOTIC_UNIFIED_VISION.md
+// §3.3): passive, informational, never acted on.
+//
+// Core, not a plugin, and hardcoded to InstallProfile.devEnabled -- this
+// is the `dev` layer's own baseline, the same call GamingProfile went the
+// other way on. It stays core specifically so the Dev notch tile and any
+// later Dev surface read one answer instead of one plugin depending on
+// another, which the layer model forbids outright.
+//
+// Not demand-gated the way AgentEvents is: there is no tail to hold open.
+// A scan is one `stat` per project open and nothing runs between them.
+//
+// Deliberately narrow. A lockfile older than the manifest it locks is a
+// fact readable from mtimes alone -- no project tooling is executed, no
+// daemon is started, and nothing here can be wrong about a version it
+// never parsed. Reading declared toolchain versions (mise, containers)
+// means running the toolchain, which needs binaries no base install has.
+Singleton {
+    id: root
+
+    readonly property bool enabled: InstallProfile.devEnabled
+
+    // [{ manifest, lock }] -- the manifest is newer than the lockfile that
+    // should have been regenerated from it.
+    readonly property var findings: root._findings
+    readonly property bool detected: root._findings.length > 0
+
+    readonly property string summary: {
+        if (root._findings.length === 0)
+            return "";
+        if (root._findings.length === 1)
+            return qsTr("%1 is newer than %2").arg(root._findings[0].manifest).arg(root._findings[0].lock);
+        return qsTr("%n lockfile(s) older than their manifest", "", root._findings.length);
+    }
+
+    readonly property var _pairs: [
+        {
+            manifest: "package.json",
+            locks: ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb"]
+        },
+        {
+            manifest: "Cargo.toml",
+            locks: ["Cargo.lock"]
+        },
+        {
+            manifest: "pyproject.toml",
+            locks: ["poetry.lock", "uv.lock", "pdm.lock"]
+        },
+        {
+            manifest: "go.mod",
+            locks: ["go.sum"]
+        },
+        {
+            manifest: "Gemfile",
+            locks: ["Gemfile.lock"]
+        },
+        {
+            manifest: "composer.json",
+            locks: ["composer.lock"]
+        }
+    ]
+
+    property var _findings: []
+    property string _scanned: ""
+
+    function _scan(path: string): void {
+        root._findings = [];
+        root._scanned = path;
+
+        if (!root.enabled || path === "")
+            return;
+
+        const names = [];
+        for (const pair of root._pairs) {
+            names.push(pair.manifest);
+            for (const lock of pair.locks)
+                names.push(lock);
+        }
+
+        const base = path.replace(/\/+$/, "");
+        // %n back, not just %Y: stat skips what does not exist, so the
+        // reply is only aligned with the request if each line names itself.
+        statProc.command = ["stat", "-c", "%n %Y", "--"].concat(names.map(n => `${base}/${n}`));
+        statProc.running = true;
+    }
+
+    function _apply(text: string): void {
+        const mtimes = {};
+        for (const line of text.split("\n")) {
+            const cut = line.lastIndexOf(" ");
+            if (cut < 0)
+                continue;
+            const epoch = parseInt(line.slice(cut + 1), 10);
+            if (!isNaN(epoch))
+                mtimes[line.slice(0, cut).split("/").pop()] = epoch;
+        }
+
+        const found = [];
+        for (const pair of root._pairs) {
+            const manifest = mtimes[pair.manifest];
+            if (manifest === undefined)
+                continue;
+
+            // A manifest with no lockfile at all is an unbuilt project, not
+            // drift -- reporting it would badge the notch on every fresh
+            // clone.
+            let newest = -1;
+            let newestName = "";
+            for (const lock of pair.locks) {
+                if (mtimes[lock] !== undefined && mtimes[lock] > newest) {
+                    newest = mtimes[lock];
+                    newestName = lock;
+                }
+            }
+            if (newest >= 0 && manifest > newest)
+                found.push({
+                    manifest: pair.manifest,
+                    lock: newestName
+                });
+        }
+        root._findings = found;
+    }
+
+    onEnabledChanged: root._scan(root.enabled ? DevProfile.activeProjectPath : "")
+
+    Connections {
+        target: DevProfile
+
+        function onActiveProjectPathChanged(): void {
+            root._scan(DevProfile.activeProjectPath);
+        }
+    }
+
+    Process {
+        id: statProc
+
+        // Missing paths make stat exit non-zero after printing every path
+        // that did exist, so stdout is read regardless of exit status.
+        stdout: StdioCollector {
+            onStreamFinished: root._apply(text)
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/profile/qmldir
+++ b/Configs/quickshell/aphotic/services/profile/qmldir
@@ -1,4 +1,5 @@
 module qs.services.profile
+singleton DevDrift 1.0 DevDrift.qml
 singleton DevProfile 1.0 DevProfile.qml
 singleton ProfileEngine 1.0 ProfileEngine.qml
 singleton ProfileEvents 1.0 ProfileEvents.qml


### PR DESCRIPTION
Fills in the Dev pillar's first real behaviour. Pairs with **aphotic-plugins#10**.

## The layer question this forced

`DevNotchTile.qml` shipped with `readonly property bool driftDetected: false` and a comment reserving it for Phase 2. Filling it in is not a free choice, because `env-drift-detector` as its own `dev` plugin would make the notch tile depend on a sibling plugin's installed state — the one thing §2 of the layer model forbids outright.

Per your call: **drift is a `dev` baseline in core**, hardcoded to `InstallProfile.devEnabled` beside `DevProfile` — the call `GamingProfile` went the other way on (PLG-03). The tile and any later Dev surface read one answer, and no plugin has to exist for the `dev` layer to detect anything.

## What it actually detects

A lockfile older than the manifest it locks, across six ecosystems (npm/yarn/pnpm/bun, Cargo, poetry/uv/pdm, Go, Bundler, Composer).

That scope is the point, not a placeholder. It is a fact readable from mtimes alone, so `DevDrift` **executes no project tooling, starts no daemon, and cannot be wrong about a version it never parsed**. Reading declared toolchain versions (mise, containers) means *running* the toolchain — which needs binaries no base install carries, and pulling those into `profiles/base/*` for a dev-layer feature is precisely the trade the hard rule about shelled-out binaries exists to prevent. `stat` is coreutils, already treated as guaranteed at `HostInfo.qml:19`.

Two judgment calls worth your eye:

- **A manifest with no lockfile at all is an unbuilt project, not drift.** Otherwise every fresh clone badges the notch.
- **Not demand-gated the way `AgentEvents` is.** A scan is one `stat` per project open with nothing running between them, so there is no tail to `hold()`. The consequence is real and worth knowing: drift is answered as of the last project open — editing a manifest in place does not re-badge until the project is reopened. Watching the manifests would mean inotify on ~22 paths per project, which felt like the wrong trade for a passive advisory; say the word if you want it.

## Verification

Headless probe against four fixtures:

| fixture | result |
|---|---|
| `package.json` newer than `package-lock.json` | `detected=true`, names the pair |
| `Cargo.lock` newer than `Cargo.toml` | `detected=false` |
| `pyproject.toml`, no lockfile | `detected=false` (unbuilt guard) |
| Go drifted + Bundler clean | reports **only** `go.mod`/`go.sum` |

Then end-to-end with the real plugin tile symlinked in: compiles, instantiates, and `attention` goes true off this state — so the collapsed notch pill badges.

## Note for whoever merges `dev-opt-in-phase1` → `main`

#105 adds a hosted-surface/capability gate to `main` so the catalogue stops offering plugins this shell cannot mount. That merge **must** grow `APHOTIC_PLUGIN_HOSTED_SURFACES` to `"dashboard notch settings"` and add `profile` to `APHOTIC_PLUGIN_HOSTED_CAPABILITIES`, or the gate will refuse the very plugins the merge makes work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wgqq93t8xbD9rN8MHd9qKN