### PR TITLE
plugin: let a plugin contribute a CLI command (C-15)

### DIFF
--- a/Configs/.local/bin/aphotic
+++ b/Configs/.local/bin/aphotic
@@ -41,9 +41,11 @@ fi
 
 _aphotic_list_commands() {
     [[ -d "$COMMANDS_DIR" ]] || return 0
-    find "$COMMANDS_DIR" -maxdepth 1 -type f -name 'cmd_*.sh' -exec basename {} \; \
-        | sed -e 's/^cmd_//' -e 's/\.sh$//' \
-        | sort
+    {
+        find "$COMMANDS_DIR" -maxdepth 1 -type f -name 'cmd_*.sh' -exec basename {} \; \
+            | sed -e 's/^cmd_//' -e 's/\.sh$//'
+        aphotic_plugin_cli_top_level | cut -f1
+    } | sort -u
 }
 
 # Built entirely from each command file's `@cmd`/`@cmd.desc`/`@cmd.group`
@@ -88,6 +90,16 @@ _aphotic_usage() {
         printf '%s%s%s\n%s\n\n' "$_B" "$g" "$_R" "${group_lines[$g]}"
     done
 
+    # Plugin-provided top-level commands, grouped apart from the built-ins
+    # so it stays obvious which ones vanish with an uninstall.
+    local pcmd psummary pplugin plines=""
+    while IFS=$'\t' read -r pcmd psummary pplugin; do
+        [[ -n "$pcmd" ]] || continue
+        ncmds=$((ncmds + 1))
+        plines+="${plines:+$'\n'}$(printf '    %s%-12s%s %s %s(%s)%s' "$_C" "$pcmd" "$_R" "$psummary" "$_D" "$pplugin" "$_R")"
+    done < <(aphotic_plugin_cli_top_level)
+    [[ -n "$plines" ]] && printf '%sPLUGINS%s\n%s\n\n' "$_B" "$_R" "$plines"
+
     printf 'Run %saphotic <command> --help%s for details on a specific command.\n' "$_C" "$_R"
     printf '%s%s command(s) discovered in %s%s\n\n' "$_D" "$ncmds" "$COMMANDS_DIR" "$_R"
 }
@@ -106,9 +118,19 @@ _aphotic_dispatch() {
             exit 1
         fi
     else
-        aphotic_err "unknown command '${cmd}'"
-        echo "Run 'aphotic --help' to see available commands." >&2
-        exit 127
+        # A plugin may own this command (capabilities = ["cli"], a [cli]
+        # block with no `subcommand`). Core files never name a plugin, so
+        # this asks which plugin declares the command rather than checking
+        # for any particular one. Core wins a collision by being tried
+        # first, so a plugin cannot shadow a built-in.
+        local hit
+        if hit="$(aphotic_plugin_cli_resolve "$cmd" "")"; then
+            aphotic_plugin_cli_run "${hit#*$'\t'}" "$@"
+        else
+            aphotic_err "unknown command '${cmd}'"
+            echo "Run 'aphotic --help' to see available commands." >&2
+            exit 127
+        fi
     fi
 }
 

--- a/Configs/.local/lib/aphotic/commands/cmd_ai.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_ai.sh
@@ -5,7 +5,6 @@
 # @cmd.group: AI
 # @cmd.opt: status         | Show reachability of Claude Code / Ollama, loaded models
 # @cmd.opt: profile <provider>[:<model>] | Switch the AI panel's active provider (ollama/claude/codex/gemini/chatgpt), optionally the ollama model
-# @cmd.opt: fit [n]        | Hardware-aware model recommendations via llmfit (default top 3)
 
 aphotic_cmd_ai() {
     local sub="${1:-}"; shift || true
@@ -79,51 +78,9 @@ aphotic_cmd_ai() {
             fi
             aphotic_ok "AI panel profile set to '${provider}'$([ -n "$model" ] && [ "$provider" == "ollama" ] && echo " (model: ${model})")"
             ;;
-        fit)
-            aphotic_require jq || return 1
-            if ! command -v llmfit >/dev/null 2>&1; then
-                aphotic_err "llmfit not found on PATH"
-                aphotic_log "install it via the 'ai' profile layer (./install.sh --with ai), or manually: curl -fsSL https://llmfit.axjns.dev/install.sh | sh"
-                return 1
-            fi
-
-            local limit="${1:-3}" out err rc=0
-            out="$(mktemp)"; err="$(mktemp)"
-            llmfit recommend --json --limit "$limit" >"$out" 2>"$err" || rc=$?
-
-            if [[ -s "$err" ]]; then
-                aphotic_warn "llmfit reported:"
-                sed 's/^/  /' "$err" >&2
-            fi
-
-            if [[ "$rc" -ne 0 ]] || ! jq empty "$out" >/dev/null 2>&1; then
-                aphotic_err "llmfit failed to detect hardware or produce valid JSON (exit ${rc})"
-                rm -f "$out" "$err"
-                return 1
-            fi
-
-            echo "Hardware detected:"
-            jq -r '.system |
-                "  CPU:  \(.cpu_name) (\(.cpu_cores) cores)",
-                "  RAM:  \(.available_ram_gb) / \(.total_ram_gb) GB available",
-                (if .has_gpu then "  GPU:  \(.gpu_name) (\(.gpu_vram_gb) GB, \(.backend))" else "  GPU:  none detected" end)
-            ' "$out"
-            echo
-            echo "Top recommendations:"
-            if [[ "$(jq '.models | length' "$out")" -eq 0 ]]; then
-                echo "  (no models meet the minimum fit threshold on this hardware)"
-            else
-                jq -r '.models | to_entries[] |
-                    "  \(.key + 1). \(.value.name) (\(.value.provider)) -- \(.value.fit_level) fit, \(.value.best_quant), ~\(.value.estimated_tps) tok/s",
-                    "     \(.value.parameter_count) params, \(.value.context_length) ctx, score \(.value.score)/100"
-                ' "$out"
-            fi
-
-            rm -f "$out" "$err"
-            ;;
         ""|-h|--help)
             cat <<HELP
-Usage: aphotic ai <status|profile|fit> [args]
+Usage: aphotic ai <status|profile|...> [args]
 
   status                     Show Claude Code / Ollama reachability and loaded models
   profile <provider>[:<model>]
@@ -131,10 +88,26 @@ Usage: aphotic ai <status|profile|fit> [args]
                              (ollama, claude, codex, gemini, chatgpt) --
                              optionally set the model too (ollama only,
                              e.g. 'ollama:llama3.1:8b')
-  fit [n]                    Hardware-aware model recommendations via llmfit (default top 3)
 HELP
+            # Whatever plugins have added to `ai`. Printed from their own
+            # manifests, so this help stays correct as they come and go
+            # without naming any of them.
+            aphotic_plugin_cli_help ai
             ;;
         *)
+            # A plugin may provide this subcommand (capabilities = ["cli"],
+            # [cli] command = "ai"). Resolved by declaration, so no plugin
+            # id appears in this file and a subcommand disappears with the
+            # plugin that owns it.
+            #
+            # Resolved before running rather than treating a failure as
+            # "no such subcommand": a plugin command that legitimately
+            # exits non-zero must not be reported as missing.
+            local hit
+            if hit="$(aphotic_plugin_cli_resolve ai "$sub")"; then
+                aphotic_plugin_cli_run "${hit#*$'\t'}" "$@"
+                return $?
+            fi
             aphotic_err "unknown ai subcommand: ${sub}"
             return 1
             ;;

--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -132,6 +132,33 @@ _aphotic_plugin_profile_json() {
         '{id: $id, label: $label, component: $component, requires_layer: $requires_layer, requires_data: $requires_data, snapshot: $snapshot}'
 }
 
+# The `cli` capability (manifest v3.2). A plugin declaring one contributes
+# a command -- top-level (`aphotic foo`) or a subcommand of an existing one
+# (`aphotic ai fit`) -- which the dispatcher and the extended core command
+# resolve by declaration. Recorded here so `aphotic plugin list --json` can
+# report it and drift detection can see it change; the CLI path itself
+# reads the manifest directly through aphotic_plugin_cli_resolve, since a
+# command must work whether or not a registry sync has run.
+_aphotic_plugin_cli_json() {
+    local manifest="$1" command subcommand script summary
+    command="$(aphotic_toml_get "$manifest" cli command)"
+    script="$(aphotic_toml_get "$manifest" cli script)"
+    if [[ -z "$command" ]] || [[ -z "$script" ]]; then
+        echo 'null'
+        return 0
+    fi
+
+    subcommand="$(aphotic_toml_get "$manifest" cli subcommand)"
+    summary="$(aphotic_toml_get "$manifest" cli summary)"
+
+    jq -n \
+        --arg command "$command" \
+        --arg subcommand "${subcommand:-}" \
+        --arg script "$script" \
+        --arg summary "${summary:-}" \
+        '{command: $command, subcommand: $subcommand, script: $script, summary: $summary}'
+}
+
 _aphotic_plugin_describe() {
     local name="$1" dir manifest display desc version category caps enabled missing bin
     dir="$(_aphotic_plugin_dir "$name")"
@@ -165,7 +192,8 @@ _aphotic_plugin_describe() {
         --argjson owns "$(_aphotic_plugin_owns_json "$manifest")" \
         --argjson ui "$(_aphotic_plugin_ui_json "$manifest")" \
         --argjson profile "$(_aphotic_plugin_profile_json "$manifest")" \
-        '{name: $name, display_name: $display_name, description: $description, version: $version, category: $category, capabilities: $capabilities, enabled: $enabled, missing_binaries: $missing_binaries, owns: $owns, ui: $ui, profile: $profile}')"
+        --argjson cli "$(_aphotic_plugin_cli_json "$manifest")" \
+        '{name: $name, display_name: $display_name, description: $description, version: $version, category: $category, capabilities: $capabilities, enabled: $enabled, missing_binaries: $missing_binaries, owns: $owns, ui: $ui, profile: $profile, cli: $cli}')"
 
     # The registry entry the shell actually reads is written by
     # _aphotic_plugin_registry_sync out of these same four manifest
@@ -178,7 +206,7 @@ _aphotic_plugin_describe() {
     # second time is deliberate: a second description of that shape is the
     # class of bug the flag exists to catch.
     local stored expected drifted="false"
-    expected="$(jq -cS '{version, capabilities, owns, ui, profile}' <<<"$entry")"
+    expected="$(jq -cS '{version, capabilities, owns, ui, profile, cli}' <<<"$entry")"
     # Missing keys are filled with the same null a fresh sync would write
     # BEFORE comparing. Without this, every entry on disk reports drift the
     # moment the registry schema grows a field -- one did (`profile`,
@@ -186,7 +214,7 @@ _aphotic_plugin_describe() {
     # upgrade is noise that trains people to ignore the signal. A plugin
     # that genuinely gained a profile block still differs from null, so the
     # real case is unaffected.
-    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else {profile: null} + . end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
+    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else {profile: null, cli: null} + . end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
     [[ "$expected" != "$stored" ]] && drifted="true"
 
     jq --argjson drifted "$drifted" '. + {drifted: $drifted}' <<<"$entry"
@@ -476,7 +504,7 @@ _aphotic_plugin_install_deps() {
 # don't touch it, since aphotic_plugin_is_enabled already layers on top
 # via the same file's "disabled" array.
 _aphotic_plugin_registry_sync() {
-    local name="$1" dir manifest version caps owns ui profile tmp
+    local name="$1" dir manifest version caps owns ui profile cli tmp
     aphotic_require jq || return 1
     dir="$(_aphotic_plugin_dir "$name")"
     manifest="${dir}/plugin.toml"
@@ -487,6 +515,7 @@ _aphotic_plugin_registry_sync() {
     owns="$(_aphotic_plugin_owns_json "$manifest")"
     ui="$(_aphotic_plugin_ui_json "$manifest")"
     profile="$(_aphotic_plugin_profile_json "$manifest")"
+    cli="$(_aphotic_plugin_cli_json "$manifest")"
 
     [[ -f "$APHOTIC_PLUGINS_STATE_FILE" ]] || echo '{"disabled": []}' > "$APHOTIC_PLUGINS_STATE_FILE"
     tmp="$(mktemp)"
@@ -496,7 +525,8 @@ _aphotic_plugin_registry_sync() {
        --argjson owns "$owns" \
        --argjson ui "$ui" \
        --argjson profile "$profile" \
-       '.installed = ((.installed // {}) + {($n): {version: $version, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile}})' \
+       --argjson cli "$cli" \
+       '.installed = ((.installed // {}) + {($n): {version: $version, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile, cli: $cli}})' \
        "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp" && mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
 }
 

--- a/Configs/.local/lib/aphotic/globalcontrol.sh
+++ b/Configs/.local/lib/aphotic/globalcontrol.sh
@@ -258,6 +258,108 @@ aphotic_plugin_is_enabled() {
     ! jq -e --arg n "$name" '.disabled // [] | index($n) != null' "$APHOTIC_PLUGINS_STATE_FILE" >/dev/null 2>&1
 }
 
+# ---- plugin CLI extension (C-15) ------------------------------------------
+# A plugin can contribute a command, either top-level (`aphotic foo`) or as
+# a subcommand of an existing one (`aphotic ai fit`):
+#
+#   capabilities = ["cli"]
+#   [cli]
+#   command = "ai"
+#   subcommand = "fit"
+#   script = "cli/ai_fit.sh"
+#   summary = "one line, shown in that command's --help"
+#
+# Resolution is by declaration, never by name: core asks which plugin
+# provides `ai fit`, not whether some particular plugin is installed. That
+# is the whole point -- removing the plugin removes the subcommand, and no
+# core file names either. Omit `subcommand` for a top-level command.
+#
+# Prints "<plugin>\t<script path>" for the first enabled plugin whose [cli]
+# block matches, and fails if none does.
+aphotic_plugin_cli_resolve() {
+    local command="$1" subcommand="${2:-}"
+    local name dir manifest caps script
+
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        aphotic_plugin_is_enabled "$name" || continue
+
+        dir="${APHOTIC_PLUGINS_DIR}/${name}"
+        manifest="${dir}/plugin.toml"
+        caps="$(aphotic_toml_get_array "$manifest" plugin capabilities)"
+        grep -qx "cli" <<<"$caps" || continue
+
+        [[ "$(aphotic_toml_get "$manifest" cli command)" == "$command" ]] || continue
+        [[ "$(aphotic_toml_get "$manifest" cli subcommand)" == "$subcommand" ]] || continue
+
+        script="$(aphotic_toml_get "$manifest" cli script)"
+        [[ -n "$script" && -r "${dir}/${script}" ]] || continue
+
+        printf '%s\t%s\n' "$name" "${dir}/${script}"
+        return 0
+    done < <(aphotic_plugin_names)
+    return 1
+}
+
+# Run a resolved plugin command. Sourced in a subshell rather than
+# executed, so it gets the same helpers a core cmd_*.sh is sourced with
+# (aphotic_err, aphotic_require, the XDG paths) while the subshell keeps it
+# from leaking state back into the dispatcher.
+#
+# Callers resolve first and dispatch second rather than treating a failure
+# here as "no such command" -- otherwise a plugin command that legitimately
+# exits non-zero is indistinguishable from one that does not exist.
+aphotic_plugin_cli_run() {
+    local script="$1"; shift
+    ( source "$script" "$@" )
+}
+
+# "<name>\t<summary>\t<plugin>" per plugin-provided top-level command, so
+# `aphotic --help` lists them beside the built-ins instead of leaving them
+# discoverable only by already knowing the name.
+aphotic_plugin_cli_top_level() {
+    local name dir manifest caps cmd
+
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        aphotic_plugin_is_enabled "$name" || continue
+
+        dir="${APHOTIC_PLUGINS_DIR}/${name}"
+        manifest="${dir}/plugin.toml"
+        caps="$(aphotic_toml_get_array "$manifest" plugin capabilities)"
+        grep -qx "cli" <<<"$caps" || continue
+        [[ -z "$(aphotic_toml_get "$manifest" cli subcommand)" ]] || continue
+
+        cmd="$(aphotic_toml_get "$manifest" cli command)"
+        [[ -n "$cmd" ]] || continue
+        printf '%s\t%s\t%s\n' "$cmd" "$(aphotic_toml_get "$manifest" cli summary)" "$name"
+    done < <(aphotic_plugin_names)
+}
+
+# One "  <name>  <summary>" line per plugin-provided subcommand of
+# `command`, for a core command to append to its own --help. Prints
+# nothing when no plugin extends it.
+aphotic_plugin_cli_help() {
+    local command="$1"
+    local name dir manifest caps sub summary
+
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        aphotic_plugin_is_enabled "$name" || continue
+
+        dir="${APHOTIC_PLUGINS_DIR}/${name}"
+        manifest="${dir}/plugin.toml"
+        caps="$(aphotic_toml_get_array "$manifest" plugin capabilities)"
+        grep -qx "cli" <<<"$caps" || continue
+        [[ "$(aphotic_toml_get "$manifest" cli command)" == "$command" ]] || continue
+
+        sub="$(aphotic_toml_get "$manifest" cli subcommand)"
+        [[ -n "$sub" ]] || continue
+        summary="$(aphotic_toml_get "$manifest" cli summary)"
+        printf '  %-26s %s (from %s)\n' "$sub" "$summary" "$name"
+    done < <(aphotic_plugin_names)
+}
+
 aphotic_plugin_set_enabled() {
     local name="$1" enabled="$2" tmp
     aphotic_require jq || return 1

--- a/tests/test_plugin_cli_dispatch.sh
+++ b/tests/test_plugin_cli_dispatch.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# tests/test_plugin_cli_dispatch.sh
+# C-15: a plugin contributes a CLI command, either top-level or as a
+# subcommand of an existing core one, resolved by declaration so no core
+# file names a plugin. See docs/PLUGIN_LAYER_MODEL.md.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+APHOTIC="$ROOT/Configs/.local/bin/aphotic"
+
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+
+# --- a plugin extending an existing core command ----------------------
+
+SUBPLUG="$APHOTIC_PLUGINS_DIR/scratch-sub"
+mkdir -p "$SUBPLUG/cli"
+cat > "$SUBPLUG/plugin.toml" <<'EOF'
+[plugin]
+name = "scratch-sub"
+display_name = "Scratch Sub"
+version = "1.0.0"
+category = "ai"
+capabilities = ["cli"]
+
+[cli]
+command = "ai"
+subcommand = "scratchfit"
+script = "cli/ai_scratchfit.sh"
+summary = "scratch subcommand"
+EOF
+cat > "$SUBPLUG/cli/ai_scratchfit.sh" <<'EOF'
+echo "SCRATCHFIT args=$*"
+# Proves the sourced script gets core's helpers, not a bare environment.
+declare -F aphotic_err >/dev/null && echo "SCRATCHFIT helpers=yes"
+EOF
+
+# --- a plugin owning a top-level command ------------------------------
+
+TOPPLUG="$APHOTIC_PLUGINS_DIR/scratch-top"
+mkdir -p "$TOPPLUG/cli"
+cat > "$TOPPLUG/plugin.toml" <<'EOF'
+[plugin]
+name = "scratch-top"
+display_name = "Scratch Top"
+version = "1.0.0"
+category = "ai"
+capabilities = ["cli"]
+
+[cli]
+command = "scratchtop"
+script = "cli/top.sh"
+summary = "scratch top-level"
+EOF
+cat > "$TOPPLUG/cli/top.sh" <<'EOF'
+echo "SCRATCHTOP args=$*"
+EOF
+
+# --- resolution -------------------------------------------------------
+
+hit="$(aphotic_plugin_cli_resolve ai scratchfit)" \
+    || fail "expected to resolve 'ai scratchfit'"
+[[ "$hit" == "scratch-sub"$'\t'* ]] || fail "resolve should name the providing plugin, got '$hit'"
+
+aphotic_plugin_cli_resolve ai nosuchthing >/dev/null 2>&1 \
+    && fail "expected no resolution for an undeclared subcommand"
+
+# A top-level command must not answer as a subcommand of the same name,
+# nor the other way round -- the empty subcommand is part of the match.
+aphotic_plugin_cli_resolve scratchtop "" >/dev/null \
+    || fail "expected to resolve top-level 'scratchtop'"
+aphotic_plugin_cli_resolve ai scratchtop >/dev/null 2>&1 \
+    && fail "a top-level command must not resolve as an 'ai' subcommand"
+
+# --- dispatch through the real CLI ------------------------------------
+
+out="$("$APHOTIC" ai scratchfit 7 2>&1)" || fail "dispatch of 'ai scratchfit' failed: $out"
+[[ "$out" == *"SCRATCHFIT args=7"* ]] || fail "subcommand did not receive its args: $out"
+[[ "$out" == *"SCRATCHFIT helpers=yes"* ]] || fail "sourced command should see core helpers: $out"
+
+out="$("$APHOTIC" scratchtop a b 2>&1)" || fail "dispatch of top-level failed: $out"
+[[ "$out" == *"SCRATCHTOP args=a b"* ]] || fail "top-level command did not receive its args: $out"
+
+# --- a disabled plugin contributes nothing ----------------------------
+
+aphotic_plugin_set_enabled scratch-sub false
+aphotic_plugin_cli_resolve ai scratchfit >/dev/null 2>&1 \
+    && fail "a disabled plugin must not provide its command"
+"$APHOTIC" ai scratchfit >/dev/null 2>&1 \
+    && fail "expected 'ai scratchfit' to fail once its plugin is disabled"
+aphotic_plugin_set_enabled scratch-sub true
+
+# --- a failing plugin command is not reported as missing --------------
+# The reason resolution happens before execution: otherwise a command that
+# legitimately exits non-zero is indistinguishable from one that does not
+# exist, and the user is told the wrong thing.
+
+cat > "$SUBPLUG/cli/ai_scratchfit.sh" <<'EOF'
+aphotic_err "the command itself failed"
+return 3
+EOF
+set +e
+out="$("$APHOTIC" ai scratchfit 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -eq 3 ]] || fail "expected the plugin command's own exit status 3, got $rc"
+[[ "$out" != *"unknown ai subcommand"* ]] || fail "a failing command must not be reported as unknown: $out"
+
+# --- core wins a collision -------------------------------------------
+
+COLLIDE="$APHOTIC_PLUGINS_DIR/scratch-collide"
+mkdir -p "$COLLIDE/cli"
+cat > "$COLLIDE/plugin.toml" <<'EOF'
+[plugin]
+name = "scratch-collide"
+version = "1.0.0"
+capabilities = ["cli"]
+
+[cli]
+command = "ai"
+script = "cli/hijack.sh"
+summary = "should never run"
+EOF
+echo 'echo "HIJACKED"' > "$COLLIDE/cli/hijack.sh"
+
+out="$("$APHOTIC" ai --help 2>&1)" || true
+[[ "$out" != *"HIJACKED"* ]] || fail "a plugin must not shadow a core command"
+[[ "$out" == *"Usage: aphotic ai"* ]] || fail "core 'ai' help should still be what runs: $out"
+
+# --- help and discovery list plugin commands --------------------------
+
+[[ "$out" == *"scratchfit"* ]] || fail "core 'ai --help' should list plugin subcommands: $out"
+[[ "$out" == *"scratch-sub"* ]] || fail "help should attribute the subcommand to its plugin: $out"
+
+out="$("$APHOTIC" --help 2>&1)"
+[[ "$out" == *"scratchtop"* ]] || fail "top-level help should list plugin commands: $out"
+[[ "$out" == *"PLUGINS"* ]] || fail "top-level help should group plugin commands: $out"
+
+out="$("$APHOTIC" -s 2>&1)"
+[[ "$out" == *"scratchtop"* ]] || fail "'aphotic -s' should list plugin commands: $out"
+[[ "$(grep -c '^ai$' <<<"$out")" -eq 1 ]] || fail "'aphotic -s' should not duplicate a name core also owns"
+
+# --- core no longer carries the moved command -------------------------
+
+grep -q "llmfit" "$ROOT/Configs/.local/lib/aphotic/commands/cmd_ai.sh" \
+    && fail "cmd_ai.sh still references llmfit -- 'ai fit' should live in its plugin now"
+grep -rqi "llm-fit" "$ROOT/Configs/.local/" \
+    && fail "a core CLI file names a plugin id, which the layer model forbids"
+
+echo "PASS: plugin CLI dispatch (resolution, subcommand + top-level, disabled, failure vs missing, collision, help/discovery, core cleanup)"


### PR DESCRIPTION
Closes `C-15`. Pairs with **aphotic-plugins#11**, which moves `aphotic ai fit` into the plugin that owns the feature.

## The gap

Last wave shipped the Hardware Advisor as a plugin owning its Settings pane — while `aphotic ai fit` stayed behind in core's `cmd_ai.sh`, because nothing let a plugin contribute a command. Half a feature in each repo, and core carrying a wrapper around `llmfit`, a binary Aphotic does not bundle and cannot install.

## The capability

```toml
capabilities = ["cli"]

[cli]
command = "ai"
subcommand = "fit"        # omit for a top-level command
script = "cli/ai_fit.sh"
summary = "shown in that command's --help"
```

Core **resolves by declaration, never by name** — it asks which plugin provides `ai fit`, not whether a particular plugin is installed. So no core file names a plugin, and the subcommand leaves with its owner. `cmd_ai.sh` loses the `llmfit` branch entirely and gains a generic fallthrough; `aphotic ai --help` prints whatever plugins have added, from their own manifests.

## Three details that go wrong if done the obvious way

**Resolution happens before execution, not as a failure fallback.** Treating a non-zero exit as "no such subcommand" makes a command that legitimately fails indistinguishable from one that does not exist. The test pins this: a plugin command returning 3 must surface as 3, never as `unknown ai subcommand`.

**The script is sourced in a subshell, not executed.** It gets the same helpers a core `cmd_*.sh` is sourced with (`aphotic_err`, `aphotic_require`, the XDG paths), while the subshell stops it leaking state back into the dispatcher. Plugin commands use `return`, not `exit`.

**Core is tried first**, so a plugin cannot shadow a built-in — also pinned by a test that installs a plugin claiming `command = "ai"` and asserts core's `ai` still runs.

The registry records `cli` alongside `ui`/`profile` for `list --json` and drift, but the CLI path reads manifests directly: a command must work whether or not a sync has run.

## Verification

`tests/test_plugin_cli_dispatch.sh` — resolution (subcommand and top-level, and that neither answers as the other), dispatch with argument passing, helpers present in the sourced script, a disabled plugin contributing nothing, failure-vs-missing, core winning a collision, help/discovery listing, and a grep asserting no core CLI file contains a plugin id.

End-to-end against the real plugin: `llmfit` is installed on this machine, so `aphotic ai fit` ran for real from `llm-fit` — full hardware detection and recommendations, exit 0, output identical to the core version it replaces, with `cmd_ai.sh` knowing nothing about it. `aphotic ai --help` lists `fit ... (from llm-fit)`.

Full suite green: 28 shell + 5 python.

## Follow-on this unblocks

`D-05` (third-party QML panes) lists `C-15` as its dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wgqq93t8xbD9rN8MHd9qKN