### PR TITLE
plugin: let a plugin contribute a chat provider (PLG-01a)

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -39,7 +39,7 @@ _aphotic_plugin_dir() { printf '%s/%s' "$APHOTIC_PLUGINS_DIR" "$1"; }
 # surface silently dropped is the failure this exists to catch.
 # ---------------------------------------------------------------------
 APHOTIC_PLUGIN_HOSTED_SURFACES="dashboard notch settings"
-APHOTIC_PLUGIN_HOSTED_CAPABILITIES="ui-surface theme-hook project-hook workspace-hook harness-hook profile cli"
+APHOTIC_PLUGIN_HOSTED_CAPABILITIES="ui-surface theme-hook project-hook workspace-hook harness-hook profile cli chat-provider"
 
 # Exact word match against a space-separated list. Not `grep -w`: grep
 # counts `-` as a word boundary, so `-w profile` matches "profile-hook"
@@ -267,6 +267,45 @@ _aphotic_plugin_cli_json() {
         '{command: $command, subcommand: $subcommand, script: $script, summary: $summary}'
 }
 
+# The `chat-provider` capability (manifest v3.3). A plugin declaring one
+# contributes a pill to the AI chat provider list. Core keeps owning the
+# transport -- a provider names a `backend` core already speaks, it does
+# not ship one -- so what a plugin adds is identity plus the two things
+# that make a backend answer as something specific: which model, and
+# which system prompt.
+#
+# Both of those are per-machine, resolved when the plugin installs (a
+# model pull picks a tag for this GPU; a rendered prompt names this
+# install's profile, layers and theme), so neither can be a static file in
+# the plugin tree. `state` names a JSON file under
+# ~/.config/aphotic/plugins/<plugin>/ that the plugin writes and the shell
+# watches: {"model": "...", "systemPrompt": "..."}. One file, so a
+# re-pull or a re-render is a single atomic write the shell picks up live
+# rather than a snapshot that goes stale.
+_aphotic_plugin_chat_provider_json() {
+    local manifest="$1" id label backend state layer data
+    id="$(aphotic_toml_get "$manifest" chat_provider id)"
+    backend="$(aphotic_toml_get "$manifest" chat_provider backend)"
+    if [[ -z "$id" ]] || [[ -z "$backend" ]]; then
+        echo 'null'
+        return 0
+    fi
+
+    label="$(aphotic_toml_get "$manifest" chat_provider label)"
+    state="$(aphotic_toml_get "$manifest" chat_provider state)"
+    layer="$(aphotic_toml_get "$manifest" chat_provider requires_layer)"
+    data="$(aphotic_toml_get "$manifest" chat_provider requires_data)"
+
+    jq -n \
+        --arg id "$id" \
+        --arg label "${label:-$id}" \
+        --arg backend "$backend" \
+        --arg state "${state:-provider.json}" \
+        --arg requires_layer "${layer:-}" \
+        --arg requires_data "${data:-}" \
+        '{id: $id, label: $label, backend: $backend, state: $state, requires_layer: $requires_layer, requires_data: $requires_data}'
+}
+
 _aphotic_plugin_describe() {
     local name="$1" dir manifest display desc version category caps enabled missing bin
     dir="$(_aphotic_plugin_dir "$name")"
@@ -301,7 +340,8 @@ _aphotic_plugin_describe() {
         --argjson ui "$(_aphotic_plugin_ui_json "$manifest")" \
         --argjson profile "$(_aphotic_plugin_profile_json "$manifest")" \
         --argjson cli "$(_aphotic_plugin_cli_json "$manifest")" \
-        '{name: $name, display_name: $display_name, description: $description, version: $version, category: $category, capabilities: $capabilities, enabled: $enabled, missing_binaries: $missing_binaries, owns: $owns, ui: $ui, profile: $profile, cli: $cli}')"
+        --argjson chat_provider "$(_aphotic_plugin_chat_provider_json "$manifest")" \
+        '{name: $name, display_name: $display_name, description: $description, version: $version, category: $category, capabilities: $capabilities, enabled: $enabled, missing_binaries: $missing_binaries, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider}')"
 
     # The registry entry the shell actually reads is written by
     # _aphotic_plugin_registry_sync out of these same four manifest
@@ -314,7 +354,7 @@ _aphotic_plugin_describe() {
     # second time is deliberate: a second description of that shape is the
     # class of bug the flag exists to catch.
     local stored expected drifted="false"
-    expected="$(jq -cS '{version, capabilities, owns, ui, profile, cli}' <<<"$entry")"
+    expected="$(jq -cS '{version, capabilities, owns, ui, profile, cli, chat_provider}' <<<"$entry")"
     # Missing keys are filled with the same null a fresh sync would write
     # BEFORE comparing. Without this, every entry on disk reports drift the
     # moment the registry schema grows a field -- one did (`profile`,
@@ -322,7 +362,7 @@ _aphotic_plugin_describe() {
     # upgrade is noise that trains people to ignore the signal. A plugin
     # that genuinely gained a profile block still differs from null, so the
     # real case is unaffected.
-    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else {profile: null, cli: null} + . end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
+    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else {profile: null, cli: null, chat_provider: null} + . end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
     [[ "$expected" != "$stored" ]] && drifted="true"
 
     jq --argjson drifted "$drifted" '. + {drifted: $drifted}' <<<"$entry"
@@ -630,7 +670,7 @@ _aphotic_plugin_install_deps() {
 # don't touch it, since aphotic_plugin_is_enabled already layers on top
 # via the same file's "disabled" array.
 _aphotic_plugin_registry_sync() {
-    local name="$1" dir manifest version caps owns ui profile cli tmp
+    local name="$1" dir manifest version caps owns ui profile cli chat_provider tmp
     aphotic_require jq || return 1
     dir="$(_aphotic_plugin_dir "$name")"
     manifest="${dir}/plugin.toml"
@@ -642,6 +682,7 @@ _aphotic_plugin_registry_sync() {
     ui="$(_aphotic_plugin_ui_json "$manifest")"
     profile="$(_aphotic_plugin_profile_json "$manifest")"
     cli="$(_aphotic_plugin_cli_json "$manifest")"
+    chat_provider="$(_aphotic_plugin_chat_provider_json "$manifest")"
 
     [[ -f "$APHOTIC_PLUGINS_STATE_FILE" ]] || echo '{"disabled": []}' > "$APHOTIC_PLUGINS_STATE_FILE"
     tmp="$(mktemp)"
@@ -652,7 +693,8 @@ _aphotic_plugin_registry_sync() {
        --argjson ui "$ui" \
        --argjson profile "$profile" \
        --argjson cli "$cli" \
-       '.installed = ((.installed // {}) + {($n): {version: $version, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile, cli: $cli}})' \
+       --argjson chat_provider "$chat_provider" \
+       '.installed = ((.installed // {}) + {($n): {version: $version, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider}})' \
        "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp" && mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
 }
 

--- a/Configs/quickshell/aphotic/modules/intelligence/IntelligenceInput.qml
+++ b/Configs/quickshell/aphotic/modules/intelligence/IntelligenceInput.qml
@@ -38,23 +38,10 @@ ColumnLayout {
     }
 
     StyledText {
-        visible: !root.ollamaHostMissing && !root.providerAvailable && root.effectiveProvider === "claude"
+        visible: !root.ollamaHostMissing && !root.providerAvailable
         Layout.fillWidth: true
         wrapMode: Text.Wrap
-        // Claude doesn't need an API key (see AiProviders.claudeAvailable's
-        // comment) -- a real login-session check instead, so this warning
-        // needs its own accurate text rather than the generic "set an env
-        // var" one below, which would be actively wrong for this provider.
-        text: !AiProviders.claudeCliPresent ? qsTr("⚠ The claude CLI isn't installed.") : qsTr("⚠ Not logged in to Claude. Run `claude login` in a terminal, then refresh.")
-        color: Colours.palette.m3error
-        font: Tokens.font.label.small
-    }
-
-    StyledText {
-        visible: !root.ollamaHostMissing && !root.providerAvailable && root.effectiveProvider !== "claude"
-        Layout.fillWidth: true
-        wrapMode: Text.Wrap
-        text: qsTr("⚠ No API key configured for %1. Set %2 to enable.").arg(AiProviders.providers.find(p => p.id === root.effectiveProvider)?.label ?? root.effectiveProvider).arg(AiProviders.requiredEnvVar(root.effectiveProvider))
+        text: `⚠ ${AiProviders.unavailableReason(root.effectiveProvider)}`
         color: Colours.palette.m3error
         font: Tokens.font.label.small
     }

--- a/Configs/quickshell/aphotic/services/PluginRegistry.qml
+++ b/Configs/quickshell/aphotic/services/PluginRegistry.qml
@@ -101,6 +101,40 @@ Singleton {
         return profiles;
     }
 
+    // Plugins that contribute a pill to the AI chat provider list -- the
+    // `chat-provider` capability. Core keeps owning every transport: a
+    // registration names a backend the shell already speaks and supplies
+    // only what makes that backend answer as something specific, so a
+    // plugin can add a provider without shipping one.
+    //
+    // `statePath` is where the plugin writes {model, systemPrompt}. It is
+    // resolved here rather than in AiProviders because this is already the
+    // one place that turns a manifest's relative paths into absolute ones,
+    // and a second resolver would be a second answer to where a plugin's
+    // files live.
+    readonly property var chatProviderRegistrations: {
+        const providers = [];
+        for (const name of Object.keys(root._installed)) {
+            if (!root.isEnabled(name))
+                continue;
+            const provider = root._installed[name]?.chat_provider;
+            if (!provider || !provider.id || !provider.backend)
+                continue;
+            const entry = {
+                plugin: name,
+                id: provider.id,
+                label: provider.label || provider.id,
+                backend: provider.backend,
+                requiresLayer: provider.requires_layer ?? "",
+                requiresData: provider.requires_data ?? "",
+                statePath: `${Quickshell.env("HOME")}/.config/aphotic/plugins/${name}/${provider.state || "provider.json"}`
+            };
+            if (root._gateSatisfied(entry))
+                providers.push(entry);
+        }
+        return providers;
+    }
+
     // A pre-`ui.surfaces` registry entry (written by a CLI older than the
     // surface unification) still carries a bare `dashboard_tab` object.
     // Reading it as one ungated dashboard surface keeps an install that

--- a/Configs/quickshell/aphotic/services/ai/AiProviders.qml
+++ b/Configs/quickshell/aphotic/services/ai/AiProviders.qml
@@ -49,7 +49,63 @@ Singleton {
     // served through Ollama, so turning the `ai` layer off has to take it
     // with everything else locally-hosted, even on a machine where
     // assistant.sh had already pulled the weights.
-    readonly property var providers: InstallProfile.aiEnabled && AiConfig.assistantEnabled ? [{ id: "assistant", label: "Aphotic Assistant", requiresApiKey: false }].concat(root._chatProviders) : root._chatProviders
+    readonly property var _coreProviders: InstallProfile.aiEnabled && AiConfig.assistantEnabled ? [{ id: "assistant", label: "Aphotic Assistant", requiresApiKey: false }].concat(root._chatProviders) : root._chatProviders
+
+    // Plugin-contributed pills (the `chat-provider` capability), ahead of
+    // the core list because a provider someone installed on purpose is the
+    // one they mean. PluginRegistry has already applied each one's gate,
+    // so anything reaching here is installed, enabled and unlocked; a
+    // backend this shell does not speak is dropped, same fail-closed rule
+    // as an unrecognised gate token.
+    readonly property var _pluginProviders: PluginRegistry.chatProviderRegistrations
+        .filter(p => root._backendSpeaks(p.backend))
+        .map(p => ({ id: p.id, label: p.label, requiresApiKey: false, backend: p.backend, plugin: p.plugin }))
+
+    // The one list every chat surface reads. Plugin providers are part of
+    // it rather than a second list beside it -- two lists would mean every
+    // consumer choosing which one it meant, and choosing wrong somewhere.
+    readonly property var providers: root._pluginProviders.concat(root._coreProviders)
+
+    function _backendSpeaks(backend: string): bool {
+        return backend === "ollama";
+    }
+
+    function pluginProviderFor(id: string): var {
+        return root._pluginProviders.find(p => p.id === id) ?? null;
+    }
+
+    // {model, systemPrompt} per plugin provider id, read from the state
+    // file each plugin writes. Kept as one object reassigned wholesale --
+    // mutating it in place would leave every binding on it stale.
+    property var pluginProviderState: ({})
+
+    function _setPluginProviderState(id: string, raw: string): void {
+        const next = Object.assign({}, root.pluginProviderState);
+        if (raw.length === 0) {
+            delete next[id];
+        } else {
+            try {
+                const data = JSON.parse(raw);
+                next[id] = { model: data.model ?? "", systemPrompt: data.systemPrompt ?? "" };
+            } catch (e) {
+                delete next[id];
+            }
+        }
+        root.pluginProviderState = next;
+    }
+
+    Instantiator {
+        model: PluginRegistry.chatProviderRegistrations
+
+        delegate: FileView {
+            required property var modelData
+
+            path: modelData.statePath
+            watchChanges: true
+            onLoaded: root._setPluginProviderState(modelData.id, text())
+            onLoadFailed: error => root._setPluginProviderState(modelData.id, "")
+        }
+    }
 
     // A provider id saved before it stopped being offered (or one an
     // [agents.*] override has since turned off) must not leave the chat
@@ -424,6 +480,15 @@ Singleton {
     }
 
     function isAvailable(providerId: string): bool {
+        const plugin = root.pluginProviderFor(providerId);
+        if (plugin) {
+            // A pulled model is what makes the provider answerable, so an
+            // installed plugin that has not finished its own setup reads as
+            // unavailable rather than as a pill that errors on first send.
+            if ((root.pluginProviderState[providerId]?.model ?? "").length === 0)
+                return false;
+            return plugin.backend === "ollama" ? root.ollamaAvailable : false;
+        }
         switch (providerId) {
         case "ollama": return root.ollamaAvailable;
         case "assistant": return root.assistantAvailable;
@@ -447,6 +512,38 @@ Singleton {
         }
     }
 
+    // Why a provider is unavailable, in the user's words. One answer, because
+    // there were two call sites guessing separately and the fallback both fell
+    // back to -- "set an API key" -- is wrong for every provider that does not
+    // use one. That already misfired: an Assistant whose Ollama host was unset
+    // was told to set an API key, naming an empty env var, because the guess
+    // keyed off "not claude" rather than off what the provider actually needs.
+    function unavailableReason(providerId: string): string {
+        const label = root.providers.find(p => p.id === providerId)?.label ?? providerId;
+
+        const plugin = root.pluginProviderFor(providerId);
+        if (plugin) {
+            if ((root.pluginProviderState[providerId]?.model ?? "").length === 0)
+                return qsTr("%1 hasn't finished setting up — no model is configured for it yet.").arg(label);
+            return qsTr("No Ollama host configured. Set it in the model pill, or set OLLAMA_BASE_URL, to enable.");
+        }
+
+        switch (providerId) {
+        case "claude":
+            return !root.claudeCliPresent ? qsTr("The claude CLI isn't installed.") : qsTr("Not logged in to Claude. Run `claude login` in a terminal, then refresh.");
+        case "codex":
+            return !root.codexCliPresent ? qsTr("The codex CLI isn't installed.") : qsTr("Not logged in to Codex. Run `codex login` in a terminal, then refresh.");
+        case "ollama":
+        case "assistant":
+            return qsTr("No Ollama host configured. Set it in the model pill, or set OLLAMA_BASE_URL, to enable.");
+        }
+
+        const envVar = root.requiredEnvVar(providerId);
+        if (envVar.length === 0)
+            return qsTr("%1 isn't available on this machine.").arg(label);
+        return qsTr("No API key configured for %1. Set %2 to enable.").arg(label).arg(envVar);
+    }
+
     property bool busy: false
     property string activeRequestId: ""
 
@@ -464,25 +561,12 @@ Singleton {
         if (root.busy)
             return;
 
-        if ((provider === "ollama" || provider === "assistant") && !AiConfig.ollamaHostConfigured) {
+        if ((provider === "ollama" || provider === "assistant" || root.pluginProviderFor(provider)?.backend === "ollama") && !AiConfig.ollamaHostConfigured) {
             root.errorReceived(requestId, qsTr("No Ollama host configured. Set it in the model pill, or set OLLAMA_BASE_URL, to enable."));
             return;
         }
         if (!root.isAvailable(provider)) {
-            const label = root.providers.find(p => p.id === provider)?.label ?? provider;
-            if (provider === "claude") {
-                // Claude doesn't need a key at all (see claudeAvailable's
-                // comment above) -- the generic "set an env var" message
-                // below would be actively wrong here, since setting
-                // ANTHROPIC_API_KEY does nothing for this provider.
-                root.errorReceived(requestId, !root.claudeCliPresent ? qsTr("The claude CLI isn't installed.") : qsTr("Not logged in to Claude. Run `claude login` in a terminal, then refresh."));
-            } else if (provider === "codex") {
-                // Same reasoning as claude above -- see codexAvailable's
-                // comment for why this is unverified.
-                root.errorReceived(requestId, !root.codexCliPresent ? qsTr("The codex CLI isn't installed.") : qsTr("Not logged in to Codex. Run `codex login` in a terminal, then refresh."));
-            } else {
-                root.errorReceived(requestId, qsTr("No API key configured for %1. Set %2 to enable.").arg(label).arg(root.requiredEnvVar(provider)));
-            }
+            root.errorReceived(requestId, root.unavailableReason(provider));
             return;
         }
 
@@ -526,9 +610,16 @@ Singleton {
             // setup_assistant renders it, so a manually-set
             // assistantEnabled with no rendered file just behaves like
             // plain Ollama with no system message.
+            // Three shapes share this one Ollama call: plain Ollama, the
+            // core Assistant, and any plugin provider on the ollama
+            // backend. All a persona amounts to is a pinned model plus a
+            // fixed system prompt, which is why a plugin can contribute one
+            // without shipping a transport.
+            const pluginState = root.pluginProviderState[provider];
             const isAssistant = provider === "assistant";
-            const resolvedModel = isAssistant ? AiConfig.assistantModel : (model || AiConfig.ollamaModel);
-            const messages = isAssistant && root.assistantSystemPrompt.length > 0 ? [{ role: "system", content: root.assistantSystemPrompt }, { role: "user", content: text }] : [{ role: "user", content: text }];
+            const resolvedModel = pluginState ? pluginState.model : (isAssistant ? AiConfig.assistantModel : (model || AiConfig.ollamaModel));
+            const systemPrompt = pluginState ? pluginState.systemPrompt : (isAssistant ? root.assistantSystemPrompt : "");
+            const messages = systemPrompt.length > 0 ? [{ role: "system", content: systemPrompt }, { role: "user", content: text }] : [{ role: "user", content: text }];
             ollamaProc.command = ["curl", "-s", "-m", "30",
                 `${AiConfig.ollamaHost}/v1/chat/completions`,
                 "-H", "content-type: application/json",

--- a/tests/test_plugin_chat_provider.sh
+++ b/tests/test_plugin_chat_provider.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# tests/test_plugin_chat_provider.sh
+# Manifest v3.3's `chat-provider` capability: a plugin contributes a pill
+# to the AI chat provider list without shipping a transport. Covers the
+# manifest parse, the registry round-trip the shell reads, drift, and the
+# host gate. See docs/PLUGIN_LAYER_MODEL.md §3.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+COMMANDS_DIR="$ROOT/Configs/.local/lib/aphotic/commands"
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_plugin.sh"
+
+# --- manifest parse ----------------------------------------------------
+
+PLUGDIR="$APHOTIC_PLUGINS_DIR/scratch-provider"
+mkdir -p "$PLUGDIR"
+cat > "$PLUGDIR/plugin.toml" <<'EOF'
+[plugin]
+name = "scratch-provider"
+display_name = "Scratch Provider"
+description = "test chat-provider plugin"
+version = "1.0.0"
+category = "ai"
+capabilities = ["chat-provider"]
+
+[chat_provider]
+id = "scratchbot"
+label = "Scratch Bot"
+backend = "ollama"
+state = "provider.json"
+requires_layer = "ai"
+EOF
+
+cp="$(_aphotic_plugin_chat_provider_json "$PLUGDIR/plugin.toml")"
+[[ "$(jq -r '.id' <<<"$cp")" == "scratchbot" ]]      || fail "id not parsed: $cp"
+[[ "$(jq -r '.label' <<<"$cp")" == "Scratch Bot" ]]  || fail "label not parsed: $cp"
+[[ "$(jq -r '.backend' <<<"$cp")" == "ollama" ]]     || fail "backend not parsed: $cp"
+[[ "$(jq -r '.state' <<<"$cp")" == "provider.json" ]] || fail "state not parsed: $cp"
+[[ "$(jq -r '.requires_layer' <<<"$cp")" == "ai" ]]  || fail "gate not parsed: $cp"
+
+# `state` is what the shell watches for {model, systemPrompt}; a manifest
+# that omits it must still resolve to a path rather than to nothing, or
+# the provider would register and then never become answerable.
+cat > "$TESTHOME/nostate.toml" <<'EOF'
+[plugin]
+name = "x"
+[chat_provider]
+id = "y"
+backend = "ollama"
+EOF
+[[ "$(_aphotic_plugin_chat_provider_json "$TESTHOME/nostate.toml" | jq -r '.state')" == "provider.json" ]] \
+    || fail "expected 'state' to default to provider.json"
+# label defaults to the id rather than to empty -- an unlabelled pill is
+# a pill the user cannot identify.
+[[ "$(_aphotic_plugin_chat_provider_json "$TESTHOME/nostate.toml" | jq -r '.label')" == "y" ]] \
+    || fail "expected label to default to the id"
+
+# --- a partial declaration is null, not a half-registered provider -----
+
+for missing in 'id = "y"' 'backend = "ollama"'; do
+    printf '[plugin]\nname = "x"\n\n[chat_provider]\n%s\n' "$missing" > "$TESTHOME/partial.toml"
+    [[ "$(_aphotic_plugin_chat_provider_json "$TESTHOME/partial.toml")" == "null" ]] \
+        || fail "a [chat_provider] with only '$missing' should read as null"
+done
+
+# A manifest with no [chat_provider] at all must read as null, not error --
+# the same "optional field, no error" contract every other capability has.
+printf '[plugin]\nname = "old"\n' > "$TESTHOME/old.toml"
+[[ "$(_aphotic_plugin_chat_provider_json "$TESTHOME/old.toml")" == "null" ]] \
+    || fail "a manifest with no [chat_provider] should read as null"
+
+# --- registry round-trip: what the shell actually reads ----------------
+
+_aphotic_plugin_registry_sync scratch-provider || fail "registry sync failed"
+entry="$(jq -c '.installed["scratch-provider"].chat_provider' "$APHOTIC_PLUGINS_STATE_FILE")"
+[[ "$(jq -r '.id' <<<"$entry")" == "scratchbot" ]] \
+    || fail "registry did not record the provider: $entry"
+[[ "$(jq -r '.backend' <<<"$entry")" == "ollama" ]] \
+    || fail "registry did not record the backend: $entry"
+
+# --- drift ------------------------------------------------------------
+# The registry schema growing a field must not make every already-stored
+# entry report drift; a real edit to the manifest must.
+
+[[ "$(_aphotic_plugin_describe scratch-provider | jq -r '.drifted')" == "false" ]] \
+    || fail "a freshly synced plugin should not report drift"
+
+sed -i 's/^label = "Scratch Bot"/label = "Renamed Bot"/' "$PLUGDIR/plugin.toml"
+[[ "$(_aphotic_plugin_describe scratch-provider | jq -r '.drifted')" == "true" ]] \
+    || fail "editing [chat_provider] in place should report drift"
+sed -i 's/^label = "Renamed Bot"/label = "Scratch Bot"/' "$PLUGDIR/plugin.toml"
+
+# An entry stored before chat_provider existed has no such key. It must
+# fill with the same null a fresh sync writes, not read as drifted.
+tmp="$(mktemp)"
+jq '.installed["scratch-provider"] |= del(.chat_provider)' "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp"
+mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
+printf '[plugin]\nname = "scratch-provider"\ndisplay_name = "Scratch Provider"\nversion = "1.0.0"\ncategory = "ai"\ncapabilities = ["chat-provider"]\n' > "$PLUGDIR/plugin.toml"
+[[ "$(_aphotic_plugin_describe scratch-provider | jq -r '.drifted')" == "false" ]] \
+    || fail "a pre-chat_provider registry entry should fill with null, not report drift"
+
+# --- host gate --------------------------------------------------------
+
+_aphotic_plugin_in_list "chat-provider" "$APHOTIC_PLUGIN_HOSTED_CAPABILITIES" \
+    || fail "this build hosts chat-provider but the gate does not say so"
+[[ "$(_aphotic_plugin_host_verdict "chat-provider" "")" == "ok" ]] \
+    || fail "a chat-provider-only plugin should be ok on this build"
+
+echo "PASS: plugin chat-provider capability (manifest parse, defaults, partial declarations, registry round-trip, drift, host gate)"


### PR DESCRIPTION
First of three for `PLG-01` (extract the Aphotic Assistant into a plugin).
**Contract only — nothing moves yet**, so this is behaviour-preserving:
core still registers the Assistant exactly as it does today.

> Based on #109, not `main` — it needs the surface registry and the host
> gate, which currently live on different branches. Retarget to `main`
> once #109 lands.

## Why a new capability was needed

The Assistant is threaded through nine core files, and unlike Agent Graph
(a self-contained dashboard tab) it has **no surface kind to land in**:

- `AiProviders.qml:52` built `providers` by prepending a literal
  `{ id: "assistant", label: "Aphotic Assistant" }`.
- The send path branched on `provider === "assistant"` to swap in a system
  prompt.

A plugin can edit neither, so the extraction needs a contract before it
can start.

## The contract

```toml
capabilities = ["chat-provider"]

[chat_provider]
id = "assistant"
label = "Aphotic Assistant"
backend = "ollama"
state = "provider.json"
requires_layer = "ai"
```

**Core keeps owning every transport.** A registration names a `backend`
the shell already speaks and never ships one; an unrecognised backend is
dropped, the same fail-closed rule as an unknown gate token. What a plugin
adds is identity plus the two things that make a backend answer as
something specific: a model and a system prompt. That is the entire
content of a persona — which is why this needed no new transport code.
The Ollama branch of `sendMessage` already took a model and an optional
system message; it now resolves both off the registration rather than off
a hardcoded id.

**Why `state` is a file, not manifest fields.** Both values are
per-machine and resolved at install time — a model tag is picked against
this GPU, a rendered prompt names this install's profile, layers and
theme. A manifest is identical on every machine, so neither can live
there. The plugin writes one watched JSON file,
`{"model": …, "systemPrompt": …}`. One file rather than two means a
re-pull or a re-render is a single write picked up live, which also closes
the drift this feature has as core code: `render_assistant_prompt` writes
a snapshot at install time that nothing regenerates, so its claims about
theme go stale the first time the user switches theme.

Plugin pills go into `AiProviders.providers` **itself**, not a second list
beside it — all five existing consumers (`AiChatTab`, `AiPane`,
`IntelligenceHeader`, `IntelligenceInput`, `AiConfig`) pick them up with
no edit. A registered provider is not yet an available one: a plugin
mid-setup has no model and reads as unavailable, the same shape as Claude
showing while logged out.

## A live bug found on the way

Both the send path and `IntelligenceInput` guessed separately at why a
provider was unavailable, and the fallback they shared —
`"No API key configured for %1. Set %2 to enable."` — keyed off "not
claude, not codex" rather than off what the provider actually needs.

So an **Assistant with no Ollama host configured was told to set an API
key, naming an empty env var**, because `requiredEnvVar` has no case for
it. Reproducible today on `main`, independent of this feature. Both call
sites now ask `AiProviders.unavailableReason()`, which has one answer per
provider and a truthful default for the key-less ones.

## Verification

- Suite **35/35 green**, including `tests/test_plugin_chat_provider.sh`:
  manifest parse, `state`/`label` defaults, partial declarations reading
  as `null` rather than half-registering, the registry round-trip the
  shell reads, drift (both a real manifest edit *and* the schema-growth
  case that must **not** report drift), and the host gate.
- Driven under a scratch `HOME` with three registered providers, so the
  QML path is exercised rather than inferred:
  - the layer gate drops a `gaming`-gated provider on an `ai`-only install
    and restores it when the layer is switched on;
  - an unknown backend (`vllm`) is dropped;
  - missing / malformed / model-less / complete state files each resolve
    correctly, and only the last reads as available;
  - `unavailableReason` checked for every provider id including an
    unknown one.
- Headless probe (compile **and** `createObject`) on all six touched or
  adjacent QML files. The one `CREATE-FAIL` (`IntelligenceHeader`,
  `required property historyOpen`) reproduces identically on a pristine
  `origin/main` worktree.

## Next

- **B** — the plugin itself in `aphotic-plugins`.
- **C** — core deletion: `AiConfig`, `AiProviders`, `AiPane`, `AiChatTab`,
  `Settings.qml`, `install.sh`, `guided.sh`, `uninstall.sh`,
  `lib/install/assistant.sh`, `lib/ai/`.
