### PR TITLE
security: profile registrant for engagement mode

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_vpn.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_vpn.sh
@@ -31,6 +31,11 @@ APHOTIC_VPN_LOG_FILE="${APHOTIC_STATE_HOME}/vpn.log"
 # track a pidfile (root-written, would need care to keep readable) or grant
 # sudo a blanket `kill` scoped to nothing more specific than "any PID".
 APHOTIC_VPN_DAEMON_TAG="aphotic-vpn"
+# Written by vpn-hook.sh on tunnel up, removed on tunnel down. This is
+# what services/Vpn.qml watches, so the shell learns the state from
+# openvpn's own hooks instead of polling for the process.
+APHOTIC_VPN_MARKER_FILE="${APHOTIC_STATE_HOME}/vpn-connected"
+APHOTIC_VPN_HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/vpn-hook.sh"
 
 _aphotic_vpn_config_path() {
     [[ -f "$APHOTIC_VPN_SETTINGS_FILE" ]] || return 0
@@ -83,7 +88,19 @@ _aphotic_vpn_connect() {
         return 1
     fi
 
-    sudo openvpn --config "$config_path" --daemon "$APHOTIC_VPN_DAEMON_TAG" --log "$APHOTIC_VPN_LOG_FILE" &&
+    if [[ ! -x "$APHOTIC_VPN_HOOK" ]]; then
+        aphotic_warn "vpn hook missing or not executable at ${APHOTIC_VPN_HOOK}; the shell will not see the connection"
+    fi
+
+    # --script-security 2 is required before openvpn will run a user
+    # script at all; without it --up/--down are accepted and then never
+    # fire. --setenv carries the marker path into root's script
+    # environment, which is the only way the hook can know where the
+    # user's state dir is.
+    sudo openvpn --config "$config_path" --daemon "$APHOTIC_VPN_DAEMON_TAG" --log "$APHOTIC_VPN_LOG_FILE" \
+        --script-security 2 \
+        --setenv APHOTIC_VPN_MARKER "$APHOTIC_VPN_MARKER_FILE" \
+        --up "$APHOTIC_VPN_HOOK" --down "$APHOTIC_VPN_HOOK" &&
         aphotic_ok "connecting via $(basename "$config_path") (see ${APHOTIC_VPN_LOG_FILE})"
 }
 

--- a/Configs/.local/lib/aphotic/vpn-hook.sh
+++ b/Configs/.local/lib/aphotic/vpn-hook.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# lib/aphotic/vpn-hook.sh
+# openvpn's --up/--down hook, one file for both halves: openvpn puts
+# "up" or "down" in $script_type, and the two halves are a touch and an
+# rm of the same marker. Two scripts would just be the same branch split
+# across two files.
+#
+# The marker is how services/Vpn.qml knows the tunnel is up -- a FileView
+# watching this path, no poll of any kind. cmd_vpn.sh passes the path in
+# through openvpn's --setenv, because openvpn runs this as root with
+# root's environment: APHOTIC_STATE_HOME is not set here and $HOME is not
+# the user's. The fallback below only covers a hand-run invocation.
+#
+# 644 on the marker: openvpn runs this as root, the shell reading it runs
+# as the user.
+#
+# Never exits nonzero. openvpn treats a failing --up as fatal and tears
+# the tunnel down, so a status marker this script could not write must
+# not be able to kill a working connection.
+
+marker="${APHOTIC_VPN_MARKER:-}"
+if [[ -z "$marker" ]]; then
+    marker="${XDG_STATE_HOME:-${HOME:-/root}/.local/state}/aphotic/vpn-connected"
+fi
+
+case "${script_type:-}" in
+    up)
+        mkdir -p "$(dirname "$marker")" 2>/dev/null || true
+        touch "$marker" 2>/dev/null || true
+        chmod 644 "$marker" 2>/dev/null || true
+        ;;
+    down)
+        rm -f "$marker" 2>/dev/null || true
+        ;;
+esac
+
+exit 0

--- a/Configs/quickshell/aphotic/services/DoNotDisturb.qml
+++ b/Configs/quickshell/aphotic/services/DoNotDisturb.qml
@@ -15,6 +15,7 @@ Singleton {
     readonly property bool enabled: Settings.dndEnabled
     property bool _pomodoroForced: false
     property bool _gamingForced: false
+    property bool _securityForced: false
 
     // The Gaming profile's APPLY/RESTORE pair, following the same rule the
     // Pomodoro handler below documents: its own forced-tracking flag, never
@@ -29,6 +30,21 @@ Singleton {
         } else if (root._gamingForced) {
             Settings.dndEnabled = false;
             root._gamingForced = false;
+        }
+    }
+
+    // The Security profile's APPLY/RESTORE pair. Its own flag again, for
+    // the same reason: an engagement ending must not clear DND that
+    // Gaming, Pomodoro or the user is still holding.
+    function setSecurityActive(active: bool): void {
+        if (active) {
+            if (!Settings.dndEnabled) {
+                Settings.dndEnabled = true;
+                root._securityForced = true;
+            }
+        } else if (root._securityForced) {
+            Settings.dndEnabled = false;
+            root._securityForced = false;
         }
     }
 

--- a/Configs/quickshell/aphotic/services/Vpn.qml
+++ b/Configs/quickshell/aphotic/services/Vpn.qml
@@ -9,23 +9,25 @@ import Quickshell.Io
 // separate from Nmcli.qml's `vpnActive`, which reflects NetworkManager's
 // own VPN connection list, a different mechanism this doesn't touch.
 //
-// Status is read directly here (pgrep, same distinctive --daemon tag
-// cmd_vpn.sh uses, no sudo needed) rather than parsing `aphotic vpn
-// status`'s human-oriented colored output -- connect()/disconnect() are
-// the only two actions that actually need root, so those are the only
-// two that shell out to the CLI (keeps privileged process management in
-// bash, QML just reflects live state, per ROADMAP_FEATURES.md PART C).
+// Status is a marker file openvpn's own --up/--down hooks write
+// (lib/aphotic/vpn-hook.sh), watched here, so this singleton costs
+// nothing while idle. It used to be a 5s `pgrep` on a Timer, which ran
+// for the whole session whether or not a tunnel existed -- the same
+// zero-idle-cost rule the Gaming profile's dbus-monitor DETECT follows.
+// A missing marker is the disconnected state, not an error, which is why
+// onLoadFailed is a normal branch here.
+//
+// connect()/disconnect() are the only two actions that need root, so
+// they stay the only two that shell out to the CLI (privileged process
+// management in bash, QML reflecting live state, per ROADMAP_FEATURES.md
+// PART C).
 Singleton {
     id: root
 
-    readonly property string daemonTag: "aphotic-vpn"
+    readonly property string markerPath: `${Quickshell.env("HOME")}/.local/state/aphotic/vpn-connected`
 
     property bool connected: false
     property bool busy: false
-
-    function refresh(): void {
-        statusProc.exec(["pgrep", "-f", root.daemonTag]);
-    }
 
     function connectVpn(configPath: string): void {
         root.busy = true;
@@ -40,34 +42,21 @@ Singleton {
         disconnectProc.exec(["aphotic", "vpn", "disconnect"]);
     }
 
-    Process {
-        id: statusProc
-        stdout: StdioCollector {
-            onStreamFinished: root.connected = text.trim().length > 0
-        }
+    FileView {
+        path: root.markerPath
+        watchChanges: true
+        onFileChanged: reload()
+        onLoaded: root.connected = true
+        onLoadFailed: root.connected = false
     }
 
     Process {
         id: connectProc
-        onExited: {
-            root.busy = false;
-            root.refresh();
-        }
+        onExited: root.busy = false
     }
 
     Process {
         id: disconnectProc
-        onExited: {
-            root.busy = false;
-            root.refresh();
-        }
-    }
-
-    Timer {
-        interval: 5000
-        running: true
-        repeat: true
-        triggeredOnStart: true
-        onTriggered: root.refresh()
+        onExited: root.busy = false
     }
 }

--- a/Configs/quickshell/aphotic/services/profile/SecurityProfile.qml
+++ b/Configs/quickshell/aphotic/services/profile/SecurityProfile.qml
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import qs.services
+import qs.services.profile
+
+// The Security profile, Phase 1: the ProfileEngine registrant and nothing
+// else. DND on APPLY, the release on RESTORE, and the identity/theme
+// revert every registrant gets for free the moment its snapshot exists --
+// no dashboard tab, no widget, no tool integration. Those attach to this
+// substrate later rather than arriving with it.
+//
+// A singleton, the same call DevProfile made: Vpn is itself a singleton,
+// so there is no injected dependency to receive and no reason to mount
+// this from shell.qml the way the Gaming plugin has to.
+//
+// DETECT is Vpn.connected -- the `aphotic vpn` daemon's own state, which
+// Vpn.qml already polls every 5s. This reacts to that signal and starts
+// no timer, no dbus monitor and no process of its own.
+Singleton {
+    id: root
+
+    readonly property string profileId: "security"
+    readonly property bool enabled: InstallProfile.securityEnabled
+
+    // Quickshell constructs a singleton on first use, and a headless
+    // registrant is named by no UI -- with no caller this file would sit
+    // unloaded, register nothing, and never arm the watch below.
+    // shell.qml makes that first use explicit.
+    function arm(): void {
+        root._register();
+    }
+
+    // The seam NEGOTIATE attaches to once an engagement has a footprint
+    // worth arbitrating. Unwired on purpose: BloodHound/Neo4j's resident
+    // memory and an active scan's cost are both real numbers nobody has
+    // measured yet, and a guessed one would feed fabricated data into
+    // arbitration that answers with real suspensions. Foreground, like
+    // Gaming and unlike Dev, because an engagement in progress is the
+    // side that raises a negotiation, not the side that answers one.
+    function registerEngagementClaim(resourceKey: string, amount: real): var {
+        if (!root.enabled || !resourceKey || !(amount > 0))
+            return null;
+        return ResourceEngine.register({
+            id: `security-engagement-${resourceKey}`,
+            owner: root.profileId,
+            resource: resourceKey,
+            amount: amount,
+            priority: "foreground"
+        });
+    }
+
+    property bool _registered: false
+
+    // snapshot is the "notifications" part only, which StateSnapshot
+    // defines as exactly {dnd: Settings.dndEnabled} -- the one thing this
+    // profile changes. Naming it explicitly matters: an empty array is
+    // NOT "capture nothing", StateSnapshot.capture() falls back to
+    // allParts when the list is empty, which would snapshot and restore
+    // theme/workspace/monitors this profile never touches.
+    //
+    // No gracefulStop: an active engagement has no pause primitive to
+    // call, so a hook here would be a fake one and canSuspend("security")
+    // correctly stays false.
+    function _register(): void {
+        if (root._registered || !root.enabled)
+            return;
+        root._registered = true;
+        ProfileEngine.register({
+            id: root.profileId,
+            label: qsTr("Security"),
+            snapshot: ["notifications"],
+            claims: [],
+            onApply: () => DoNotDisturb.setSecurityActive(true),
+            onRestore: () => DoNotDisturb.setSecurityActive(false)
+        });
+    }
+
+    // Unregisters rather than only deactivating, which is where this
+    // parts ways with DevProfile. InstallProfile reports `enabled` before
+    // it has read aphotic.toml (unknown means enabled, so a git clone
+    // sees the shell it cloned), and shell.qml arms this at startup --
+    // so on an install without the exploit layers this registers first
+    // and learns it should not have a moment later. Deactivating would
+    // leave `security` sitting in ProfileEngine.profiles forever on
+    // every machine that never asked for it. The Gaming plugin gets the
+    // same effect from Component.onDestruction; a singleton is never
+    // destroyed, so it has to happen here.
+    onEnabledChanged: {
+        if (root.enabled) {
+            root._register();
+            return;
+        }
+        if (!root._registered)
+            return;
+        root._registered = false;
+        ProfileEngine.unregister(root.profileId);
+    }
+
+    // The target is guarded rather than bound straight to Vpn so an
+    // install without the exploit layers never touches that singleton at
+    // all: Vpn is demand-created today (the Network settings pane is its
+    // only other reader) and constructing it starts its 5s pgrep poll.
+    Connections {
+        target: root.enabled ? Vpn : null
+
+        function onConnectedChanged(): void {
+            if (Vpn.connected) {
+                if (!ProfileEngine.isActive(root.profileId))
+                    ProfileEngine.activate(root.profileId, "vpn-connect");
+            } else if (ProfileEngine.isActive(root.profileId)) {
+                ProfileEngine.deactivate(root.profileId, "vpn-disconnect");
+            }
+        }
+    }
+
+    Component.onCompleted: root._register()
+}

--- a/Configs/quickshell/aphotic/services/profile/qmldir
+++ b/Configs/quickshell/aphotic/services/profile/qmldir
@@ -4,5 +4,6 @@ singleton DevProfile 1.0 DevProfile.qml
 singleton ProfileEngine 1.0 ProfileEngine.qml
 singleton ProfileEvents 1.0 ProfileEvents.qml
 singleton ResourceEngine 1.0 ResourceEngine.qml
+singleton SecurityProfile 1.0 SecurityProfile.qml
 singleton StateSnapshot 1.0 StateSnapshot.qml
 RingBuffer 1.0 RingBuffer.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -344,6 +344,15 @@ ShellRoot {
         }
     }
 
+    // Security registers from a singleton, not from the Instantiator
+    // above -- it needs no injected seam, so it has nothing to mount. But
+    // Quickshell builds a singleton on first use, and a headless
+    // registrant is named by no UI, so without this call SecurityProfile
+    // would never load and its VPN watch would never arm. Dev is reached
+    // through the launcher and Gaming through the plugin registry; this
+    // is the only registrant with no other caller.
+    Component.onCompleted: SecurityProfile.arm()
+
     // The profile substrate's inspection/drive surface (Phase 0 --
     // docs/APHOTIC_UNIFIED_VISION.md section 3.5). Lives here rather than
     // inside the singletons so declaring the IPC target doesn't

--- a/tests/test_vpn_hook.sh
+++ b/tests/test_vpn_hook.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# tests/test_vpn_hook.sh
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+HOOK="$ROOT/Configs/.local/lib/aphotic/vpn-hook.sh"
+MARKER="$WORKDIR/state/vpn-connected"
+
+[[ -x "$HOOK" ]] || fail "vpn-hook.sh is not executable (openvpn will refuse to run it)"
+
+# --- 1. up creates the marker, world-readable ---------------------------
+rc=0
+env APHOTIC_VPN_MARKER="$MARKER" script_type=up "$HOOK" || rc=$?
+[[ "$rc" -eq 0 ]] || fail "up hook exited $rc, expected 0"
+[[ -f "$MARKER" ]] || fail "up hook did not create the marker"
+mode="$(stat -c '%a' "$MARKER")"
+[[ "$mode" == "644" ]] || fail "marker mode is $mode, expected 644 (root writes it, the user reads it)"
+
+# --- 2. up is idempotent ------------------------------------------------
+rc=0
+env APHOTIC_VPN_MARKER="$MARKER" script_type=up "$HOOK" || rc=$?
+[[ "$rc" -eq 0 ]] || fail "second up hook exited $rc, expected 0"
+[[ -f "$MARKER" ]] || fail "second up hook removed the marker"
+
+# --- 3. down removes it, and is idempotent ------------------------------
+rc=0
+env APHOTIC_VPN_MARKER="$MARKER" script_type=down "$HOOK" || rc=$?
+[[ "$rc" -eq 0 ]] || fail "down hook exited $rc, expected 0"
+[[ ! -e "$MARKER" ]] || fail "down hook did not remove the marker"
+
+rc=0
+env APHOTIC_VPN_MARKER="$MARKER" script_type=down "$HOOK" || rc=$?
+[[ "$rc" -eq 0 ]] || fail "down hook on a missing marker exited $rc, expected 0"
+
+# --- 4. any other script_type is a no-op, still exit 0 ------------------
+for st in "" route-up tls-verify; do
+    rc=0
+    env APHOTIC_VPN_MARKER="$MARKER" script_type="$st" "$HOOK" || rc=$?
+    [[ "$rc" -eq 0 ]] || fail "hook with script_type='$st' exited $rc, expected 0"
+    [[ ! -e "$MARKER" ]] || fail "hook with script_type='$st' touched the marker"
+done
+
+# --- 5. an unwritable marker path must NOT fail the tunnel --------------
+# openvpn treats a nonzero --up as fatal, so a state dir it cannot write
+# has to degrade to "the shell never shows connected", never to a torn
+# down VPN.
+rc=0
+env APHOTIC_VPN_MARKER="/proc/definitely-not-writable/vpn-connected" script_type=up "$HOOK" || rc=$?
+[[ "$rc" -eq 0 ]] || fail "up hook on an unwritable path exited $rc, expected 0 (would kill the tunnel)"
+
+# --- 6. cmd_vpn.sh hands openvpn the flags the hook needs ---------------
+OK_LOG="$WORKDIR/ok.log"
+ERR_LOG="$WORKDIR/err.log"
+aphotic_log()  { echo "$*" >> "$OK_LOG"; }
+aphotic_ok()   { echo "$*" >> "$OK_LOG"; }
+aphotic_warn() { echo "$*" >> "$ERR_LOG"; }
+aphotic_err()  { echo "$*" >> "$ERR_LOG"; }
+aphotic_require() {
+    command -v "$1" >/dev/null 2>&1 || { aphotic_err "missing dependency: $1"; return 1; }
+}
+
+export APHOTIC_STATE_HOME="$WORKDIR/state"
+mkdir -p "$APHOTIC_STATE_HOME" "$WORKDIR/bin"
+
+export SUDO_CALL_LOG="$WORKDIR/sudo_calls.log"
+cat > "$WORKDIR/bin/sudo" <<'SUDO'
+#!/usr/bin/env bash
+# `sudo -n true` is the passwordless probe cmd_vpn.sh makes first.
+[[ "${1:-}" == "-n" ]] && exit 0
+printf '%s\n' "$*" > "$SUDO_CALL_LOG"
+exit 0
+SUDO
+cat > "$WORKDIR/bin/openvpn" <<'OVPN'
+#!/usr/bin/env bash
+exit 0
+OVPN
+# No aphotic-vpn process exists, so connect proceeds rather than
+# short-circuiting on "already connected".
+cat > "$WORKDIR/bin/pgrep" <<'PGREP'
+#!/usr/bin/env bash
+exit 1
+PGREP
+chmod +x "$WORKDIR/bin/sudo" "$WORKDIR/bin/openvpn" "$WORKDIR/bin/pgrep"
+export PATH="$WORKDIR/bin:$PATH"
+
+source "$ROOT/Configs/.local/lib/aphotic/commands/cmd_vpn.sh"
+
+CONFIG="$WORKDIR/test.ovpn"
+: > "$CONFIG"
+
+rc=0
+_aphotic_vpn_connect "$CONFIG" || rc=$?
+[[ "$rc" -eq 0 ]] || fail "connect exited $rc, expected 0"
+[[ -f "$SUDO_CALL_LOG" ]] || fail "connect never invoked sudo openvpn"
+call="$(cat "$SUDO_CALL_LOG")"
+
+case "$call" in
+    *"--script-security 2"*) ;;
+    *) fail "connect omitted --script-security 2; --up/--down would silently never fire. Got: $call" ;;
+esac
+case "$call" in
+    *"--setenv APHOTIC_VPN_MARKER ${APHOTIC_STATE_HOME}/vpn-connected"*) ;;
+    *) fail "connect did not pass the marker path via --setenv. Got: $call" ;;
+esac
+case "$call" in
+    *"--up ${ROOT}/Configs/.local/lib/aphotic/vpn-hook.sh"*) ;;
+    *) fail "connect did not pass --up <vpn-hook.sh>. Got: $call" ;;
+esac
+case "$call" in
+    *"--down ${ROOT}/Configs/.local/lib/aphotic/vpn-hook.sh"*) ;;
+    *) fail "connect did not pass --down <vpn-hook.sh>. Got: $call" ;;
+esac
+
+# --- 7. status detection must not have regressed into a poll -----------
+# Comments are stripped first: this file's own header explains what the
+# poll used to be, so a raw grep would match the prose describing the
+# thing it is checking is gone.
+VPN_CODE="$WORKDIR/Vpn.code.qml"
+sed 's://.*::' "$ROOT/Configs/quickshell/aphotic/services/Vpn.qml" > "$VPN_CODE"
+
+if grep -Eq '^[[:space:]]*Timer[[:space:]]*\{' "$VPN_CODE"; then
+    fail "Vpn.qml declares a Timer again -- status detection is the marker FileView, not a poll"
+fi
+if grep -q 'pgrep' "$VPN_CODE"; then
+    fail "Vpn.qml still shells out to pgrep for status"
+fi
+if grep -Eq '^[[:space:]]*FileView[[:space:]]*\{' "$VPN_CODE"; then :; else
+    fail "Vpn.qml has no FileView watching the marker"
+fi
+if grep -q 'vpn-connected' "$VPN_CODE"; then :; else
+    fail "Vpn.qml does not reference the vpn-connected marker vpn-hook.sh writes"
+fi
+
+echo "PASS: tests/test_vpn_hook.sh"


### PR DESCRIPTION
The Security domain's ProfileEngine registrant, Phase 1. DETECT via VPN
connect, DND on APPLY, and the RESTORE that comes free once a profile is
registered with a snapshot. No Strix reference, no dashboard tab, no
widget, no tool integrations. Those attach to this substrate later.

## What landed

`services/profile/SecurityProfile.qml`, a singleton on the same call
DevProfile made: `Vpn` is already a singleton, so there is no injected
seam to receive and no reason to mount this from `shell.qml` the way the
Gaming plugin has to.

- Registers `{ id: "security", label: "Security", snapshot:
  ["notifications"], onApply/onRestore }` with `ProfileEngine`. The
  snapshot part is named rather than left empty, because
  `StateSnapshot.capture()` reads an empty array as "unspecified" and
  falls through to `allParts`.
- DETECT is `Vpn.connected`. `Vpn.qml` already polls every 5s, so this
  reacts to `onConnectedChanged` and starts no timer, no dbus monitor and
  no process of its own.
- `claims: []`. `registerEngagementClaim(resourceKey, amount)` is stubbed
  and unwired rather than carrying a made-up number (open question
  below).
- No `gracefulStop`. An engagement has no pause primitive, so a hook here
  would be a fake one, and `canSuspend("security")` stays false.

`services/DoNotDisturb.qml` gains `_securityForced` and
`setSecurityActive()`, the shape the file's existing Focus Mode note
prescribes for any new caller: its own tracking flag, never touching
`_gamingForced` or `_pomodoroForced`.

## Two things the scope had to grow to cover

Both were verified with a `qs -p` probe, not reasoned about.

**1. `shell.qml` calls `SecurityProfile.arm()`.** Quickshell builds a
singleton on first use, and a headless registrant is named by no UI. A
throwaway config with an unreferenced singleton confirmed it: its
`Component.onCompleted` never fires. Dev is reached through the launcher
and Gaming through the plugin registry, so Security is the only
registrant with no other caller. Without this line the file loads,
registers nothing, and the VPN watch never arms. `DevDrift.qml` looks to
have the same problem on `main` today, referenced by nothing but its own
`qmldir` line, which is worth a separate look.

**2. `onEnabledChanged` unregisters instead of only deactivating.**
`InstallProfile` reports `securityEnabled` true before it has read
`aphotic.toml`, by design, so a git clone sees the shell it cloned. Armed
at startup, this registers first and learns it should not have a moment
later. The deactivate-only pattern left `security` sitting in
`ProfileEngine.profiles` on a machine with no exploit layers, which the
probe caught. Dev gets away with the weaker pattern only because nothing
constructs it until a project is opened.

## Verified

A probe drove the lifecycle directly:

- connect gets to `monitor`, snapshot captured, DND on, `canSuspend`
  false; disconnect returns to `idle` with DND released.
- DND holds stay independent in all three orderings. Manual DND survives
  an engagement ending. Gaming keeps its hold when Security releases, and
  the reverse.
- With `layers = ["ai", "dev", "gaming"]`, `registered=false`,
  `profiles=[]`, and a VPN connect does nothing.
- With `layers = ["ai", "exploit-web"]`, the sublayer matches and the
  full path runs.
- Binding loops on a full shell load: 0, same as the baseline.

## Open questions

- **What does an engagement claim, and how much?** BloodHound and Neo4j's
  resident memory and an active scan's footprint are real numbers nobody
  has measured. The stub registers `foreground`, matching Gaming rather
  than Dev, on the reasoning that an engagement in progress raises a
  negotiation rather than answering one. Worth confirming when the number
  arrives.
- **Stale marker after an unclean daemon death.** An OOM-kill or crash
  skips openvpn's `--down`, leaving a marker that claims connected.
  Gaming's dbus-monitor has the equivalent gap and closes it with a
  restart timer that runs only while the monitor process itself is down,
  never as a fixed poll of state. The same shape fits here if this ever
  needs closing. Not built speculatively.
- **No test covered `cmd_vpn.sh` before this.** `tests/test_vpn_hook.sh`
  is new and covers the hook plus the connect flags, following
  `test_bar_cli.sh`'s existing shape (source the command file, fake
  binaries on PATH). The rest of `cmd_vpn.sh`, `status`/`autostart`/the
  settings-file readers, is still uncovered.

## Out of scope, deliberately

1. **Dedicated workspace on APPLY.** The design doc mentions it, but
   nothing in the codebase switches a hyprctl workspace the way DND has a
   mechanism to call. Building that is separate real scope.
2. **post-engagement-sanitizer's background agent sessions and scrollback
   clear.** The identity and theme revert half already comes free from
   RESTORE. The agent-session half needs Agent Graph write access, the
   same category as Dev's deferred Agent Context Handoff, and belongs in
   that branch rather than a second mechanism here.

## Follow-up in this PR: the poll is gone

Review caught that `Vpn.qml` detected state with `pgrep -f aphotic-vpn` on
a 5s Timer, running for the singleton's whole lifetime. The
`Connections` guard kept non-security installs from ever constructing it,
but every exploit-layer install would now carry that poll all session
whether or not a tunnel existed. That breaks the same zero-idle-cost rule
Gaming's dbus-monitor DETECT follows.

Replaced with a marker file openvpn's own hooks write:

- `lib/aphotic/vpn-hook.sh`, new. One script for both halves, branching on
  openvpn's `$script_type`. `up` touches the marker and chmods it 644,
  `down` removes it. Always exits 0, because openvpn treats a failing
  `--up` as fatal and a status marker must never be able to tear down a
  working tunnel.
- `cmd_vpn.sh` passes `--script-security 2 --setenv APHOTIC_VPN_MARKER
  <path> --up <hook> --down <hook>`. The script-security level is load
  bearing: without it openvpn accepts the hooks and silently never runs
  them. `--setenv` carries the path because openvpn runs the hook as root,
  where `APHOTIC_STATE_HOME` is unset and `$HOME` is not the user's.
- `Vpn.qml` drops the Timer, `statusProc`, `refresh()` and `daemonTag`
  (nothing outside the file read either of the last two) for a `FileView`
  with `watchChanges`. A missing marker is the disconnected state, so
  `onLoadFailed` is a normal branch.
- `disconnect` is unchanged. `pkill` sends SIGTERM and openvpn runs
  `--down` before exiting. The CLI's own one-shot `pgrep` in `aphotic vpn
  status` is unchanged too, since it is an invocation, not a loop.

Verified: `FileView` with `watchChanges` on a path that does not exist yet
does pick up creation and deletion, probed directly before relying on it.
A probe against the real `Vpn.qml` flips `connected` true on marker
create and false on delete. `script_type` and all four openvpn flags
checked against openvpn 2.7.6's man page and `--help`, not assumed. The
new test's four guards were each mutation-checked by breaking the thing
they cover. Full suite: 32 shell tests and 57 pytest, all passing. Shell
load: 0 binding loops.
