### PR TITLE
notifs: clear the whole notification history in one press

### DIFF
--- a/Configs/quickshell/aphotic/modules/notificationcenter/NotificationCenterContent.qml
+++ b/Configs/quickshell/aphotic/modules/notificationcenter/NotificationCenterContent.qml
@@ -132,6 +132,64 @@ Item {
                 }
 
                 Item {
+                    id: clearAll
+
+                    property bool armed: false
+
+                    visible: NotificationHistory.entries.length > 0
+                    implicitWidth: clearIcon.implicitHeight + Tokens.padding.extraSmall * 2
+                    implicitHeight: clearIcon.implicitHeight + Tokens.padding.extraSmall * 2
+
+                    // The card is 400px, which is why this is an icon and
+                    // not the labelled pill "Mark all read" gets. An
+                    // unlabelled control that drops the whole history
+                    // wants a second press to mean it, so the first one
+                    // arms and the icon says so.
+                    Timer {
+                        id: clearAllDisarm
+
+                        interval: 3000
+                        onTriggered: clearAll.armed = false
+                    }
+
+                    Connections {
+                        target: root
+
+                        function onOpenChanged(): void {
+                            if (!root.open) {
+                                clearAll.armed = false;
+                                clearAllDisarm.stop();
+                            }
+                        }
+                    }
+
+                    StateLayer {
+                        anchors.fill: parent
+                        radius: Tokens.rounding.full
+                        onClicked: {
+                            if (clearAll.armed) {
+                                NotificationHistory.clearAll();
+                                clearAll.armed = false;
+                                clearAllDisarm.stop();
+                            } else {
+                                clearAll.armed = true;
+                                clearAllDisarm.restart();
+                            }
+                        }
+                    }
+
+                    MaterialIcon {
+                        id: clearIcon
+
+                        anchors.centerIn: parent
+                        text: clearAll.armed ? "delete_forever" : "delete_sweep"
+                        color: clearAll.armed ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                        fill: clearAll.armed ? 1 : 0
+                        fontStyle: Tokens.font.icon.small
+                    }
+                }
+
+                Item {
                     implicitWidth: dndIcon.implicitHeight + Tokens.padding.extraSmall * 2
                     implicitHeight: dndIcon.implicitHeight + Tokens.padding.extraSmall * 2
 

--- a/Configs/quickshell/aphotic/services/NotificationHistory.qml
+++ b/Configs/quickshell/aphotic/services/NotificationHistory.qml
@@ -52,6 +52,13 @@ Singleton {
         root._save();
     }
 
+    function clearAll(): void {
+        if (root.entries.length === 0)
+            return;
+        root.entries = [];
+        root._save();
+    }
+
     function _record(n: var): void {
         const entry = {
             id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,


### PR DESCRIPTION
Reported as "can't clear notifications, they are full".

## What was actually wrong

Nothing was broken. The bulk action was never built. The Notification
Center header has four controls (title, "Mark all read", DND, close) and
none of them empties the list. The only removal path in the UI is
`deleteEntry(id)` on a per-item delete icon
(`NotificationHistoryItem.qml:135`).

History caps at `maxEntries: 500`
(`services/NotificationHistory.qml:21`), and this machine sits at 480. So
emptying it meant 480 clicks, which is indistinguishable from a clear that
does not work.

Checked and ruled out before writing anything: the persisted file is
well-formed (480 entries, 147KB, `jq length` clean), `_save()` writes
through on every mutation, and `NotificationHistory.qml` follows
`PinnedSnippets.qml`'s `mkdir -p` + `stateWriter` + `_writePending`
pattern faithfully. The cap does not block writes or removals either. The
persistence layer is fine.

## The change

`services/NotificationHistory.qml` gains `clearAll()`, the same shape as
the `markAllRead`/`deleteEntry` pair beside it, writing through with the
same `_save()`.

`modules/notificationcenter/NotificationCenterContent.qml` gains a header
control. It is an icon rather than a labelled pill like "Mark all read"
because the card is 400px and a second pill does not fit next to the
title, DND and close. Since an unlabelled icon that drops the whole
history is easy to hit by accident, the first press arms it and swaps
`delete_sweep` for `delete_forever` in the error colour; the second press
clears. It disarms after 3s, and on panel close so a reopen cannot land
on an armed control.

Live popup toasts are untouched. Those are a separate thing with its own
`Notifs.clear()` IPC, and dismissing transient toasts is not what
"clear the history" should mean.

## Verified

A probe instantiated the real `NotificationCenterContent.qml` against a
throwaway HOME seeded with 480 entries: component compiles, instantiates,
loads all 480, `clearAll()` takes memory to 0 and rewrites the file on
disk to `[]`. The real history was confirmed untouched by that run. Full
shell load: 0 binding loops. Shell and pytest suites pass.

The arm-then-confirm interaction is worth a look in the running shell,
since that is a feel question rather than a correctness one. Say the word
if you would rather it clear on a single press.
