### PR TITLE
plugins pane: settings shortcut on installed rows

### DIFF
--- a/Configs/quickshell/aphotic/config/PluginSurfaces.qml
+++ b/Configs/quickshell/aphotic/config/PluginSurfaces.qml
@@ -1,0 +1,40 @@
+pragma Singleton
+import QtQuick
+import qs.config
+
+QtObject {
+    id: root
+
+    readonly property var kinds: [
+        { id: "dashboard", icon: "dashboard", description: qsTr("Adds a Dashboard tab: %1") },
+        { id: "notch", icon: "expand_more", description: qsTr("Adds a notch tile: %1") },
+        { id: "settings", icon: "tune", description: qsTr("Adds a Settings section: %1") },
+        { id: "overlay", icon: "layers", description: qsTr("Adds an overlay: %1") }
+    ]
+
+    function kind(surface: string): var {
+        return root.kinds.find(k => k.id === surface) ?? root.kinds[0];
+    }
+
+    function iconFor(surface: string): string {
+        return root.kind(surface).icon;
+    }
+
+    function describe(surface: string, label: string): string {
+        return root.kind(surface).description.arg(label);
+    }
+
+    function jumpsFor(plugin: string): var {
+        return SettingsCategories.pluginSections.filter(s => s.plugin === plugin).map(s => ({
+            surface: "settings",
+            icon: "settings",
+            label: s.label,
+            address: `${s.parentId}/${s.id}`
+        }));
+    }
+
+    function navigate(screenState: var, jump: var): void {
+        if (jump.surface === "settings")
+            screenState.settingsCategory = jump.address;
+    }
+}

--- a/Configs/quickshell/aphotic/config/qmldir
+++ b/Configs/quickshell/aphotic/config/qmldir
@@ -3,3 +3,4 @@ singleton Tokens 1.0 Tokens.qml
 singleton Config 1.0 Config.qml
 singleton GlobalConfig 1.0 GlobalConfig.qml
 singleton SettingsCategories 1.0 SettingsCategories.qml
+singleton PluginSurfaces 1.0 PluginSurfaces.qml

--- a/Configs/quickshell/aphotic/modules/settings/SettingsPanel.qml
+++ b/Configs/quickshell/aphotic/modules/settings/SettingsPanel.qml
@@ -389,7 +389,9 @@ RowLayout {
     }
     Component {
         id: pluginsComp
-        PluginsPane {}
+        PluginsPane {
+            screenState: root.screenState
+        }
     }
     Component {
         id: systemComp

--- a/Configs/quickshell/aphotic/modules/settings/panes/PluginsPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PluginsPane.qml
@@ -19,6 +19,8 @@ import qs.modules.settings
 ColumnLayout {
     id: root
 
+    required property ScreenState screenState
+
     readonly property string repoUrl: "https://github.com/T-Crypt/aphotic-plugins"
 
     property var installed: []
@@ -391,7 +393,7 @@ ColumnLayout {
                         spacing: Tokens.spacing.extraSmall
 
                         MaterialIcon {
-                            text: surfaceRow.modelData.icon || (surfaceRow.modelData.surface === "notch" ? "expand_more" : "dashboard")
+                            text: surfaceRow.modelData.icon || PluginSurfaces.iconFor(surfaceRow.modelData.surface)
                             color: Colours.palette.m3onSurfaceVariant
                             fontStyle: Tokens.font.icon.small
                         }
@@ -399,7 +401,7 @@ ColumnLayout {
                         StyledText {
                             Layout.fillWidth: true
                             elide: Text.ElideRight
-                            text: surfaceRow.modelData.surface === "notch" ? qsTr("Adds a notch tile: %1").arg(surfaceRow.modelData.label ?? "") : qsTr("Adds a Dashboard tab: %1").arg(surfaceRow.modelData.label ?? "")
+                            text: PluginSurfaces.describe(surfaceRow.modelData.surface, surfaceRow.modelData.label ?? "")
                             color: Colours.palette.m3onSurfaceVariant
                             font: Tokens.font.label.small
                         }
@@ -581,6 +583,27 @@ ColumnLayout {
 
                 RowLayout {
                     spacing: Tokens.spacing.small
+
+                    Repeater {
+                        model: installedRow.modelData.enabled ? PluginSurfaces.jumpsFor(installedRow.modelData.name) : []
+
+                        MaterialIcon {
+                            id: surfaceJump
+
+                            required property var modelData
+
+                            text: surfaceJump.modelData.icon
+                            color: Colours.palette.m3onSurfaceVariant
+                            fontStyle: Tokens.font.icon.small
+
+                            StateLayer {
+                                anchors.fill: parent
+                                anchors.margins: -Tokens.padding.small
+                                radius: Tokens.rounding.full
+                                onClicked: PluginSurfaces.navigate(root.screenState, surfaceJump.modelData)
+                            }
+                        }
+                    }
 
                     MaterialIcon {
                         text: installedRow.modelData.enabled ? "toggle_on" : "toggle_off"


### PR DESCRIPTION
## What

An installed plugin that registers a settings surface gets an icon next to its toggle. Clicking it opens that plugin's section, expanded and highlighted, in whichever category owns it.

The pane already listed what a plugin contributes. It had no way to reach any of it, so you had to know which category swallowed the section and go hunting.

## The surface-kind table

Plugins will surface all over the shell, so the per-kind vocabulary moves into one place: `config/PluginSurfaces.qml`. It holds the icon and description for each kind, plus `jumpsFor()` and `navigate()`.

`jumpsFor()` answers "where can the user go from this plugin's row" and returns plain records. `navigate()` takes one and does the work, so `PluginsPane` never names a `ScreenState` property. Making a dashboard tab or an overlay reachable later means a branch in those two functions and no edit to any pane.

Only `settings` is reachable today, which is why it is the only kind contributing records. A kind with no way to reach it returns nothing and draws no button.

Two details worth calling out:

- Addresses come from `SettingsCategories.pluginSections`, not from `modelData.ui.surfaces`. `pluginSections` already applies the fallback-to-`plugins` rule for an unrecognised parent category, and re-deriving that locally would be a second answer that can drift from the first.
- `pluginSections` is also the visibility gate. It reads `PluginRegistry.surfacesFor("settings")`, which is enabled-plugins-only and layer/data-gate satisfied, so a disabled or gated-off plugin contributes no records and needs no separate `visible:` expression.

The table keys on surface kind, never on a plugin id, so `PLUGIN_LAYER_MODEL.md`'s rule holds.

## Also fixed

The surface description in `PluginRow` branched only on `notch`. Everything else fell through to "Adds a Dashboard tab", so `settings` and `overlay` rows both misdescribed themselves. Both read from the table now. `PluginRow` is shared by the installed and available lists, so both lists get it.

## For whoever adds a fifth surface kind

The vocabulary lives in two places on purpose: `cmd_plugin.sh`'s `APHOTIC_PLUGIN_HOSTED_SURFACES` is the install-time host gate, and `PluginSurfaces.kinds` is how the shell describes and navigates to a hosted surface. Add the kind to both.

## Plumbing

`PluginsPane` had no `ScreenState`. It is per-screen, not a singleton, so `SettingsPanel.qml` gains one binding at the single instantiation site. `SettingsWindow.qml`, `ScreenState.qml` and `SettingsCategories.qml` are untouched; the addressing mechanism already handled a jump with Settings open.

## Testing

`tests/test_singleton_reachability.py` passes.

Verified with `qs -p` probes:

- `iconFor`/`describe` return the right icon and text for all four kinds, and an unknown kind falls back to dashboard.
- `jumpsFor("llm-fit")` returns `ai/llmFit`; `jumpsFor("visualizer")` returns `appearance/visualizerSettings`. `agent-graph` is disabled on this box and contributes nothing, which is the intended gate.
- `navigate()` sets `settingsCategory` to `ai/llmFit`.
- The `Repeater` builds one delegate with `text: "settings"` and the address intact.
- Sweeping `SettingsPanel` across all sixteen categories loads clean. The nineteen `ColorPickerField` binding loops in `ThemeCreatorPane` match the pre-existing baseline.