### PR TITLE
perf: gate disk and network usage polling behind real visibility

### DIFF
--- a/Configs/quickshell/aphotic/components/NetworkUsageWatch.qml
+++ b/Configs/quickshell/aphotic/components/NetworkUsageWatch.qml
@@ -1,0 +1,11 @@
+import QtQuick
+import qs.services
+
+// Mount this for as long as a surface reading NetworkUsage's live speeds
+// is on screen. Object lifetime is the registration, same shape as
+// SystemUsageWatch, so a surface behind a Loader cannot leak a watch by
+// missing an unpaired call.
+QtObject {
+    Component.onCompleted: NetworkUsage.subscribe()
+    Component.onDestruction: NetworkUsage.unsubscribe()
+}

--- a/Configs/quickshell/aphotic/components/qmldir
+++ b/Configs/quickshell/aphotic/components/qmldir
@@ -9,6 +9,7 @@ DepthLayer 1.0 DepthLayer.qml
 KbCodeField 1.0 KbCodeField.qml
 Logo 1.0 Logo.qml
 MaterialIcon 1.0 MaterialIcon.qml
+NetworkUsageWatch 1.0 NetworkUsageWatch.qml
 ProcessUsageWatch 1.0 ProcessUsageWatch.qml
 ScreenState 1.0 ScreenState.qml
 SettingsGroup 1.0 SettingsGroup.qml

--- a/Configs/quickshell/aphotic/modules/bar/components/status/NetworkSpeedStatus.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/status/NetworkSpeedStatus.qml
@@ -14,4 +14,6 @@ MaterialIcon {
     text: "swap_vert"
     color: root.colour
     fill: root.active ? 1 : 0
+
+    NetworkUsageWatch {}
 }

--- a/Configs/quickshell/aphotic/modules/bar/popouts/NetworkSpeedPopout.qml
+++ b/Configs/quickshell/aphotic/modules/bar/popouts/NetworkSpeedPopout.qml
@@ -9,6 +9,8 @@ ColumnLayout {
 
     spacing: Tokens.spacing.medium
 
+    NetworkUsageWatch {}
+
     component SpeedRow: RowLayout {
         required property string icon
         required property string label

--- a/Configs/quickshell/aphotic/modules/dashboard/Dashboard.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/Dashboard.qml
@@ -840,6 +840,8 @@ Item {
         radius: Tokens.rounding.large
         clip: true
 
+        NetworkUsageWatch {}
+
         ColumnLayout {
             anchors.fill: parent
             anchors.margins: Tokens.padding.large

--- a/Configs/quickshell/aphotic/services/NetworkUsage.qml
+++ b/Configs/quickshell/aphotic/services/NetworkUsage.qml
@@ -37,6 +37,25 @@ Singleton {
     property real _initialTxBytes: 0
     property bool _initialized: false
 
+    // Ungated before this: the bar's networkSpeed status icon is
+    // filtered out of the entries model entirely when disabled
+    // (StatusIcons.qml), so NetworkSpeedStatus.qml is never even
+    // instantiated in that case, yet this timer polled /proc/net/dev
+    // every tick anyway with nothing to show it to. Same registration-
+    // counted shape as SystemUsage.detailedMonitoring -- see
+    // NetworkUsageWatch.qml, mounted by NetworkSpeedStatus.qml,
+    // NetworkSpeedPopout.qml and Dashboard.qml's NetworkCard.
+    property int _watchers: 0
+    readonly property bool wanted: root._watchers > 0
+
+    function subscribe(): void {
+        root._watchers = root._watchers + 1;
+    }
+
+    function unsubscribe(): void {
+        root._watchers = Math.max(0, root._watchers - 1);
+    }
+
     function formatBytes(bytes: real): var {
         // Handle negative or invalid values
         if (bytes < 0 || isNaN(bytes) || !isFinite(bytes)) {
@@ -153,7 +172,7 @@ Singleton {
 
     Timer {
         interval: GlobalConfig.dashboard.resourceUpdateInterval
-        running: true
+        running: root.wanted
         repeat: true
         triggeredOnStart: true
 

--- a/Configs/quickshell/aphotic/services/SystemUsage.qml
+++ b/Configs/quickshell/aphotic/services/SystemUsage.qml
@@ -397,19 +397,28 @@ Singleton {
         onTriggered: {
             statProc.running = true;
             memProc.running = true;
-            diskProc.running = true;
         }
     }
 
     // triggeredOnStart is what makes opening a surface feel instant: the
     // gate going true fires a tick immediately rather than leaving the
     // card blank for up to 30s.
+    //
+    // diskProc lives here, not on the 2s timer above -- disk usage has no
+    // always-visible consumer (only the Performance tab/System pane/
+    // resources popout show it, same as tempProc/GPU stats), where
+    // cpuPerc/memPerc feed the bar directly and have to stay on the fast
+    // tick. `df` was running every 2s forever for a reading nothing was
+    // displaying most of the time. See docs/archive/BACKLOG.md's E2-09.
     Timer {
         interval: Config.dashboard.detailUpdateInterval
         running: root.detailedMonitoring
         repeat: true
         triggeredOnStart: true
-        onTriggered: tempProc.running = true
+        onTriggered: {
+            tempProc.running = true;
+            diskProc.running = true;
+        }
     }
 
     // Split out of the timer above rather than sharing it: the two used to


### PR DESCRIPTION
## What this changes

Two of `docs/archive/BACKLOG.md`'s `E2-09` tracked always-on timers, both fixable now without needing a design decision first (unlike `Colours.qml`/`Themes.qml`'s 1s polls, which are the deliberate mitigation for `FileView.watchChanges`'s documented unreliability):

- `SystemUsage`'s disk poll (`df`, every 2s) had no always-visible consumer -- only the Performance tab, Settings' System pane, and the bar's resources popout show disk usage. Moved it onto the existing `detailedMonitoring`-gated timer alongside `tempProc`, so `df` only runs while one of those is actually open. Verified those three surfaces are covered: `SettingsWindow.qml`/`DashboardWindow.qml` both already mount `SystemUsageWatch` at the window level, and `ResourcesPopout.qml` mounts its own.
- `NetworkUsage`'s `/proc/net/dev` poll ran every 2s even with the bar's `networkSpeed` status icon disabled -- `StatusIcons.qml` filters disabled icons out of the entries model entirely, so nothing was reading it in that case. Added the same registration-counted watch shape `SystemUsage.detailedMonitoring` already uses: `NetworkUsageWatch.qml`, mounted by the status icon itself, its popout, and the dashboard's network card.

## Scope

- [x] This is scoped to one module/command/fix, not a multi-surface change (both are the same class of fix -- gate an always-on poll behind real visibility)
- [ ] Related `README.md` Roadmap item (if any):
- [ ] If this touches `install.sh` or a systemd unit file: N/A

## Verification

- [ ] `pkill -x qs` then a fresh `qs -c aphotic` restart -- not run against the live session from here, see below
- [x] Checked logs for `Configuration Loaded` and zero new errors (`qs -p Configs/quickshell/aphotic/shell.qml -n`)
- [x] Confirmed the shell is still running afterward
- [x] For visual changes: N/A, no visual change -- same data, same surfaces, just gated
- [x] `bash -n` on any shell script touched -- N/A, no shell script in this diff
- [ ] Added/updated a test under `tests/`
- [x] No debug residue left behind

## Anything the reviewer should know

- Only ran the headless QML probe. Did not restart the live shell from this session.
- Did not attempt the `QSG_RENDERER_DEBUG=change` pass `PERF-01` also prescribes for the residual, unattributed idle-GPU gap -- that needs a live instrumented run, not a code change, and is out of scope here.
- Confirmed via an audit pass that no *new* ungated timer exists beyond what `E2-09`/`PERF-01` already track -- the full inventory (`Nmcli`, `AiProviders`, `PkgSearch`, `ProcessUsage`, `GpuVramSource`, `AgentEvents`, `DepthFx`) was cross-checked and every one is either already gated or already flagged as its own separate decision.