### PR TITLE
ci: issue triage, weekly digest, and wiki drift automation

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,96 @@
+name: Issue triage
+
+on:
+  issues:
+    types: [opened, reopened]
+
+concurrency:
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
+
+      # Untrusted issue content goes through a JS file write, never through
+      # shell string interpolation -- issue bodies are attacker-controlled
+      # on a public repo and `${{ }}` inside a `run:` block is a classic
+      # script-injection hole.
+      - name: Dump issue content
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const issue = context.payload.issue;
+            fs.writeFileSync('issue.txt', `${issue.title}\n\n${issue.body || ''}`);
+
+      - name: Classify issue
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          copilot -p "Read issue.txt in the working directory -- it's a GitHub issue's title and body. Also read README.md's Overview section and CONTRIBUTING.md's scope-boundary notes to understand this project's scope: Aphotic-Hypr is an Arch/AUR-only Hyprland desktop shell (Quickshell), no multi-distro support. Classify the issue and write ONLY a JSON object to result.json with keys: scope (\"aphotic\" if it's about this project, or \"off-topic\" if it's a generic Linux/Hyprland/Arch question unrelated to Aphotic itself), category (\"bug\", \"question\", \"enhancement\", or \"unclear\"), and summary (at most 2 plain sentences, empty string if scope is off-topic). Do not write or modify any other file, do not use git or gh." \
+            --allow-tool=write \
+            --no-ask-user
+
+      - name: Apply labels and summary
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let result;
+            try {
+              result = JSON.parse(fs.readFileSync('result.json', 'utf8'));
+            } catch (e) {
+              core.warning(`Could not parse triage result: ${e}`);
+              return;
+            }
+
+            const issue_number = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (e) {
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              }
+            }
+
+            if (result.scope === 'off-topic') {
+              await ensureLabel('off-topic', 'cfd3d7', 'Not about Aphotic-Hypr itself');
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['off-topic'] });
+              return;
+            }
+
+            if (result.category === 'unclear') {
+              await ensureLabel('needs-triage', 'fbca04', 'Scope or category unclear, needs a human look');
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['needs-triage'] });
+              return;
+            }
+
+            if (result.category === 'bug') {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['bug'] });
+            } else if (result.category === 'enhancement') {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['enhancement'] });
+            }
+
+            if (result.summary) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number,
+                body: `**Triage summary:** ${result.summary}\n\n<sub>Automated triage, not a maintainer response.</sub>`,
+              });
+            }

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -1,0 +1,90 @@
+name: Weekly repo-health digest
+
+on:
+  schedule:
+    - cron: "0 14 * * 1" # Monday 14:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Gather backlog data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          THIRTY_DAYS_AGO=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          FOURTEEN_DAYS_AGO=$(date -u -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ)
+
+          gh issue list -R "$REPO" --state open --json number,title,labels,updatedAt --limit 200 > open_issues.json
+          gh pr list -R "$REPO" --state open --json number,title,updatedAt,statusCheckRollup --limit 200 > open_prs.json
+
+          jq --arg cutoff "$THIRTY_DAYS_AGO" '[.[] | select(.updatedAt < $cutoff)]' open_issues.json > stale_issues.json
+          jq --arg cutoff "$FOURTEEN_DAYS_AGO" '[.[] | select(.updatedAt < $cutoff)]' open_prs.json > stale_prs.json
+          jq '[.[] | select([.statusCheckRollup[]?.conclusion] | any(. == "FAILURE"))]' open_prs.json > failing_prs.json
+
+          jq -n \
+            --slurpfile open_issues open_issues.json \
+            --slurpfile stale_issues stale_issues.json \
+            --slurpfile open_prs open_prs.json \
+            --slurpfile stale_prs stale_prs.json \
+            --slurpfile failing_prs failing_prs.json \
+            '{
+              open_issue_count: ($open_issues[0] | length),
+              stale_issues: $stale_issues[0],
+              open_pr_count: ($open_prs[0] | length),
+              stale_prs: $stale_prs[0],
+              failing_prs: $failing_prs[0],
+              labels_breakdown: ($open_issues[0] | map(.labels[].name) | group_by(.) | map({(.[0]): length}) | add // {})
+            }' > data.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
+
+      - name: Write digest
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          copilot -p "Read data.json in the working directory. It holds real, already-computed backlog numbers for this GitHub repo (open issue/PR counts, stale issues/PRs with no activity in 30/14 days, PRs with failing checks, label breakdown). Write a short markdown digest to digest.md summarizing exactly what's in data.json -- do not invent any numbers, issue titles, or facts not present in the file. Use headings and bullet lists. Link issues/PRs as #<number>. Keep it under 300 words." \
+            --allow-tool=write \
+            --no-ask-user
+
+      - name: Post to tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const digest = fs.existsSync('digest.md') ? fs.readFileSync('digest.md', 'utf8') : 'Digest generation failed -- see workflow run.';
+            const { owner, repo } = context.repo;
+            const title = 'Weekly Health Report';
+
+            const results = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue in:title "${title}"`,
+            });
+            let issueNumber = results.data.items.find(i => i.title === title)?.number;
+
+            if (!issueNumber) {
+              const created = await github.rest.issues.create({
+                owner, repo, title,
+                body: 'Rolling weekly repo-health digest. Each run adds a comment below.',
+              });
+              issueNumber = created.data.number;
+            }
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issueNumber,
+              body: `## ${new Date().toISOString().slice(0, 10)}\n\n${digest}`,
+            });

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,94 @@
+name: Wiki grounding sync
+
+on:
+  schedule:
+    - cron: "0 15 * * 1" # Monday 15:00 UTC, after the health digest
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  wiki-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone wiki
+        run: git clone --depth 1 "https://github.com/${{ github.repository }}.wiki.git" wiki
+
+      - name: Find mechanical drift
+        run: |
+          set -euo pipefail
+          findings=""
+
+          repo_ver=$(grep -oP '^## \K[0-9]+\.[0-9]+\.[0-9]+' RELEASE_NOTES.md | head -1)
+          wiki_ver=$(grep -oP '^## v\K[0-9]+\.[0-9]+\.[0-9]+' wiki/Release-Notes.md | head -1)
+          if [ "$repo_ver" != "$wiki_ver" ]; then
+            missing=$(awk -v stop="## $wiki_ver" '/^## / && index($0, stop) {exit} {print}' RELEASE_NOTES.md)
+            findings="${findings}### Release-Notes.md is behind\n\nRELEASE_NOTES.md's newest entry is \`$repo_ver\`, wiki's Release-Notes.md tops out at \`$wiki_ver\`. Missing entries, verbatim from RELEASE_NOTES.md:\n\n\`\`\`markdown\n${missing}\n\`\`\`\n\n"
+          fi
+
+          version=$(cat VERSION)
+          if ! grep -q "$version" wiki/Project-Status.md; then
+            findings="${findings}### Project-Status.md version mismatch\n\nVERSION file says \`$version\`, wiki/Project-Status.md doesn't mention it.\n\n"
+          fi
+
+          missing_cmds=""
+          for f in Configs/.local/lib/aphotic/commands/cmd_*.sh; do
+            name=$(basename "$f" .sh | sed 's/^cmd_//')
+            if ! grep -qi "aphotic $name\b" wiki/CLI-Reference.md; then
+              missing_cmds="${missing_cmds}- \`aphotic $name\`\n"
+            fi
+          done
+          if [ -n "$missing_cmds" ]; then
+            findings="${findings}### CLI-Reference.md may be missing commands\n\nThese exist as \`cmd_*.sh\` files but no \`aphotic <name>\` mention was found in CLI-Reference.md (false positives possible for grouped sub-verb commands):\n\n${missing_cmds}\n\n"
+          fi
+
+          if [ -z "$findings" ]; then
+            findings="No mechanical drift found this run."
+          fi
+          printf '%b' "$findings" > findings.md
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
+
+      - name: Write readable report
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          copilot -p "Read findings.md in the working directory. It lists mechanically-verified drift between this repo's docs and its GitHub wiki, already computed by a script -- every fact and code block in it is sourced, not guessed. Rewrite it as a clean markdown report to report.md: keep every fact, quoted snippet, and file path exactly as given, just improve the prose and headings. Do not add any claim, file, or fix that isn't already in findings.md." \
+            --allow-tool=write \
+            --no-ask-user
+
+      - name: Post to tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.existsSync('report.md') ? fs.readFileSync('report.md', 'utf8') : fs.readFileSync('findings.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const title = 'Wiki Drift Report';
+
+            const results = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue in:title "${title}"`,
+            });
+            let issueNumber = results.data.items.find(i => i.title === title)?.number;
+
+            if (!issueNumber) {
+              const created = await github.rest.issues.create({
+                owner, repo, title,
+                body: 'Rolling wiki-vs-repo drift report. Findings are mechanically verified, not guessed -- apply fixes to the wiki by hand. Each run adds a comment below.',
+              });
+              issueNumber = created.data.number;
+            }
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issueNumber,
+              body: `## ${new Date().toISOString().slice(0, 10)}\n\n${report}`,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,12 @@ CLAUDE.md
 aphotic.toml
 install.log
 
-# Clamped live palettes (themes/THEME_SPEC.md's "Clamped palettes") --
-# regenerated on every theme apply from the current wallpaper, and landing
-# inside the repo only because ~/.config/wallust symlinks here.
-Configs/wallust/colorschemes/*-live.json
+# ~/.config/wallust symlinks here, so everything that writes a colorscheme
+# at runtime lands in the working tree: the palette clamp's *-live.json
+# (themes/THEME_SPEC.md's "Clamped palettes"), a downloaded theme's own
+# scheme, and the Theme Creator's. Only the per-theme anchors are ours.
+Configs/wallust/colorschemes/*.json
+!Configs/wallust/colorschemes/*-anchor.json
 __pycache__/
 .DS_Store
 Thumbs.db

--- a/Configs/.local/lib/aphotic/commands/cmd_theme.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_theme.sh
@@ -115,6 +115,44 @@ _aphotic_theme_write_state() {
     jq -n --arg t "$theme" --arg w "$wallpaper" '{theme: $t, wallpaper: $w}' > "$tmp" && mv "$tmp" "$APHOTIC_THEME_STATE_FILE"
 }
 
+# `wallust cs <name>` resolves a scheme by name inside wallust's own
+# config dir, so a theme's [engine].colorscheme / [palette].anchor file
+# has to physically land here -- there's no path form to point elsewhere.
+_aphotic_theme_schemes_dir() {
+    printf '%s/wallust/colorschemes' "${XDG_CONFIG_HOME:-$HOME/.config}"
+}
+
+# A downloaded theme may ship <theme>/colorschemes/*.json for the palette
+# it pins. Core themes get theirs from the dots repo, which the community
+# ones have no way to write into, so the download installs them instead.
+_aphotic_theme_install_colorschemes() {
+    local dir="$1" schemes_dir scheme
+    schemes_dir="$(_aphotic_theme_schemes_dir)"
+    [[ -d "${dir}/colorschemes" ]] || return 0
+    mkdir -p "$schemes_dir"
+    for scheme in "${dir}/colorschemes"/*.json; do
+        [[ -f "$scheme" ]] || continue
+        cp "$scheme" "${schemes_dir}/$(basename "$scheme")"
+    done
+}
+
+# Only the ones this theme actually put there. Compared by content
+# rather than by name: ~/.config/wallust is a symlink into the dots
+# checkout, so a shipped scheme and a core one live at the same path and
+# no path test can tell them apart. An installed file that still matches
+# what this theme ships came from this theme; anything edited since, or
+# owned by something else, is left alone.
+_aphotic_theme_remove_colorschemes() {
+    local dir="$1" schemes_dir scheme
+    schemes_dir="$(_aphotic_theme_schemes_dir)"
+    [[ -d "${dir}/colorschemes" ]] || return 0
+    for scheme in "${dir}/colorschemes"/*.json; do
+        [[ -f "$scheme" ]] || continue
+        cmp -s "$scheme" "${schemes_dir}/$(basename "$scheme")" || continue
+        rm -f "${schemes_dir}/$(basename "$scheme")"
+    done
+}
+
 # Clone APHOTIC_THEMES_REPO on first use, `git pull --ff-only` on later
 # ones -- mirrors _aphotic_plugin_sync_repo (cmd_plugin.sh) exactly. A
 # pull failure is non-fatal, falls through to whatever's on disk already.
@@ -149,6 +187,7 @@ _aphotic_theme_download() {
 
     echo "Downloading ${name}..."
     cp -r "$src" "$dest"
+    _aphotic_theme_install_colorschemes "$dest"
 
     aphotic_ok "downloaded ${name}"
     echo "THEME DOWNLOADED: ${name}"
@@ -190,6 +229,7 @@ _aphotic_theme_update_one() {
         return 1
     fi
     rm -rf "$previous"
+    _aphotic_theme_install_colorschemes "$dest"
 
     aphotic_ok "updated ${name}"
     echo "THEME UPDATED: ${name}"
@@ -228,6 +268,7 @@ _aphotic_theme_remove() {
     [[ -e "$dest" ]] || { aphotic_err "not downloaded: ${name}"; return 1; }
 
     local was_active; was_active="$(_aphotic_theme_read_state | head -n1)"
+    _aphotic_theme_remove_colorschemes "$dest"
     rm -rf "$dest"
     aphotic_ok "removed ${name}"
 
@@ -265,7 +306,7 @@ _aphotic_theme_clamp_palette() {
         return 0
     }
 
-    local schemes_dir="${XDG_CONFIG_HOME:-$HOME/.config}/wallust/colorschemes"
+    local schemes_dir; schemes_dir="$(_aphotic_theme_schemes_dir)"
     local anchor_file="${schemes_dir}/${anchor}.json"
     if [[ ! -f "$anchor_file" ]]; then
         aphotic_warn "theme '${theme_name}' pins [palette].anchor = '${anchor}' but ${anchor_file} is missing -- applying unclamped palette"

--- a/Configs/quickshell/aphotic/modules/settings/panes/AppearancePane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/AppearancePane.qml
@@ -95,13 +95,7 @@ Item {
             Process {
                 id: downloadProc
                 onExited: {
-                    // Themes.qml's own scan (scanProc) has no public
-                    // rescan() to call here -- a freshly downloaded theme
-                    // won't show in the grid above until the shell
-                    // restarts. Re-running the two Processes above at
-                    // least moves the entry out of "available to
-                    // download" and picks up its `core: false` badge once
-                    // Themes.themes does notice it.
+                    Themes.rescan();
                     landing.refreshCommunity();
                 }
             }

--- a/Configs/quickshell/aphotic/services/Themes.qml
+++ b/Configs/quickshell/aphotic/services/Themes.qml
@@ -36,6 +36,13 @@ Singleton {
         return themes.find(t => t.name === themeName) ?? null;
     }
 
+    // The filesystem is the registry, so anything that adds or removes a
+    // directory under awwwDir (`aphotic theme download`/`remove`, or the
+    // Theme Creator) has to say so -- there's nothing watching it.
+    function rescan(): void {
+        scanProc.running = true;
+    }
+
     // Deliberately minimal: themes/THEME_SPEC.md's theme.toml is flat
     // ([section] headers, key = "value"/bool/number pairs, no arrays-of-
     // tables or multi-line strings), so a purpose-built line parser here

--- a/tests/test_theme_download.sh
+++ b/tests/test_theme_download.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# tests/test_theme_download.sh
+# `aphotic theme download/update/remove`: pull a community theme out of a
+# local aphotic-themes checkout. A theme is a directory plus a
+# theme.toml, so "downloaded" is answered by the filesystem and there is
+# no state file to assert against. What is worth pinning down is the
+# refusals (no manifest, already there, core theme), the staged swap on
+# update, and the colorschemes a theme ships alongside its wallpapers.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+# SCHEMES_DIR below resolves into the checkout (see the symlink note), so
+# clean the fixtures out of it rather than leaving them in the worktree.
+cleanup() {
+    rm -rf "$TESTHOME"
+    rm -f "$ROOT/Configs/wallust/colorschemes/scratch.json" \
+          "$ROOT/Configs/wallust/colorschemes/shared.json"
+}
+trap cleanup EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+COMMANDS_DIR="$ROOT/Configs/.local/lib/aphotic/commands"
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_theme.sh"
+
+export APHOTIC_THEMES_REPO="$TESTHOME/fake-themes"
+
+# Reproduce the live layout: install.sh symlinks ~/.config/wallust at the
+# dots checkout, so the directory a downloaded scheme lands in and the
+# one core schemes are tracked in are the same directory. Testing against
+# two separate dirs hides anything that tries to tell them apart by path.
+mkdir -p "$XDG_CONFIG_HOME" "$ROOT/Configs/wallust/colorschemes"
+ln -sfn "$ROOT/Configs/wallust" "$XDG_CONFIG_HOME/wallust"
+SCHEMES_DIR="$XDG_CONFIG_HOME/wallust/colorschemes"
+mkdir -p "$APHOTIC_AWWW_DIR"
+
+# The repo the download reads from. Already a git checkout so
+# _aphotic_theme_sync_repo takes its `git pull` branch and leaves the
+# fixture alone instead of trying to clone over the network.
+SRC="$APHOTIC_THEMES_REPO/scratch"
+mkdir -p "$SRC/colorschemes"
+cat > "$SRC/theme.toml" <<'EOF'
+[theme]
+display_name = "Scratch"
+
+[engine]
+colorscheme = "scratch"
+EOF
+printf 'x' > "$SRC/one.png"
+echo '{"special":{},"colors":{}}' > "$SRC/colorschemes/scratch.json"
+git -C "$APHOTIC_THEMES_REPO" init -q
+git -C "$APHOTIC_THEMES_REPO" add -A
+git -C "$APHOTIC_THEMES_REPO" -c user.email=t@t -c user.name=t commit -qm init
+
+# A directory with no theme.toml is not a theme.
+mkdir -p "$APHOTIC_THEMES_REPO/notatheme"
+_aphotic_theme_download notatheme >/dev/null 2>&1 && fail "downloaded a directory with no theme.toml"
+[[ -e "$APHOTIC_AWWW_DIR/notatheme" ]] && fail "left a directory behind for a rejected download"
+
+_aphotic_theme_download nosuchtheme >/dev/null 2>&1 && fail "downloaded a name that isn't in the repo"
+
+# The happy path, plus the colorscheme the theme ships.
+_aphotic_theme_download scratch >/dev/null 2>&1 || fail "download failed"
+[[ -f "$APHOTIC_AWWW_DIR/scratch/theme.toml" ]] || fail "no theme.toml after download"
+[[ -f "$APHOTIC_AWWW_DIR/scratch/one.png" ]] || fail "no wallpaper after download"
+[[ -f "$SCHEMES_DIR/scratch.json" ]] || fail "shipped colorscheme not installed to the wallust dir"
+
+_aphotic_theme_download scratch >/dev/null 2>&1 && fail "downloaded over an existing theme"
+
+# Update refreshes the payload in place and re-lands the colorscheme.
+printf 'xx' > "$SRC/two.png"
+echo '{"special":{"background":"#111111"},"colors":{}}' > "$SRC/colorschemes/scratch.json"
+_aphotic_theme_update scratch >/dev/null 2>&1 || fail "update failed"
+[[ -f "$APHOTIC_AWWW_DIR/scratch/two.png" ]] || fail "update didn't bring the new wallpaper"
+grep -q '111111' "$SCHEMES_DIR/scratch.json" || fail "update didn't refresh the colorscheme"
+
+# A staging failure must leave the working copy alone. An unreadable
+# source makes `cp -r` fail without touching the destination.
+chmod 000 "$SRC"
+_aphotic_theme_update scratch >/dev/null 2>&1 && fail "update reported success on an unreadable source"
+chmod 755 "$SRC"
+[[ -f "$APHOTIC_AWWW_DIR/scratch/one.png" ]] || fail "failed update destroyed the downloaded copy"
+[[ -e "$APHOTIC_AWWW_DIR/scratch.updating" ]] && fail "failed update left its staging directory behind"
+
+_aphotic_theme_update notdownloaded >/dev/null 2>&1 && fail "updated a theme that was never downloaded"
+
+# Core themes ship with Aphotic and `remove` must refuse them.
+CORE_ONE="${APHOTIC_CORE_THEMES[0]:-}"
+[[ -n "$CORE_ONE" ]] || fail "no core themes discovered from Configs/awww"
+mkdir -p "$APHOTIC_AWWW_DIR/$CORE_ONE"
+_aphotic_theme_remove "$CORE_ONE" >/dev/null 2>&1 && fail "removed a core theme"
+[[ -d "$APHOTIC_AWWW_DIR/$CORE_ONE" ]] || fail "refused remove deleted the core theme anyway"
+
+# Removing a theme takes its directory and the colorscheme it brought.
+# Kept off the active theme deliberately: removing the active one ends in
+# _aphotic_theme_apply, which needs awww and wallust running, so its
+# fallback is not something this suite can assert headlessly.
+_aphotic_theme_write_state "$CORE_ONE" ""
+_aphotic_theme_remove scratch >/dev/null 2>&1 || fail "remove failed"
+[[ -e "$APHOTIC_AWWW_DIR/scratch" ]] && fail "remove left the theme directory"
+[[ -f "$SCHEMES_DIR/scratch.json" ]] && fail "remove left the theme's colorscheme behind"
+
+_aphotic_theme_remove scratch >/dev/null 2>&1 && fail "removed a theme that wasn't downloaded"
+
+# A scheme whose installed copy no longer matches what the theme ships
+# belongs to someone else by then -- a core file of the same name, or an
+# edit the user made -- and remove must leave it there.
+rm -f "$SRC/colorschemes/scratch.json"
+echo '{"mine":true}' > "$SRC/colorschemes/shared.json"
+_aphotic_theme_download scratch >/dev/null 2>&1 || fail "second download failed"
+echo '{"someone-elses":true}' > "$SCHEMES_DIR/shared.json"
+_aphotic_theme_remove scratch >/dev/null 2>&1 || fail "second remove failed"
+[[ -f "$SCHEMES_DIR/shared.json" ]] || fail "remove deleted a colorscheme it did not install"
+rm -f "$SCHEMES_DIR/shared.json"
+
+echo "PASS: tests/test_theme_download.sh"

--- a/themes/THEME_SPEC.md
+++ b/themes/THEME_SPEC.md
@@ -200,8 +200,8 @@ theme's wallpaper image (`wallust run`). Some themes have a real brand
 palette that shouldn't drift with whatever art ships as the default
 wallpaper. None of the 8 shipped themes currently use this (HackTheBox
 briefly did, but its dynamically-derived look was preferred and it was
-reverted back to image-derivation) — the mechanism is still real and
-tested, just unused for now. For a theme that wants it, set
+reverted back to image-derivation). The community `dracula` theme does,
+and is the worked example. For a theme that wants it, set
 `[engine].colorscheme` to a name under
 `Configs/wallust/colorschemes/<name>.json` (pywal format: a `special`
 object with `background`/`foreground`/`cursor`, and a `colors` object
@@ -239,7 +239,8 @@ rolls out theme by theme.
 `anchor` names a pywal-format file under
 `Configs/wallust/colorschemes/<name>.json` — the same directory and format
 `[engine].colorscheme` reads, holding the palette this theme's colours are
-measured against. `scripts/generate-theme-anchors.sh` bootstraps one per
+measured against. A downloadable theme ships its own; see "Shipping a
+palette with a downloadable theme" below. `scripts/generate-theme-anchors.sh` bootstraps one per
 theme by deriving the palette of that theme's `[wallpaper].default` image
 (in an isolated wallust config/cache dir, so it never disturbs the live
 session), writing `<theme>-anchor.json`. Generating an anchor doesn't opt
@@ -342,6 +343,35 @@ currently-hardcoded `light: false`, which drives a couple of
 Quickshell-side visual tweaks (icon weight, desktop clock inversion)
 independently and would need its own theme.toml-driven wiring to
 actually flip for Latte.
+
+### Shipping a palette with a downloadable theme
+
+`[engine].colorscheme` and `[palette].anchor` both name a file under
+`~/.config/wallust/colorschemes/`, because `wallust cs <name>` resolves a
+scheme by name inside wallust's own config dir and takes no path. The 8
+shipped themes get theirs from this repo, which `install.sh` symlinks
+that directory at. A theme downloaded from
+[`aphotic-themes`](https://github.com/T-Crypt/aphotic-themes) has no way
+to write there, so it ships the file instead:
+
+```
+<theme>/
+├── theme.toml
+├── colorschemes/
+│   └── <name>.json      # pywal format, same as the -anchor.json files here
+└── wallpaper.png
+```
+
+`aphotic theme download` copies everything under `colorschemes/` into
+`~/.config/wallust/colorschemes/` after the theme itself, `update`
+refreshes them, and `remove` takes back the ones whose installed copy
+still matches what the theme ships. A file edited since install, or one
+that belongs to a shipped theme, is left where it is.
+
+Because that directory is a symlink into the checkout, anything landing
+there shows up in `git status`. `.gitignore` covers it: everything under
+`Configs/wallust/colorschemes/` is ignored except the tracked
+`*-anchor.json` files.
 
 ## Minimal valid theme
 


### PR DESCRIPTION
Three GitHub Actions workflows, all Copilot-CLI-backed, none touching application code:

- **`issue-triage.yml`** — on new/reopened issues, classifies scope (aphotic vs. off-topic) and category. Off-topic gets labeled and nothing else. Unclear gets `needs-triage`. Real bugs/enhancements get labeled and a 1-2 sentence triage summary comment.
- **`weekly-digest.yml`** — every Monday, computes real backlog numbers (open issue/PR counts, stale items, failing-check PRs) via `gh`/`jq`, then has Copilot CLI phrase them into a digest posted to a rolling "Weekly Health Report" issue.
- **`wiki-sync.yml`** — mechanically diffs `RELEASE_NOTES.md`/`VERSION`/CLI command files against the wiki, then has Copilot CLI clean up the wording of the findings (not invent new ones). Posts to a rolling "Wiki Drift Report" issue. Never pushes to the wiki — report only, you apply fixes by hand.

Verified locally against this repo's real wiki: the drift check already catches a real, existing gap — the wiki's `Release-Notes.md` tops out at v2.0.0 while `RELEASE_NOTES.md` has 2.0.1 and 2.0.2.

Untrusted issue content (title/body) is routed through `actions/github-script` file writes rather than shell string interpolation, since interpolating `${{ github.event.issue.body }}` into a `run:` block is a known injection vector on a public repo.

## Setup required before these run for real

All three need Copilot CLI authenticated via a **fine-grained PAT** (classic tokens are silently ignored):

1. Create a fine-grained PAT: resource owner = your personal account (not an org), repository access = public repos, Account permissions → Copilot Requests = Read-only.
2. Add it as a repo secret named `COPILOT_PAT`.

## Test plan

- [x] Add the `COPILOT_PAT` secret
- [ ] `workflow_dispatch` each workflow manually and check the output before trusting the schedule
- [ ] Open a throwaway off-topic-looking issue, confirm it gets labeled `off-topic` with no comment
- [ ] Confirm the digest and wiki-drift issues get created once and then accumulate comments on repeat runs, not duplicate issues