### PR TITLE
fix: construct WallpaperCycle and DevDrift, which never ran

### DIFF
--- a/Configs/quickshell/aphotic/services/profile/SecurityProfile.qml
+++ b/Configs/quickshell/aphotic/services/profile/SecurityProfile.qml
@@ -28,14 +28,6 @@ Singleton {
     readonly property string profileId: "security"
     readonly property bool enabled: InstallProfile.securityEnabled
 
-    // Quickshell constructs a singleton on first use, and a headless
-    // registrant is named by no UI -- with no caller this file would sit
-    // unloaded, register nothing, and never arm the watch below.
-    // shell.qml makes that first use explicit.
-    function arm(): void {
-        root._register();
-    }
-
     // The seam NEGOTIATE attaches to once an engagement has a footprint
     // worth arbitrating. Unwired on purpose: BloodHound/Neo4j's resident
     // memory and an active scan's cost are both real numbers nobody has

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -367,14 +367,19 @@ ShellRoot {
         }
     }
 
-    // Security registers from a singleton, not from the Instantiator
-    // above -- it needs no injected seam, so it has nothing to mount. But
-    // Quickshell builds a singleton on first use, and a headless
-    // registrant is named by no UI, so without this call SecurityProfile
-    // would never load and its VPN watch would never arm. Dev is reached
-    // through the launcher and Gaming through the plugin registry; this
-    // is the only registrant with no other caller.
-    Component.onCompleted: SecurityProfile.arm()
+    // Quickshell constructs a singleton on first use, so a singleton
+    // nothing else names never runs at all: no Component.onCompleted, no
+    // timers, no Connections, and no error anywhere. These three are
+    // complete features that only react to state, so no UI names any of
+    // them. SecurityProfile is the ProfileEngine registrant Dev reaches
+    // through the launcher and Gaming through the plugin registry;
+    // WallpaperCycle owns the auto-cycle Timer the Appearance pane
+    // already ships a toggle and an interval picker for; DevDrift watches
+    // DevProfile for a stale lockfile. Listing them here is what makes
+    // them exist. Anything added to services/ that runs on its own rather
+    // than answering a reader belongs in this list, and
+    // tests/test_singleton_reachability.py fails the build if it does not.
+    readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift]
 
     // The profile substrate's inspection/drive surface (Phase 0 --
     // docs/APHOTIC_UNIFIED_VISION.md section 3.5). Lives here rather than

--- a/tests/test_singleton_reachability.py
+++ b/tests/test_singleton_reachability.py
@@ -1,0 +1,75 @@
+"""A QML singleton nothing references is never constructed, so it never runs.
+
+Quickshell builds a singleton on first use. A `pragma Singleton` that no
+other QML file names therefore never reaches Component.onCompleted, never
+starts its timers and never wires its Connections -- silently, with no
+error anywhere. The feature simply does nothing.
+
+This has now bitten three times:
+  - SecurityProfile, caught before it shipped (PR #114)
+  - WallpaperCycle, shipped with a working Settings toggle and interval
+    picker in front of a Timer that never ran
+  - DevDrift, shipped and presented as working in two docs
+
+Comments are stripped before matching, because both of the shipped cases
+WERE mentioned by name in other files -- only ever in prose explaining
+what they do.
+"""
+import re
+from pathlib import Path
+
+QML_ROOT = Path(__file__).resolve().parent.parent / "Configs" / "quickshell" / "aphotic"
+
+# A singleton reachable only from outside this repo (a plugin in the
+# aphotic-plugins repo, say) belongs here with the reason. Empty on
+# purpose: nothing qualifies today, and an entry is a claim someone has
+# to justify.
+ALLOWED_UNREFERENCED: dict[str, str] = {}
+
+
+def _code(path: Path) -> str:
+    """File contents with // comments removed."""
+    return "\n".join(re.sub(r"//.*$", "", line) for line in path.read_text(
+        encoding="utf-8", errors="ignore").splitlines())
+
+
+def _qml_files() -> list[Path]:
+    return sorted(QML_ROOT.rglob("*.qml"))
+
+
+def _singletons() -> list[Path]:
+    return [p for p in _qml_files()
+            if re.search(r"^\s*pragma\s+Singleton", p.read_text(
+                encoding="utf-8", errors="ignore"), re.M)]
+
+
+def test_qml_root_exists():
+    assert QML_ROOT.is_dir(), f"expected the shell at {QML_ROOT}"
+
+
+def test_finds_singletons():
+    # A scan that silently matches nothing would pass forever.
+    assert len(_singletons()) > 10, "singleton scan found suspiciously few files"
+
+
+def test_every_singleton_is_referenced():
+    files = _qml_files()
+    unreferenced = []
+
+    for singleton in _singletons():
+        name = singleton.stem
+        if name in ALLOWED_UNREFERENCED:
+            continue
+        referenced = any(
+            other != singleton and re.search(rf"\b{re.escape(name)}\b", _code(other))
+            for other in files
+        )
+        if not referenced:
+            unreferenced.append(name)
+
+    assert not unreferenced, (
+        "these singletons are never constructed, so their timers, "
+        f"Connections and Component.onCompleted never run: {unreferenced}. "
+        "Give each one a construction site (shell.qml's _residentSingletons "
+        "is where a self-driving service goes) or delete it."
+    )


### PR DESCRIPTION
Two complete features that have never run on any install.

Quickshell constructs a singleton on first use. A `pragma Singleton` that
no other QML file names therefore never reaches `Component.onCompleted`,
never starts its timers and never wires its `Connections` — silently, with
no error anywhere.

## WallpaperCycle

The user-visible one. `AppearancePane.qml:413-463` ships an
"Auto-cycle wallpaper" toggle and a 5/15/30/60 minute interval picker,
both bound to `Settings` keys that persist correctly. Behind them,
`services/WallpaperCycle.qml` holds the `Timer` that does the work, and it
was never constructed. You could turn auto-cycle on, watch the setting
stick, and nothing would ever happen.

The implementation itself is complete and correct. It only needed to
exist.

Worth noting the knock-on: `SessionLockState` and `UiPickerState` exist
only to be read by that timer, so that whole chain was inert too.

## DevDrift

Same shape. `services/profile/DevDrift.qml` watches `DevProfile` for a
lockfile older than the manifest it locks, and is presented as working in
both `CLAUDE.md` and `PLUGIN_LAYER_MODEL.md`.

**Correction to an earlier note on this PR:** I first said the consumer
was still stubbed and this was only half a fix. That was wrong, from
reading a stale local checkout of the plugins repo. `dev-notch-tile` on
`origin/main` already reads `DevDrift.detected` (`:28`) and
`DevDrift.summary` (`:143`), and gates its drift row on it (`:129`),
shipped in aphotic-plugins#10.

So this is the completing half, not half a fix. Constructing the singleton
is the only thing standing between a wired consumer and a feature that
works. With this merged, Dev drift detection runs end to end for the first
time.

## Why comments made this invisible

Both singletons *were* named elsewhere — only ever in prose:

```
services/UiPickerState.qml:7:    // auto-cycle timer (services/WallpaperCycle.qml) can pause rather than
services/Settings.qml:184:      // services/WallpaperCycle.qml) -- interval in minutes.
modules/settings/SettingsPanel.qml:13: // Wallpaper auto-cycle (services/WallpaperCycle.qml) pauses while this
```

A grep for the name looks reassuring. That is exactly why the new test
strips `//` comments before matching.

## The fix

One construction site in `shell.qml`. Anything added to `services/` that
runs on its own rather than answering a reader belongs in that list.

## The guard

`tests/test_singleton_reachability.py` scans every `pragma Singleton`
under the shell and fails if nothing outside its own file names it.

**This is the third instance of this bug class.** The Security registrant
in #114 was caught only because I probed it; these two shipped. A test is
overdue.

Run against unmodified `main` the scan reports exactly
`['WallpaperCycle', 'DevDrift']` and nothing else, across 54 singletons.
With the fix it passes. Mutation-checked by dropping `WallpaperCycle` back
out of the list, which fails with a message naming it.

`ALLOWED_UNREFERENCED` is deliberately empty. A singleton reachable only
from the plugins repo would go there with a reason attached, so an entry
is a claim someone has to justify.

## Verified

Probe with auto-cycle persisted on at a 5 minute interval:

```
PROBE settings enabled=true interval=5min
PROBE wallpaperCycle constructed=true type=WallpaperCycle_QMLTYPE_40(0x...)
PROBE devDrift constructed=true enabled=true detected=false
```

Both objects now exist, so the `running: Settings.wallpaperAutoCycleEnabled`
binding on the timer is live. Full shell load: 0 binding loops. All shell
tests pass, 60 pytest pass (57 plus the 3 new).


---

## Rebased onto main, and the two mechanisms are now one

#114 merged while this was open, and it had solved the same problem its
own way: `Component.onCompleted: SecurityProfile.arm()`, where `arm()`
existed purely so `shell.qml` had something to call. That collided with
this PR's `_residentSingletons` list, since both edit the same spot in
`shell.qml` for the same reason.

Resolved by unifying rather than keeping both. One list now covers all
three:

```qml
readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift]
```

Reading the singleton in that binding constructs it, and
`SecurityProfile`'s own `Component.onCompleted: root._register()` does the
registering, so **`arm()` is now dead and is removed** in this PR. That is
the one scope addition versus the original diff. Leaving two mechanisms
and an uncalled function behind would have been worse than the small
extra reach.

Re-verified after the rebase, on an install with
`layers = ["ai", "dev", "exploit-web"]`:

```
PROBE securityRegistered=true profiles=["security","dev"]
PROBE wallpaperCycle=true devDrift=true devDriftEnabled=true
PROBE autoCycle enabled=true interval=5
PROBE afterVpnConnect    phase=monitor dnd=true
PROBE afterVpnDisconnect phase=idle    dnd=false
```

So the security registrant still registers and still runs its full
DETECT/APPLY/RESTORE cycle without `arm()`. 60 pytest pass.

