### PR TITLE
wallpaper picker: blurred band backdrop, beveled cards, HUD rail

### DIFF
--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperBackdrop.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperBackdrop.qml
@@ -1,0 +1,145 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Effects
+import qs.components
+import qs.services
+
+Item {
+    id: root
+
+    required property string source
+    required property int bandHeight
+    required property int fadeExtent
+    property bool active: false
+
+    readonly property int decodeWidth: 640
+    readonly property int decodeHeight: 360
+
+    readonly property string bandSource: root.active ? root.source : ""
+    readonly property real fadeStop: root.bandHeight > 0 ? root.fadeExtent / root.bandHeight : 0
+
+    onBandSourceChanged: {
+        if (bleed.current === one)
+            two.path = root.bandSource;
+        else
+            one.path = root.bandSource;
+    }
+
+    Item {
+        id: band
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        height: root.bandHeight
+        visible: root.bandSource.length > 0
+
+        layer.enabled: true
+        layer.effect: MultiEffect {
+            maskEnabled: true
+            maskSource: fade
+            autoPaddingEnabled: false
+        }
+
+        Item {
+            id: bleed
+
+            property Image current: one
+
+            width: root.width
+            height: root.height
+            y: -band.y
+
+            layer.enabled: DepthFx.enabled
+            layer.effect: MultiEffect {
+                saturation: -0.08
+                brightness: -0.02
+                blurEnabled: true
+                blur: 1
+                blurMax: DepthFx.full ? 64 : 40
+                autoPaddingEnabled: false
+            }
+
+            Img {
+                id: one
+            }
+
+            Img {
+                id: two
+            }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: Colours.palette.m3surfaceContainer
+            opacity: 0.15
+
+            Behavior on color {
+                CAnim {}
+            }
+        }
+
+        DepthLayer {
+            anchors.fill: parent
+            opacityScale: 1
+        }
+    }
+
+    Rectangle {
+        id: fade
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        height: root.bandHeight
+        visible: false
+        layer.enabled: true
+
+        gradient: Gradient {
+            GradientStop {
+                position: 0
+                color: "#00ffffff"
+            }
+            GradientStop {
+                position: root.fadeStop
+                color: "#ffffffff"
+            }
+            GradientStop {
+                position: 1 - root.fadeStop
+                color: "#ffffffff"
+            }
+            GradientStop {
+                position: 1
+                color: "#00ffffff"
+            }
+        }
+    }
+
+    component Img: Image {
+        id: img
+
+        property string path
+
+        anchors.fill: parent
+        source: img.path
+        fillMode: Image.PreserveAspectCrop
+        asynchronous: true
+        cache: true
+        smooth: true
+        sourceSize.width: root.decodeWidth
+        sourceSize.height: root.decodeHeight
+        opacity: bleed.current === img ? 1 : 0
+
+        onStatusChanged: {
+            if (img.status === Image.Ready)
+                bleed.current = img;
+        }
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperCard.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperCard.qml
@@ -15,8 +15,6 @@ Item {
     required property int decodeHeight
     required property int matteWidth
     required property int matteHeight
-    required property int textureWidth
-    required property int textureHeight
 
     property real distance: 0
     property bool active: false

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperCard.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperCard.qml
@@ -92,7 +92,7 @@ Item {
         layer.enabled: true
         layer.smooth: true
         layer.effect: Mask {
-            maskSource: silhouette
+            maskSource: silhouetteSource
             maskThresholdMin: 0
             maskSpreadAtMin: 0
             blurEnabled: root.dofAmount > 0.04
@@ -133,13 +133,27 @@ Item {
         id: silhouette
 
         anchors.fill: parent
-        visible: false
-        layer.enabled: true
         fillColour: "white"
         strokeColour: "transparent"
         strokeWidth: 0
         chamfer: root.chamfer
         corner: root.corner
+    }
+
+    // The mask source is an explicit live ShaderEffectSource rather than
+    // `visible: false` + `layer.enabled` on the shape itself. An invisible
+    // item leaves the scene graph while the picker window is hidden, and
+    // nothing dirties it when the window comes back, so the mask sampled an
+    // empty texture and multiplied the whole card away -- an empty bevel with
+    // no artwork, until any movement happened to dirty the layer again.
+    ShaderEffectSource {
+        id: silhouetteSource
+
+        anchors.fill: parent
+        sourceItem: silhouette
+        hideSource: true
+        live: true
+        visible: false
     }
 
     BevelPath {

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperCard.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperCard.qml
@@ -1,0 +1,224 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Shapes
+import qs.config
+import qs.components
+import qs.components.effects
+import qs.services
+
+Item {
+    id: root
+
+    required property string source
+    required property int decodeWidth
+    required property int decodeHeight
+    required property int matteWidth
+    required property int matteHeight
+    required property int textureWidth
+    required property int textureHeight
+
+    property real distance: 0
+    property bool active: false
+    property bool locked: false
+
+    readonly property real closeness: Math.max(0, 1 - Math.abs(root.distance))
+    readonly property real dofAmount: DepthFx.enabled ? Math.min(1, Math.abs(root.distance) * 0.5) : 0
+
+    readonly property int chamfer: Math.max(10, Math.round(root.height * 0.14))
+    readonly property int corner: Math.max(4, Math.round(root.height * 0.04))
+
+    property real _punch: 0
+    property bool _hovered: false
+    property real _lift: root.active ? -root.height * 0.07 : 0
+
+    signal activated
+    signal requested
+
+    scale: (root._hovered && !root.active ? 1.05 : 1) * (1 + 0.06 * root._punch)
+
+    onLockedChanged: {
+        if (root.locked)
+            punch.restart();
+    }
+
+    transform: Translate {
+        y: root._lift
+    }
+
+    Behavior on scale {
+        Anim {
+            type: Anim.FastEffects
+        }
+    }
+
+    Behavior on _lift {
+        Anim {
+            type: Anim.DefaultSpatial
+        }
+    }
+
+    SequentialAnimation {
+        id: punch
+
+        NumberAnimation {
+            target: root
+            property: "_punch"
+            to: 1
+            duration: Tokens.anim.durations.expressiveFastEffects
+            easing: Tokens.anim.expressiveDefaultSpatial
+        }
+        NumberAnimation {
+            target: root
+            property: "_punch"
+            to: 0
+            duration: Tokens.anim.durations.expressiveFastEffects
+            easing: Tokens.anim.expressiveDefaultSpatial
+        }
+    }
+
+    BioluminescentGlow {
+        target: body
+        radius: Tokens.rounding.large
+        glowColour: Colours.palette.m3primary
+        glowBlur: 40
+        glowSpread: 0.1
+        intensity: root.active ? DepthFx.glowIntensity : 0
+    }
+
+    Item {
+        id: body
+
+        anchors.fill: parent
+
+        layer.enabled: true
+        layer.smooth: true
+        layer.effect: Mask {
+            maskSource: silhouette
+            maskThresholdMin: 0
+            maskSpreadAtMin: 0
+            blurEnabled: root.dofAmount > 0.04
+            blur: root.dofAmount
+            blurMax: DepthFx.full ? 24 : 12
+            autoPaddingEnabled: false
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: Colours.tPalette.m3surfaceContainer
+        }
+
+        Image {
+            anchors.fill: parent
+            source: root.source
+            fillMode: Image.PreserveAspectCrop
+            asynchronous: true
+            cache: true
+            smooth: true
+            opacity: 0.55
+            sourceSize.width: root.matteWidth
+            sourceSize.height: root.matteHeight
+        }
+
+        Image {
+            anchors.fill: parent
+            source: root.source
+            fillMode: Image.PreserveAspectFit
+            asynchronous: true
+            cache: true
+            sourceSize.width: root.decodeWidth
+            sourceSize.height: root.decodeHeight
+        }
+    }
+
+    BevelPath {
+        id: silhouette
+
+        anchors.fill: parent
+        visible: false
+        layer.enabled: true
+        fillColour: "white"
+        strokeColour: "transparent"
+        strokeWidth: 0
+        chamfer: root.chamfer
+        corner: root.corner
+    }
+
+    BevelPath {
+        anchors.fill: parent
+        fillColour: "transparent"
+        strokeColour: Qt.tint(Colours.palette.m3outlineVariant, Qt.alpha(Colours.palette.m3primary, 0.5 * root.closeness))
+        strokeWidth: 1.5
+        opacity: 0.25 + 0.35 * root.closeness
+        chamfer: root.chamfer
+        corner: root.corner
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onEntered: root._hovered = true
+        onExited: root._hovered = false
+        onClicked: root.active ? root.activated() : root.requested()
+    }
+
+    component BevelPath: Shape {
+        id: bevel
+
+        property color fillColour: "transparent"
+        property color strokeColour: "transparent"
+        property real strokeWidth: 0
+        property int chamfer: 44
+        property int corner: Tokens.rounding.medium
+
+        preferredRendererType: Shape.CurveRenderer
+
+        ShapePath {
+            fillColor: bevel.fillColour
+            strokeColor: bevel.strokeColour
+            strokeWidth: bevel.strokeWidth
+            joinStyle: ShapePath.MiterJoin
+
+            startX: bevel.chamfer
+            startY: 0
+
+            PathLine {
+                x: bevel.width - bevel.corner
+                y: 0
+            }
+            PathArc {
+                x: bevel.width
+                y: bevel.corner
+                radiusX: bevel.corner
+                radiusY: bevel.corner
+            }
+            PathLine {
+                x: bevel.width
+                y: bevel.height - bevel.chamfer
+            }
+            PathLine {
+                x: bevel.width - bevel.chamfer
+                y: bevel.height
+            }
+            PathLine {
+                x: bevel.corner
+                y: bevel.height
+            }
+            PathArc {
+                x: 0
+                y: bevel.height - bevel.corner
+                radiusX: bevel.corner
+                radiusY: bevel.corner
+            }
+            PathLine {
+                x: 0
+                y: bevel.chamfer
+            }
+            PathLine {
+                x: bevel.chamfer
+                y: 0
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
@@ -19,14 +19,9 @@ Item {
     readonly property int stripWidth: Math.min(slotPitch * visibleSlots, Math.max(cellWidth, Math.round(root.width * 0.86)))
     readonly property real centerOffset: (stripWidth - cellWidth) / 2
 
-    // The strip clips horizontally, so its height has to clear the tallest a
-    // card ever gets -- centre scale times the hover and settle-punch bumps --
-    // plus the glow's bleed, or the clip edge slices the top of the card the
-    // moment it grows.
-    readonly property int stripHeight: Math.round(cellHeight * centerScale * 1.18) + Math.round(cellHeight * 0.28)
+    readonly property int heroHeight: Math.round(cellHeight * centerScale)
+    readonly property int stripHeight: heroHeight + Math.round(cellHeight * 0.5)
 
-    readonly property int textureWidth: Math.round(cellWidth * centerScale)
-    readonly property int textureHeight: Math.round(cellHeight * centerScale)
     readonly property int matteWidth: 64
     readonly property int matteHeight: 36
 
@@ -202,7 +197,6 @@ Item {
             spacing: root.cellSpacing
             leftMargin: root.centerOffset
             rightMargin: root.centerOffset
-            clip: true
             cacheBuffer: root.slotPitch * 2
 
             snapMode: ListView.NoSnap
@@ -266,8 +260,7 @@ Item {
                 readonly property real distance: (itemCenterX - viewCenterX) / root.slotPitch
 
                 width: root.cellWidth
-                height: root.cellHeight
-                y: (strip.height - height) / 2
+                height: strip.height
                 scale: Math.max(0.42, root.centerScale - Math.abs(distance) * 0.34)
                 opacity: Math.max(0, 1 - Math.abs(distance) * 0.38)
 
@@ -283,15 +276,16 @@ Item {
                 }
 
                 WallpaperCard {
-                    anchors.fill: parent
+                    anchors.centerIn: parent
+
+                    width: root.cellWidth
+                    height: root.cellHeight
 
                     source: `file://${Themes.awwwDir}/${Themes.activeTheme}/${delegate.modelData}`
                     decodeWidth: root.cellWidth
                     decodeHeight: root.cellHeight
                     matteWidth: root.matteWidth
                     matteHeight: root.matteHeight
-                    textureWidth: root.textureWidth
-                    textureHeight: root.textureHeight
                     distance: delegate.distance
                     active: delegate.index === strip.currentIndex
                     locked: delegate.index === root.settledIndex

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
@@ -74,9 +74,13 @@ Item {
         root.screenState.wallpaperPicker = false;
     }
 
+    // Escaping without having moved used to re-apply the wallpaper that was
+    // already active, spending a full wallust + awww + sddm-sync run to
+    // arrive back where it started.
     function _revertAndClose(): void {
         root._cancelPreview();
-        Themes.setWallpaperInActiveTheme(root._originalWallpaper);
+        if (root._originalWallpaper && root._originalWallpaper !== Themes.activeWallpaper)
+            Themes.setWallpaperInActiveTheme(root._originalWallpaper);
         root.screenState.wallpaperPicker = false;
     }
 

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
@@ -37,6 +37,9 @@ Item {
     property string _originalWallpaper: ""
     property int _previewIndex: -1
     property int settledIndex: -1
+    property int _pendingIndex: -1
+
+    readonly property int _focusIndex: root._pendingIndex >= 0 ? root._pendingIndex : strip.currentIndex
 
     focus: true
 
@@ -115,23 +118,50 @@ Item {
         root.settledIndex = strip.currentIndex;
     }
 
-    function _flickToIndex(targetIndex: int): void {
-        const clamped = Math.max(0, Math.min(targetIndex, strip.count - 1));
-        const deltaItems = clamped - strip.currentIndex;
-        if (deltaItems === 0)
+    // A keyed step used to be a flick() sized to coast exactly one slot,
+    // which fought both the settle spring still writing contentX and the
+    // next keypress reading a currentIndex that was mid-flight. _pendingIndex
+    // holds the target across an in-flight glide so presses accumulate
+    // instead of each restarting from wherever the strip happens to be.
+    function _goToIndex(targetIndex: int): void {
+        if (strip.count === 0)
             return;
-        const direction = Math.sign(deltaItems);
-        const distance = Math.abs(deltaItems) * root.slotPitch;
-        strip.flick(root._clampVelocity(-direction * Math.sqrt(2 * root.flickDeceleration * distance)), 0);
+        const clamped = Math.max(0, Math.min(targetIndex, strip.count - 1));
+        if (clamped === root._focusIndex)
+            return;
+
+        root._cancelPreview();
+        root.settledIndex = -1;
+        root._pendingIndex = clamped;
+
+        settleAnim.stop();
+        glideAnim.stop();
+        strip.cancelFlick();
+
+        const steps = Math.max(1, Math.abs(clamped - root._indexAtCenter()));
+        glideAnim.duration = Math.min(Tokens.anim.durations.expressiveDefaultSpatial, Tokens.anim.durations.small + 40 * steps);
+        glideAnim.from = strip.contentX;
+        glideAnim.to = root._targetContentX(clamped);
+        glideAnim.start();
+    }
+
+    function _step(delta: int): void {
+        root._goToIndex(root._focusIndex + delta);
+    }
+
+    function _abortGlide(): void {
+        glideAnim.stop();
+        root._pendingIndex = -1;
     }
 
     function _wheelImpulse(direction: int): void {
+        root._abortGlide();
         const combined = -strip.horizontalVelocity + direction * root.singleStepVelocity;
         strip.flick(root._clampVelocity(-combined), 0);
     }
 
-    Keys.onLeftPressed: root._flickToIndex(strip.currentIndex - 1)
-    Keys.onRightPressed: root._flickToIndex(strip.currentIndex + 1)
+    Keys.onLeftPressed: root._step(-1)
+    Keys.onRightPressed: root._step(1)
     Keys.onReturnPressed: root._commit()
     Keys.onEscapePressed: root._revertAndClose()
 
@@ -141,6 +171,7 @@ Item {
             if (!root.screenState.wallpaperPicker)
                 return;
             root._cancelPreview();
+            root._abortGlide();
             root._originalWallpaper = Themes.activeWallpaper;
             const idx = Themes.wallpapersInActiveTheme.indexOf(Themes.activeWallpaper);
             if (idx !== -1) {
@@ -227,7 +258,12 @@ Item {
             }
 
             onMovementStarted: root.settledIndex = -1
-            onMovementEnded: root._settle()
+            onMovementEnded: {
+                if (glideAnim.running)
+                    return;
+                root._settle();
+            }
+            onDragStarted: root._abortGlide()
 
             Timer {
                 id: previewDelay
@@ -243,6 +279,25 @@ Item {
                 property: "contentX"
                 spring: 2.2
                 damping: 0.42
+            }
+
+            NumberAnimation {
+                id: glideAnim
+
+                target: strip
+                property: "contentX"
+                easing: Tokens.anim.emphasizedDecel
+
+                onFinished: {
+                    const landed = root._pendingIndex;
+                    root._pendingIndex = -1;
+                    if (landed < 0)
+                        return;
+                    strip.currentIndex = landed;
+                    root._previewIndex = landed;
+                    previewDelay.restart();
+                    root.settledIndex = landed;
+                }
             }
 
             WheelHandler {
@@ -291,7 +346,7 @@ Item {
                     locked: delegate.index === root.settledIndex
 
                     onActivated: root._commit()
-                    onRequested: root._flickToIndex(delegate.index)
+                    onRequested: root._goToIndex(delegate.index)
                 }
             }
         }
@@ -359,7 +414,7 @@ Item {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: root._flickToIndex(dot.wallpaperIndex)
+                            onClicked: root._goToIndex(dot.wallpaperIndex)
                         }
                     }
                 }

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
@@ -1,7 +1,6 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Effects
 import qs.config
 import qs.components
 import qs.services
@@ -11,25 +10,45 @@ Item {
 
     required property ScreenState screenState
 
-    readonly property int cellWidth: 300
-    readonly property int cellHeight: 169
-    readonly property int cellSpacing: 20
+    readonly property int cellHeight: Math.max(120, Math.round(root.height * 0.219))
+    readonly property int cellWidth: Math.round(cellHeight * 16 / 9)
+    readonly property int cellSpacing: Math.max(8, Math.round(root.width * 0.007))
     readonly property int slotPitch: cellWidth + cellSpacing
     readonly property real centerScale: 1.35
     readonly property int visibleSlots: 5
-    readonly property real centerOffset: (slotPitch * visibleSlots - cellWidth) / 2
+    readonly property int stripWidth: Math.min(slotPitch * visibleSlots, Math.max(cellWidth, Math.round(root.width * 0.86)))
+    readonly property real centerOffset: (stripWidth - cellWidth) / 2
+
+    // The strip clips horizontally, so its height has to clear the tallest a
+    // card ever gets -- centre scale times the hover and settle-punch bumps --
+    // plus the glow's bleed, or the clip edge slices the top of the card the
+    // moment it grows.
+    readonly property int stripHeight: Math.round(cellHeight * centerScale * 1.18) + Math.round(cellHeight * 0.28)
+
+    readonly property int textureWidth: Math.round(cellWidth * centerScale)
+    readonly property int textureHeight: Math.round(cellHeight * centerScale)
+    readonly property int matteWidth: 64
+    readonly property int matteHeight: 36
+
+    readonly property int bandHeight: Math.max(320, Math.round(root.height * 0.63))
+    readonly property int bandFade: Math.round(bandHeight * 0.15)
 
     readonly property real flickDeceleration: 1000
     readonly property real maxFlickVelocity: 4800
     readonly property real singleStepVelocity: Math.sqrt(2 * flickDeceleration * slotPitch)
 
+    readonly property string backdropSource: root._pathFor(strip.currentIndex)
+
     property string _originalWallpaper: ""
     property int _previewIndex: -1
-
-    implicitWidth: slotPitch * visibleSlots + Tokens.padding.large * 2
-    implicitHeight: cellHeight * centerScale + caption.implicitHeight + Tokens.spacing.large + Tokens.padding.large * 2
+    property int settledIndex: -1
 
     focus: true
+
+    function _pathFor(index: int): string {
+        const file = Themes.wallpapersInActiveTheme[index];
+        return file ? `file://${Themes.awwwDir}/${Themes.activeTheme}/${file}` : "";
+    }
 
     // Themes.setTheme() writes ~/.local/state/aphotic/theme.json and queues
     // wallust + awww, which rewrites Colours.qml and so hot-reloads the whole
@@ -79,11 +98,26 @@ Item {
         return clamped * root.slotPitch - root.centerOffset;
     }
 
+    // centerOffset is derived from the window's width, which is still
+    // unresolved when the picker is first shown, so the contentX set on open
+    // is computed against the wrong offset and leaves the strip parked
+    // between two slots. Re-anchoring whenever the offset changes is what
+    // keeps the selected card actually centred.
+    function _recenter(): void {
+        if (!root.screenState?.wallpaperPicker)
+            return;
+        strip.contentX = root._targetContentX(strip.currentIndex);
+    }
+
+    onCenterOffsetChanged: Qt.callLater(root._recenter)
+    onSlotPitchChanged: Qt.callLater(root._recenter)
+
     function _settle(): void {
         settleAnim.to = root._targetContentX(strip.currentIndex);
         settleAnim.restart();
         root._previewIndex = strip.currentIndex;
         previewDelay.restart();
+        root.settledIndex = strip.currentIndex;
     }
 
     function _flickToIndex(targetIndex: int): void {
@@ -117,7 +151,10 @@ Item {
             if (idx !== -1) {
                 strip.currentIndex = idx;
                 strip.contentX = root._targetContentX(idx);
+                Qt.callLater(root._recenter);
             }
+            root.settledIndex = -1;
+            root.settledIndex = strip.currentIndex;
             root.forceActiveFocus();
         }
     }
@@ -132,181 +169,205 @@ Item {
 
             visible: false
 
+            readonly property string path: `file://${Themes.awwwDir}/${Themes.activeTheme}/${preload.modelData}`
+
             Image {
-                source: `file://${Themes.awwwDir}/${Themes.activeTheme}/${preload.modelData}`
+                source: preload.path
                 asynchronous: true
                 cache: true
                 sourceSize.width: root.cellWidth
                 sourceSize.height: root.cellHeight
             }
+
+            Image {
+                source: preload.path
+                asynchronous: true
+                cache: true
+                sourceSize.width: root.matteWidth
+                sourceSize.height: root.matteHeight
+            }
         }
     }
 
-    StyledClippingRect {
-        id: filmstripSurface
+    Column {
+        anchors.centerIn: parent
+        spacing: Tokens.spacing.large
 
-        anchors.fill: parent
-        radius: Tokens.rounding.extraLarge
-        color: Colours.palette.m3surfaceContainerHigh
-        border.width: Config.border.thickness
-        border.color: Colours.palette.m3outlineVariant
+        ListView {
+            id: strip
 
-        DepthLayer {
-            anchors.fill: parent
-            opacityScale: 0.7
-        }
+            width: root.stripWidth
+            height: root.stripHeight
+            orientation: ListView.Horizontal
+            spacing: root.cellSpacing
+            leftMargin: root.centerOffset
+            rightMargin: root.centerOffset
+            clip: true
+            cacheBuffer: root.slotPitch * 2
 
-        DepthGradient {
-            anchors.fill: parent
-            radius: filmstripSurface.radius
-            baseColour: filmstripSurface.color
+            snapMode: ListView.NoSnap
+
+            flickDeceleration: root.flickDeceleration
+            maximumFlickVelocity: root.maxFlickVelocity
+            boundsBehavior: Flickable.DragOverBounds
+
+            model: Themes.wallpapersInActiveTheme
+
+            onContentXChanged: {
+                // This filmstrip's item tree stays alive even while the
+                // picker window is hidden (only PanelWindow.visible
+                // toggles). Switching themes from Settings elsewhere
+                // reassigns Themes.wallpapersInActiveTheme, which resets
+                // this (currently invisible) ListView's model -- Qt resets
+                // contentX to 0 as part of that, re-entering this handler
+                // while QQuickItemView::setModel is still mid-update.
+                // None of this logic is meaningful while the picker isn't
+                // open, so skip it rather than let it run reentrantly.
+                // The margins below also nudge contentX during creation,
+                // before the required screenState is assigned.
+                if (!root.screenState?.wallpaperPicker)
+                    return;
+                const idx = root._indexAtCenter();
+                if (idx !== -1 && idx !== strip.currentIndex)
+                    strip.currentIndex = idx;
+            }
+
+            onMovementStarted: root.settledIndex = -1
+            onMovementEnded: root._settle()
+
+            Timer {
+                id: previewDelay
+
+                interval: Tokens.anim.durations.expressiveSlowEffects
+                onTriggered: root._applyPreview()
+            }
+
+            SpringAnimation {
+                id: settleAnim
+
+                target: strip
+                property: "contentX"
+                spring: 2.2
+                damping: 0.42
+            }
+
+            WheelHandler {
+                onWheel: event => root._wheelImpulse(event.angleDelta.y < 0 ? 1 : -1)
+            }
+
+            delegate: Item {
+                id: delegate
+
+                required property string modelData
+                required property int index
+
+                readonly property real itemCenterX: x + width / 2
+                readonly property real viewCenterX: strip.contentX + strip.width / 2
+                readonly property real distance: (itemCenterX - viewCenterX) / root.slotPitch
+
+                width: root.cellWidth
+                height: root.cellHeight
+                y: (strip.height - height) / 2
+                scale: Math.max(0.42, root.centerScale - Math.abs(distance) * 0.34)
+                opacity: Math.max(0, 1 - Math.abs(distance) * 0.38)
+
+                transform: Rotation {
+                    origin.x: delegate.width / 2
+                    origin.y: delegate.height / 2
+                    axis {
+                        x: 0
+                        y: 1
+                        z: 0
+                    }
+                    angle: Math.max(-32, Math.min(32, delegate.distance * -26))
+                }
+
+                WallpaperCard {
+                    anchors.fill: parent
+
+                    source: `file://${Themes.awwwDir}/${Themes.activeTheme}/${delegate.modelData}`
+                    decodeWidth: root.cellWidth
+                    decodeHeight: root.cellHeight
+                    matteWidth: root.matteWidth
+                    matteHeight: root.matteHeight
+                    textureWidth: root.textureWidth
+                    textureHeight: root.textureHeight
+                    distance: delegate.distance
+                    active: delegate.index === strip.currentIndex
+                    locked: delegate.index === root.settledIndex
+
+                    onActivated: root._commit()
+                    onRequested: root._flickToIndex(delegate.index)
+                }
+            }
         }
 
         Column {
-            anchors.centerIn: parent
-            spacing: Tokens.spacing.large
+            id: hud
 
-            ListView {
-                id: strip
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: Tokens.spacing.small
 
-                width: root.slotPitch * root.visibleSlots
-                height: root.cellHeight * root.centerScale
-                orientation: ListView.Horizontal
-                spacing: root.cellSpacing
-                leftMargin: root.centerOffset
-                rightMargin: root.centerOffset
-                clip: true
-                cacheBuffer: root.slotPitch * 2
-
-                snapMode: ListView.NoSnap
-
-                flickDeceleration: root.flickDeceleration
-                maximumFlickVelocity: root.maxFlickVelocity
-                boundsBehavior: Flickable.DragOverBounds
-
-                model: Themes.wallpapersInActiveTheme
-
-                onContentXChanged: {
-                    // This filmstrip's item tree stays alive even while the
-                    // picker window is hidden (only PanelWindow.visible
-                    // toggles). Switching themes from Settings elsewhere
-                    // reassigns Themes.wallpapersInActiveTheme, which resets
-                    // this (currently invisible) ListView's model -- Qt resets
-                    // contentX to 0 as part of that, re-entering this handler
-                    // while QQuickItemView::setModel is still mid-update.
-                    // None of this logic is meaningful while the picker isn't
-                    // open, so skip it rather than let it run reentrantly.
-                    // The margins below also nudge contentX during creation,
-                    // before the required screenState is assigned.
-                    if (!root.screenState?.wallpaperPicker)
-                        return;
-                    const idx = root._indexAtCenter();
-                    if (idx !== -1 && idx !== strip.currentIndex)
-                        strip.currentIndex = idx;
-                }
-
-                onMovementEnded: root._settle()
-
-                Timer {
-                    id: previewDelay
-
-                    interval: Tokens.anim.durations.expressiveSlowEffects
-                    onTriggered: root._applyPreview()
-                }
-
-                SpringAnimation {
-                    id: settleAnim
-
-                    target: strip
-                    property: "contentX"
-                    spring: 2.2
-                    damping: 0.42
-                }
-
-                WheelHandler {
-                    onWheel: event => root._wheelImpulse(event.angleDelta.y < 0 ? 1 : -1)
-                }
-
-                delegate: Item {
-                    id: delegate
-
-                    required property string modelData
-                    required property int index
-
-                    readonly property real itemCenterX: x + width / 2
-                    readonly property real viewCenterX: strip.contentX + strip.width / 2
-                    readonly property real distance: (itemCenterX - viewCenterX) / root.slotPitch
-                    readonly property real closeness: Math.max(0, 1 - Math.abs(distance))
-
-                    width: root.cellWidth
-                    height: root.cellHeight
-                    y: (strip.height - height) / 2
-                    scale: Math.max(0.42, root.centerScale - Math.abs(distance) * 0.34)
-                    opacity: Math.max(0.25, 1 - Math.abs(distance) * 0.26)
-
-                    transform: Rotation {
-                        origin.x: delegate.width / 2
-                        origin.y: delegate.height / 2
-                        axis {
-                            x: 0
-                            y: 1
-                            z: 0
-                        }
-                        angle: Math.max(-32, Math.min(32, delegate.distance * -26))
-                    }
-
-                    StyledClippingRect {
-                        anchors.fill: parent
-                        radius: Tokens.rounding.large
-                        color: Colours.tPalette.m3surfaceContainer
-
-                        layer.enabled: Math.abs(delegate.distance) < 1.6
-                        layer.effect: MultiEffect {
-                            shadowEnabled: true
-                            shadowColor: Qt.tint(Colours.palette.m3shadow, Qt.alpha(Colours.palette.m3primary, 0.55 * delegate.closeness))
-                            shadowOpacity: 0.3 + 0.35 * delegate.closeness
-                            shadowBlur: 0.5 + 0.3 * delegate.closeness
-                            shadowVerticalOffset: 4
-                        }
-
-                        Image {
-                            anchors.fill: parent
-                            source: `file://${Themes.awwwDir}/${Themes.activeTheme}/${delegate.modelData}`
-                            fillMode: Image.PreserveAspectCrop
-                            asynchronous: true
-                            cache: true
-                            sourceSize.width: root.cellWidth
-                            sourceSize.height: root.cellHeight
-                        }
-                    }
-
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: delegate.index === strip.currentIndex ? root._commit() : root._flickToIndex(delegate.index)
-                    }
-                }
+            StyledText {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: Themes.wallpapersInActiveTheme[strip.currentIndex] ?? Themes.activeWallpaper
+                font: Tokens.font.title.large
+                color: Colours.palette.m3onSurface
+                animate: true
             }
 
-            Column {
-                id: caption
+            Row {
+                id: rail
+
+                readonly property int capacity: 25
+                readonly property int shown: Math.min(strip.count, capacity)
+                readonly property int start: Math.max(0, Math.min(strip.currentIndex - Math.floor(capacity / 2), strip.count - shown))
+                readonly property bool windowed: strip.count > capacity
 
                 anchors.horizontalCenter: parent.horizontalCenter
                 spacing: Tokens.spacing.extraSmall
 
-                StyledText {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: Themes.wallpapersInActiveTheme[strip.currentIndex] ?? Themes.activeWallpaper
-                    font: Tokens.font.body.medium
-                    color: Colours.palette.m3onSurfaceVariant
-                    animate: true
-                }
+                Repeater {
+                    model: rail.shown
 
-                StyledText {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    text: `${strip.currentIndex + 1} / ${strip.count}`
-                    font: Tokens.font.label.small
-                    color: Colours.palette.m3onSurfaceVariant
-                    opacity: 0.7
+                    Item {
+                        id: dot
+
+                        required property int index
+
+                        readonly property int wallpaperIndex: rail.start + dot.index
+                        readonly property bool current: dot.wallpaperIndex === strip.currentIndex
+                        readonly property real edgeFade: rail.windowed ? Math.min(1, (Math.min(dot.index, rail.shown - 1 - dot.index) + 1) / 3) : 1
+
+                        implicitWidth: Tokens.spacing.large
+                        implicitHeight: Tokens.spacing.large
+
+                        Rectangle {
+                            anchors.centerIn: parent
+
+                            implicitWidth: dot.current ? 9 : 6
+                            implicitHeight: implicitWidth
+                            radius: implicitWidth / 2
+                            color: dot.current ? Colours.palette.m3primary : Colours.palette.m3onSurface
+                            opacity: dot.current ? 0.55 + 0.45 * DepthFx.pulse : 0.4 * dot.edgeFade
+
+                            Behavior on implicitWidth {
+                                Anim {
+                                    type: Anim.FastEffects
+                                }
+                            }
+
+                            Behavior on color {
+                                CAnim {}
+                            }
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root._flickToIndex(dot.wallpaperIndex)
+                        }
+                    }
                 }
             }
         }

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperPickerWindow.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperPickerWindow.qml
@@ -28,13 +28,23 @@ PanelWindow {
     implicitWidth: screen.width
     implicitHeight: screen.height
 
+    WallpaperBackdrop {
+        anchors.fill: parent
+        active: root.screenState.wallpaperPicker
+        source: filmstrip.backdropSource
+        bandHeight: filmstrip.bandHeight
+        fadeExtent: filmstrip.bandFade
+    }
+
     MouseArea {
         anchors.fill: parent
         onClicked: root.screenState.wallpaperPicker = false
     }
 
     WallpaperFilmstrip {
-        anchors.centerIn: parent
+        id: filmstrip
+
+        anchors.fill: parent
         screenState: root.screenState
     }
 }

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/qmldir
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/qmldir
@@ -1,3 +1,5 @@
 module qs.modules.wallpaperpicker
+WallpaperBackdrop 1.0 WallpaperBackdrop.qml
+WallpaperCard 1.0 WallpaperCard.qml
 WallpaperFilmstrip 1.0 WallpaperFilmstrip.qml
 WallpaperPickerWindow 1.0 WallpaperPickerWindow.qml


### PR DESCRIPTION
## What changed

The picker used to be a grey rounded panel floating on a transparent
overlay, so whatever sat on the desktop bled through around it. It now
renders a full-width blurred band across the middle of the screen and
leaves the desktop untouched above and below, which reads as a selection
band cut across the screen instead of another menu.

**Backdrop** (`WallpaperBackdrop.qml`, new). The band shows the selected
wallpaper drawn at full-screen geometry and clipped to the band, so it
lines up with the real desktop wallpaper behind it. A 4-stop gradient
alpha mask fades the top and bottom edges. Two images crossfade as the
selection moves, decoded at 640x360, so scrolling costs a small async
decode rather than a full-resolution load.

**Cards** (`WallpaperCard.qml`, new). Each card is a beveled panel:
corners cut at 45 degrees on the top-left and bottom-right, the other two
rounded. The shape is a `Shape` with `CurveRenderer`, drawn twice, once
white and invisible as a mask source and once stroked as the outline.
Masking follows the idiom in `modules/bar/capsule/CapsuleArtwork.qml`.
The centered card gets a `BioluminescentGlow` and lifts 7% of its height
so it floats above the row. Off-center cards get a `MultiEffect` blur
scaled by their distance.

Wallpapers here run 1.50 to 2.35 aspect, so a fixed 16:9 frame cropped
most of them. Cards use `PreserveAspectFit` and fill the frame behind the
image with a 64x36 copy of the same wallpaper, where the upscale supplies
the blur at no shader cost.

**HUD.** A dot rail replaces the `n / total` line. The active dot pulses
on `DepthFx.pulse`, the rail windows to 25 dots for large themes, and
each dot flicks to its index on click.

**Sizing.** Every dimension derives from the screen: band 63% of height,
fade 15% of the band, cards 21.9% of height, strip 86% of width. Checked
on 3440x1440 and 1920x1080.

## Why no MultiEffect shadow

`MultiEffect` builds its shadow from the source alpha before the mask
applies, so a beveled card would sit on a rectangular shadow with corners
poking out of the cuts. The glow and the outline that follows the
silhouette replace it.

## Depth tiers

`off` gives a mask-only shader pass per card, no glow, no particles, no
depth-of-field, and no blur pass on the band. `subtle` adds the glow at
half intensity, 12 particles, and `blurMax` 12. `full` raises those to
26 particles and `blurMax` 24, and turns on the band's blur layer.

## The top-of-card clipping

The `ListView`'s own layout overwrote the delegate's `y` binding, so every
card sat at the top of the strip rather than centred in it. From there the
clip was arithmetic. A delegate at `y = 0` scaled 1.35x about its own
middle puts its top edge at -55px, past the clip line, while 220px of the
strip went unused below.

That accounts for all four symptoms: it clipped at rest, the top stayed
pinned while the bottom grew, the line landed in the same place every time,
and the 44px top-left chamfer sat inside the sliced band, so a straight
edge showed in its place.

The earlier headroom on `stripHeight` could never have worked. The card was
pinned to the top of the box, so a taller box only added room underneath.

Two changes fix it:

- Delegates span the full strip height and centre the card inside. Vertical
  centring is structural now, so the view has no binding left to clobber.
- `clip: true` is gone. The distance-based opacity falloff reaches zero at
  2.63 slots and the viewport edge sits at 2.5, so the clip bounded nothing
  horizontally. Dropping it removes the boundary rather than sizing around
  it.

`stripHeight` now reserves layout space and sets the gap to the HUD, nothing
more. `textureWidth` and `textureHeight` go with it, dead since the
`layer.textureSize` overrides came out.

### Measured

A windowed `qs -p` probe puts the hero card at scene Y 442-867 inside a
strip of 393-976, with a distinct top edge per card. The live shell on DP-1
measures 444-869. Checked at rest, on hover, mid-punch and after the settle,
on both monitors, with the chamfer intact in each.

One thing worth knowing before trusting a probe here: positioners need a
real window to polish. Parent the filmstrip to a bare `Item` and `Column`
reports garbage sizes.

## Stutter check

The wallust-per-scroll guard is intact. `onContentXChanged`, its
reentrancy guard, `previewDelay`, `_applyPreview`, `_cancelPreview`,
`_commit` and `_revertAndClose` are unchanged, and `_settle()` gained one
line that records the settled index for the punch animation. No new call
site reaches `Themes.setWallpaperInActiveTheme`.

A headless probe drove `contentX` across all 13 wallpapers in the active
theme: 13 index changes, 0 previews queued, and `_settle()` queues exactly
one. Re-run after the clipping fix with the same result. Both new
components compile and instantiate with no warnings and no binding loops.

## Arrow key stepping

A keyed step ran through `Flickable.flick()` with a velocity sized to coast
exactly one slot. Two things fought it.

The settle spring was never stopped, so it kept writing `contentX` after a
settle. Press Left right after one and the flick starts while the spring
drags it back, which is why left-after-right registered as nothing. The next
press also read `strip.currentIndex` while it was mid-flight, and since that
index is derived from live `contentX`, a fast second press computed its target
off a moving value. Sometimes it resolved to the index already centred and did
nothing, sometimes it landed somewhere unrelated. `flick()` replaces velocity
rather than accumulating it, so rapid presses swallowed each other on top of
that.

Stepping is discrete, so `_goToIndex` animates to an explicit target instead.
`_pendingIndex` carries that target across an in-flight glide, so presses
accumulate off the intended index rather than the moving one and none get
dropped. The glide stops the spring and cancels any live flick before it
starts; a drag or the wheel cancels the glide. Duration scales with the gap
and caps at 500ms.

Nine assertions in a headless probe cover it: five rapid presses land five
away, zero previews arm mid-burst and exactly one after, reverse immediately
after a settle, `R,L,L` mid-glide nets +1, re-targeting the index already
being approached is a no-op, and 30 presses clamp at 0.

Driven on the live shell with real key events:

| input | from | to |
|---|---|---|
| 3 slow rights | 0 | 3 |
| 5 rapid rights | 3 | 8 |
| 2 immediate lefts | 8 | 6 |
| hold Left 1.5s | 6 | 0 |
| `R,L,R,L,R,R,R` | 0 | 3 |
| hold Right 2s | 0 | 12 |

## The hero card rendering as an empty bevel

Reopening the picker often left the centred card as an outline with no
artwork, and once it happened it stayed that way until the shell restarted.
Twenty open/close cycles reproduced it sixteen times, always from the fifth
cycle on.

The mask source was a `Shape` with `visible: false` and `layer.enabled: true`.
An invisible item leaves the scene graph while the picker window is hidden,
and nothing dirties it when the window comes back, so the mask sampled an
empty texture and multiplied the card body away. The bevel outline is a
separate unmasked shape, which is why the frame survived while only the
artwork went missing. Any movement dirtied the layer again and the card came
back, which is what made it look intermittent.

Measuring settled it: inside the blank card read `(29, 26, 34)` against
`(25, 25, 34)` for the backdrop beside it, so the body was painting nothing
at all rather than failing to decode an image. No image load errors appear in
the shell log either.

The mask now reads an explicit live `ShaderEffectSource`. Same twenty cycles,
zero empty bevels.

Escape also no longer re-applies the wallpaper that is already active, which
had been spending a full wallust + awww + sddm-sync run to arrive back where
it started. That turned out not to be the cause of the blank card, but it is
still work worth not doing.

## Known items

**The strip clamps at both ends, it does not wrap.** Reaching the last
wallpaper stops there. #135 makes it endless in both directions and reworks
the rail into five rotating dots; it is stacked on this branch.

**A reopen can still park off centre, rarely.** Seen once, not reproduced
since. An earlier revision of this description blamed a hot reload emptying
`Themes.wallpapersInActiveTheme` during an async theme scan. That was wrong
and is worth recording as wrong: instrumenting the singleton showed the
wallpaper list never empties on a wallpaper change, and no config reload
happens at all. The real trigger is still unknown.

## Follow-up question

Should `WallpaperCard.qml` also replace the plain tiles in
`WallpaperTile.qml` and `DashWallpapersTab.qml`? Those grid views are
untouched here. Worth deciding separately.

## Not yet done

Per-tier GPU numbers need a re-run. The ones I took measured an earlier
version of the backdrop and no longer describe this code.
