### PR TITLE
install: add cava to the minimal profile

### DIFF
--- a/profiles/base/minimal.toml
+++ b/profiles/base/minimal.toml
@@ -4,4 +4,4 @@ description = "Bare Hyprland + Quickshell bar, no extras"
 
 [packages]
 prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "procps-ng", "util-linux", "gawk"]
-main = ["quickshell", "kitty", "awww", "xdg-desktop-portal-hyprland", "wallust-git", "matugen", "openvpn", "swappy", "grim", "slurp", "brightnessctl", "swaylock-effects"]
+main = ["quickshell", "kitty", "awww", "xdg-desktop-portal-hyprland", "wallust-git", "matugen", "openvpn", "swappy", "grim", "slurp", "brightnessctl", "swaylock-effects", "cava"]


### PR DESCRIPTION
Companion to aphotic-plugins#13 (the Spectrum visualiser). Merge this
first, or a minimal install that enables the plugin gets a visualiser with
no binary behind it.

`cava` was in `profiles/base/full.toml` only. The project rule is that
every binary the shell shells out to is in **both** base profiles, since
the shell always loads in full regardless of install profile.

## Why it did not already qualify

Worth stating precisely, because a research pass this session reported
this as a standing rule violation and it was not one. Core does **not**
run `cava` today: `services/CavaProvider.qml` is a stub `QtObject` with a
`bars` property and no `Process` at all, kept only so `Audio.qml`'s
binding resolves.

What changes the answer is the Spectrum plugin, which is **ungated** — no
`requires_layer`, no `requires_data` — so any install including a minimal
one can enable it, and it does really invoke `cava`.

## Verified

`cava` now appears exactly once in each of `full.toml` and `minimal.toml`.
All shell tests pass, 57 pytest pass.
