### PR TITLE
readme: suggest testing the install in a Proxmox guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,18 @@ Run the installer:
 > ./install.sh --profile full --with gaming,dev --dry-run
 > ```
 
+> [!TIP]
+> Running Proxmox VE? Build an Arch guest and install there before you
+> touch the machine you work on. You get to watch a full run, try a
+> profile, break it, and roll back to a snapshot. `install.sh` changes go
+> through a VM before they ship, so a guest run follows a path that
+> already works.
+>
+> The installer warns when it detects a VM. Continuing past it is the
+> point of the exercise. Rendering in a guest depends on what your
+> hypervisor exposes, so judge the install path and ignore the frame
+> rate.
+
 The installer supports profiles and optional features without requiring
 every component to be installed.
 

--- a/README.md
+++ b/README.md
@@ -369,10 +369,17 @@ Run the installer:
 > through a VM before they ship, so a guest run follows a path that
 > already works.
 >
-> The installer warns when it detects a VM. Continuing past it is the
-> point of the exercise. Rendering in a guest depends on what your
-> hypervisor exposes, so judge the install path and ignore the frame
-> rate.
+> [Proxmox Test VM](https://github.com/T-Crypt/Aphotic-Hypr/wiki/Proxmox-Test-VM)
+> has the `qm create` line and the settings off the dev VM.
+
+> [!WARNING]
+> Set the guest's display adapter to **VirtIO-GPU**. Proxmox defaults to
+> `std`, and VirtIO-GPU is what gives the guest the `/dev/dri/renderD128`
+> render node Hyprland draws through.
+>
+> The installer warns when it detects a VM. You can continue past it. A
+> guest still shows you nothing about GPU layers or frame rate, so judge
+> the install path and leave performance to real hardware.
 
 The installer supports profiles and optional features without requiring
 every component to be installed.

--- a/README.md
+++ b/README.md
@@ -373,9 +373,11 @@ Run the installer:
 > has the `qm create` line and the settings off the dev VM.
 
 > [!WARNING]
-> Set the guest's display adapter to **VirtIO-GPU**. Proxmox defaults to
-> `std`, and VirtIO-GPU is what gives the guest the `/dev/dri/renderD128`
-> render node Hyprland draws through.
+> Two settings decide whether the guest is usable. Set the display adapter
+> to **VirtIO-GPU**, which supplies the `/dev/dri/renderD128` render node
+> Hyprland draws through; Proxmox defaults to `std`. Then reach the guest
+> over **SPICE** with `virt-viewer`, since the browser console swallows the
+> SUPER key that most of Aphotic hangs off.
 >
 > The installer warns when it detects a VM. You can continue past it. A
 > guest still shows you nothing about GPU layers or frame rate, so judge


### PR DESCRIPTION
Adds a tip and a warning to the Installation section pointing people at a
Proxmox guest for a first run, next to the existing `--dry-run` tip since
they answer the same worry.

Paired with a new wiki page,
[Proxmox Test VM](https://github.com/T-Crypt/Aphotic-Hypr/wiki/Proxmox-Test-VM),
already pushed and linked from the wiki Home index.

## VirtIO-GPU gets a warning, not a footnote

I read the settings off the running dev VM rather than writing a plausible
template. One of them decides whether this works at all:

```console
$ lspci | grep -i vga
00:01.0 VGA compatible controller: Red Hat, Inc. Virtio 1.0 GPU (rev 01)

$ ls /sys/class/drm/
card1  card1-Virtual-1  renderD128  version

$ pgrep -a Hyprland
1017983 Hyprland --watchdog-fd 4
```

VirtIO-GPU is what supplies `/dev/dri/renderD128`, and Hyprland comes up
on its own with it. Proxmox defaults the display to `std`, so anyone
following the tip without changing that is the person who files the issue.
Hence a `[!WARNING]`.

Also confirmed: nothing in the guest sets `WLR_RENDERER_ALLOW_SOFTWARE`,
and nothing in this repo does either.

## What the wiki page carries

The full guest spec as measured (q35, OVMF, `cpu host`, 6 cores, 12 GB,
60 GB SCSI, VirtIO-GPU), a `qm create` line, snapshot and rollback
commands for repeat runs, and a section on what a guest will not tell you:
GPU-layer detection, frame rate, multi-monitor.

The `qm create` snippet is shell-checked, `bash -n` clean. `--boot` is
quoted, since the semicolon in `order=ide2;scsi0` would otherwise split
the command.

## Two claims I deliberately did not make

**"VM support included."** `lib/install/detect.sh:45` still prints:

```
running in a VM (Chassis: vm) -- not fully supported, there's a high
chance this fails.
```

A README promising support followed by that would read as a bug in one of
them. Both the tip and the wiki page name the warning up front instead.

**That `std` fails.** Widely reported, but I only tested VirtIO-GPU, so
the text says what VirtIO-GPU provides rather than what `std` does not.

## Still worth deciding

That `detect.sh` warning predates the dev-VM workflow and is stronger than
the practice behind it, given a guest now demonstrably runs the shell. Say
the word and I will soften it to something like "VMs are not a supported
target for daily use; the installer itself is exercised in one." It
changes installer output, so it stays out of a README PR.

Send me the host-side `qm config <vmid>` when convenient and I will fold
the real dump into the wiki page next to the reconstructed one.
