### PR TITLE
install: soften the VM warning to match what a guest actually does

### DIFF
--- a/lib/install/detect.sh
+++ b/lib/install/detect.sh
@@ -42,7 +42,7 @@ detect_environment() {
   vm_chassis=$(hostnamectl | grep Chassis || true)
   if [[ "$vm_chassis" == *"vm"* ]]; then
     DETECTED_VM=1
-    echo -e "  $CWR running in a VM ($vm_chassis) -- not fully supported, there's a high chance this fails."
+    echo -e "  $CWR running in a VM ($vm_chassis) -- fine for testing the install, which is exercised in a VM before it ships. It is not a supported daily driver: GPU layers do not apply, and Hyprland needs a render node, so give the guest a VirtIO-GPU display. See https://github.com/T-Crypt/Aphotic-Hypr/wiki/Proxmox-Test-VM"
   fi
 
   if [[ -f "$APHOTIC_TOML" ]]; then


### PR DESCRIPTION
The installer greets every VM with this:

```
running in a VM (Chassis: vm) -- not fully supported, there's a high
chance this fails.
```

That text predates the dev VM. `install.sh` changes now go through a
Proxmox guest before they ship, and the shell comes up there on
VirtIO-GPU, so "high chance this fails" overstates the install path.

New text:

```
running in a VM (Chassis: vm) -- fine for testing the install, which is
exercised in a VM before it ships. It is not a supported daily driver:
GPU layers do not apply, and Hyprland needs a render node, so give the
guest a VirtIO-GPU display. See
https://github.com/T-Crypt/Aphotic-Hypr/wiki/Proxmox-Test-VM
```

It still says a VM is not a daily driver, since that has not changed. What
it drops is the claim that the install will probably fail, and what it
adds is the one setting people get wrong.

Pairs with #122 and the
[Proxmox Test VM](https://github.com/T-Crypt/Aphotic-Hypr/wiki/Proxmox-Test-VM)
wiki page, which now also covers the SPICE setup: a SPICE client rather
than the browser console, since Aphotic hangs off SUPER and the browser
console swallows it.

## Verified

Guest facts read off the running dev VM over ssh, not assumed:

```console
$ lspci | grep -i vga
00:01.0 VGA compatible controller: Red Hat, Inc. Virtio 1.0 GPU (rev 01)

$ ls /sys/class/drm/
card1  card1-Virtual-1  renderD128  version

$ pgrep -a Hyprland
1017983 Hyprland --watchdog-fd 4

$ ls /dev/virtio-ports/
com.redhat.spice.0  org.qemu.guest_agent.0

$ systemctl is-enabled spice-vdagentd qemu-guest-agent
static
static
```

The branch itself was exercised both ways with a stubbed `hostnamectl`:
fires on `Chassis: vm`, stays silent on `Chassis: desktop`. All shell
tests pass, 60 pytest pass.

## Noticed while in here, not changed

`DETECTED_VM` is assigned at `detect.sh:44` and read nowhere in
`install.sh` or `lib/`. It is either a seam waiting for a caller or a
leftover. Left alone since this PR is about wording, but worth a decision.
