### PR TITLE
add a copyright notice

### DIFF
--- a/Configs/quickshell/aphotic/components/AppIcon.qml
+++ b/Configs/quickshell/aphotic/components/AppIcon.qml
@@ -1,0 +1,58 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell.Widgets
+import qs.config
+import qs.services
+import qs.utils
+
+Item {
+    id: root
+
+    property string name: ""
+    property var appClass: ""
+    property string fallbackGlyph: "apps"
+    // Pixel size for the image branch. Left at 0 the glyph metrics decide,
+    // which is what the workspace pills want -- they sized to their text
+    // before this component existed.
+    property real size: 0
+    property font fontStyle: Tokens.font.icon.small
+    property int grade: Colours.light ? 0 : -25
+    property color colour: Colours.palette.m3onSurface
+    property bool animate: false
+    property bool asynchronous: false
+
+    readonly property var resolved: Icons.resolveAppIcon(root.name, root.appClass, root.fallbackGlyph)
+
+    implicitWidth: loader.item?.implicitWidth ?? 0
+    implicitHeight: loader.item?.implicitHeight ?? 0
+
+    Loader {
+        id: loader
+
+        anchors.centerIn: parent
+        sourceComponent: root.resolved.kind === "image" ? imageComp : glyphComp
+    }
+
+    Component {
+        id: imageComp
+
+        IconImage {
+            source: root.resolved.value
+            asynchronous: root.asynchronous
+            implicitSize: root.size > 0 ? root.size : Math.round(root.fontStyle.pointSize * 1.35)
+        }
+    }
+
+    Component {
+        id: glyphComp
+
+        MaterialIcon {
+            text: root.resolved.value
+            color: root.colour
+            fontStyle: root.fontStyle
+            grade: root.grade
+            animate: root.animate
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/components/qmldir
+++ b/Configs/quickshell/aphotic/components/qmldir
@@ -1,6 +1,7 @@
 module qs.components
 AphoticMark 1.0 AphoticMark.qml
 Anim 1.0 Anim.qml
+AppIcon 1.0 AppIcon.qml
 CAnim 1.0 CAnim.qml
 ColorPickerField 1.0 ColorPickerField.qml
 ColorWheel 1.0 ColorWheel.qml

--- a/Configs/quickshell/aphotic/modules/bar/DockAppIcon.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockAppIcon.qml
@@ -1,7 +1,6 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import Quickshell.Widgets
 import qs.config
 import qs.components
 import qs.services
@@ -49,10 +48,13 @@ Item {
         }
     }
 
-    IconImage {
+    AppIcon {
         anchors.centerIn: parent
-        source: root.item.icon
-        implicitSize: parent.width * 0.6
+        name: root.item.iconName
+        appClass: root.item.iconKeys
+        size: parent.width * 0.6
+        fontStyle: Tokens.font.icon.large
+        colour: Colours.palette.m3onSurface
     }
 
     Rectangle {

--- a/Configs/quickshell/aphotic/modules/bar/DockBar.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockBar.qml
@@ -37,7 +37,8 @@ Item {
             items.push({
                 key: id,
                 name: entry.name,
-                icon: Quickshell.iconPath(entry.icon, "application-x-executable"),
+                iconName: entry.icon,
+                iconKeys: [id, entry.name],
                 running: matches.length > 0,
                 windows: matches.flatMap(g => g.windows),
                 entry
@@ -53,7 +54,8 @@ Item {
             items.push({
                 key: g.appClass,
                 name: entry?.name ?? g.appClass,
-                icon: g.windows[0]?.icon ?? Quickshell.iconPath(g.appClass, "application-x-executable"),
+                iconName: entry?.icon ?? "",
+                iconKeys: g.appClass,
                 running: true,
                 windows: g.windows,
                 entry: entry ?? null

--- a/Configs/quickshell/aphotic/modules/bar/TaskbarBar.qml
+++ b/Configs/quickshell/aphotic/modules/bar/TaskbarBar.qml
@@ -207,10 +207,12 @@ Item {
         radius: Tokens.rounding.full
         color: item.focused ? Colours.palette.m3secondaryContainer : Colours.palette.m3surfaceContainerHigh
 
-        IconImage {
+        AppIcon {
             anchors.centerIn: parent
-            source: item.group.windows[0]?.icon ?? ""
-            implicitSize: parent.width * 0.6
+            appClass: item.group.appClass
+            size: parent.width * 0.6
+            fontStyle: Tokens.font.icon.large
+            colour: Colours.palette.m3onSurface
         }
 
         StyledRect {

--- a/Configs/quickshell/aphotic/modules/bar/components/ActiveWindow.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/ActiveWindow.qml
@@ -5,7 +5,6 @@ import qs.config
 import qs.components
 import qs.components.effects
 import qs.services
-import qs.utils
 
 Item {
     id: root
@@ -98,7 +97,7 @@ Item {
         }
     }
 
-    MaterialIcon {
+    AppIcon {
         id: icon
 
         anchors.horizontalCenter: parent.horizontalCenter
@@ -107,8 +106,9 @@ Item {
         anchors.leftMargin: Settings.barHorizontal ? Tokens.padding.small : 0
 
         animate: true
-        text: Icons.getAppCategoryIcon(Hypr.activeToplevel?.lastIpcObject.class, "desktop_windows")
-        color: root.colour
+        appClass: Hypr.activeToplevel?.lastIpcObject?.class ?? ""
+        fallbackGlyph: "desktop_windows"
+        colour: root.colour
 
         states: State {
             name: "horizontal"

--- a/Configs/quickshell/aphotic/modules/bar/components/workspaces/SpecialWorkspaces.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/workspaces/SpecialWorkspaces.qml
@@ -355,12 +355,13 @@ Item {
                         }
                     }
 
-                    MaterialIcon {
+                    AppIcon {
                         required property var modelData
 
                         grade: 0
-                        text: Icons.getAppCategoryIcon(modelData.lastIpcObject.class, "terminal")
-                        color: Colours.palette.m3onSurfaceVariant
+                        appClass: modelData.lastIpcObject?.class ?? ""
+                        fallbackGlyph: "terminal"
+                        colour: Colours.palette.m3onSurfaceVariant
                     }
                 }
             }

--- a/Configs/quickshell/aphotic/modules/bar/components/workspaces/Workspace.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/workspaces/Workspace.qml
@@ -6,7 +6,6 @@ import Quickshell
 import qs.config
 import qs.components
 import qs.services
-import qs.utils
 
 GridLayout {
     id: root
@@ -125,12 +124,13 @@ GridLayout {
                     }
                 }
 
-                MaterialIcon {
+                AppIcon {
                     required property var modelData
 
                     grade: 0
-                    text: Icons.getAppCategoryIcon(modelData.lastIpcObject.class, "terminal")
-                    color: Colours.palette.m3onSurfaceVariant
+                    appClass: modelData.lastIpcObject?.class ?? ""
+                    fallbackGlyph: "terminal"
+                    colour: Colours.palette.m3onSurfaceVariant
                 }
             }
         }

--- a/Configs/quickshell/aphotic/modules/dashboard/WorkspacesTab.qml
+++ b/Configs/quickshell/aphotic/modules/dashboard/WorkspacesTab.qml
@@ -6,7 +6,6 @@ import Quickshell
 import qs.config
 import qs.components
 import qs.services
-import qs.utils
 
 StyledRect {
     id: root
@@ -74,11 +73,12 @@ StyledRect {
                         Repeater {
                             model: wsCard.windows.slice(0, 9)
 
-                            MaterialIcon {
+                            AppIcon {
                                 required property var modelData
 
-                                text: Icons.getAppCategoryIcon(modelData.lastIpcObject.class, "desktop_windows")
-                                color: Colours.palette.m3onSurfaceVariant
+                                appClass: modelData.lastIpcObject?.class ?? ""
+                                fallbackGlyph: "desktop_windows"
+                                colour: Colours.palette.m3onSurfaceVariant
                                 fontStyle: Tokens.font.icon.small
                             }
                         }

--- a/Configs/quickshell/aphotic/modules/launcher/AppGridItem.qml
+++ b/Configs/quickshell/aphotic/modules/launcher/AppGridItem.qml
@@ -34,11 +34,13 @@ Item {
         width: parent.width - Tokens.spacing.small * 2
         spacing: Tokens.spacing.small
 
-        IconImage {
+        AppIcon {
             anchors.horizontalCenter: parent.horizontalCenter
             asynchronous: true
-            source: Quickshell.iconPath(root.modelData.icon, "image-missing")
-            implicitSize: 48
+            name: root.modelData.icon
+            appClass: [root.modelData.id, root.modelData.name]
+            size: 48
+            fontStyle: Tokens.font.icon.extraLarge
         }
 
         StyledText {

--- a/Configs/quickshell/aphotic/modules/launcher/AppItem.qml
+++ b/Configs/quickshell/aphotic/modules/launcher/AppItem.qml
@@ -32,12 +32,14 @@ Item {
         anchors.rightMargin: Tokens.padding.medium
         spacing: Tokens.spacing.medium
 
-        IconImage {
+        AppIcon {
             id: icon
 
             asynchronous: true
-            source: Quickshell.iconPath(root.modelData.icon, "image-missing")
-            implicitSize: parent.height * 0.7
+            name: root.modelData.icon
+            appClass: [root.modelData.id, root.modelData.name]
+            size: parent.height * 0.7
+            fontStyle: Tokens.font.icon.large
             anchors.verticalCenter: parent.verticalCenter
         }
 

--- a/Configs/quickshell/aphotic/modules/launcher/WindowItem.qml
+++ b/Configs/quickshell/aphotic/modules/launcher/WindowItem.qml
@@ -7,7 +7,6 @@ import Quickshell.Hyprland
 import qs.config
 import qs.components
 import qs.services
-import qs.utils
 
 Item {
     id: root
@@ -38,12 +37,13 @@ Item {
         anchors.rightMargin: Tokens.padding.medium
         spacing: Tokens.spacing.medium
 
-        IconImage {
+        AppIcon {
             id: icon
 
             asynchronous: true
-            source: Icons.getAppIcon(root.modelData.lastIpcObject?.class, "application-x-executable")
-            implicitSize: parent.height * 0.7
+            appClass: root.modelData.lastIpcObject?.class ?? ""
+            size: parent.height * 0.7
+            fontStyle: Tokens.font.icon.large
             anchors.verticalCenter: parent.verticalCenter
         }
 

--- a/Configs/quickshell/aphotic/modules/notificationcenter/NotificationHistoryItem.qml
+++ b/Configs/quickshell/aphotic/modules/notificationcenter/NotificationHistoryItem.qml
@@ -7,22 +7,13 @@ import Quickshell.Widgets
 import qs.config
 import qs.components
 import qs.services
+import qs.utils
 
 StyledRect {
     id: root
 
     required property var modelData
 
-    readonly property bool hasAppIcon: root.modelData.appIcon.length > 0
-    // Quickshell.iconPath()'s two-arg (icon, fallback) overload only
-    // resolves icon-THEME NAMES -- a raw path/file:// URI (both valid
-    // per the freedesktop notification spec's app_icon field) silently
-    // falls through to the fallback glyph instead. See Notification.qml's
-    // matching comment for the full source-level reasoning. History
-    // doesn't persist the separate `image` field NotifData/Notification.qml
-    // read (NotificationHistory.qml only stores appIcon), so this fix is
-    // narrower here than the live popup's.
-    readonly property bool appIconIsPath: root.modelData.appIcon.startsWith("/") || root.modelData.appIcon.startsWith("file://")
 
     function relativeTime(ms: real): string {
         const diff = Date.now() - ms;
@@ -61,16 +52,17 @@ StyledRect {
             color: Colours.palette.m3primary
         }
 
-        Loader {
-            active: root.hasAppIcon
+        AppIcon {
             Layout.alignment: Qt.AlignVCenter
             Layout.preferredWidth: Tokens.sizes.notifs.image
             Layout.preferredHeight: Tokens.sizes.notifs.image
 
-            sourceComponent: IconImage {
-                source: root.appIconIsPath ? root.modelData.appIcon : Quickshell.iconPath(root.modelData.appIcon, "image-missing")
-                implicitSize: Tokens.sizes.notifs.image
-            }
+            name: root.modelData.appIcon
+            appClass: root.modelData.appName ?? ""
+            fallbackGlyph: Icons.getNotifIcon(root.modelData.summary, root.modelData.urgency)
+            size: Tokens.sizes.notifs.image
+            fontStyle: Tokens.font.icon.medium
+            colour: Colours.palette.m3primary
         }
 
         ColumnLayout {

--- a/Configs/quickshell/aphotic/modules/notifications/Notification.qml
+++ b/Configs/quickshell/aphotic/modules/notifications/Notification.qml
@@ -21,22 +21,6 @@ StyledRect {
     // of the two when both exist. Falls back to appIcon, then the
     // generic keyword-matched glyph.
     readonly property bool hasImage: modelData.image.length > 0
-    readonly property bool hasAppIcon: !hasImage && modelData.appIcon.length > 0
-    // Quickshell.iconPath()'s two-arg (icon, fallback) overload only
-    // resolves ICON-THEME NAMES via QIcon::fromTheme() -- confirmed by
-    // reading quickshell-mirror/quickshell's own
-    // src/core/iconimageprovider.cpp: the two-arg call never sets the
-    // separate `path=` parameter its own file-path fallback branch
-    // (`icon = QPixmap(path)`) depends on. The freedesktop notification
-    // spec explicitly allows app_icon to be EITHER a themed icon name OR
-    // a file:// URI/absolute path -- when a sending app uses the latter
-    // (common for Electron apps, some game launchers), the theme lookup
-    // fails silently and falls through to the "image-missing" fallback
-    // glyph, which is what "icons not properly rendering for certain
-    // notifications" actually was. Detecting the path/URI case and
-    // sourcing it directly (Image accepts a plain absolute path or
-    // file:// URI natively) fixes exactly that class of notification.
-    readonly property bool appIconIsPath: modelData.appIcon.startsWith("/") || modelData.appIcon.startsWith("file://")
     readonly property int bodyTextFormat: /[<*_`#\[\]]/.test(modelData.body) ? Text.MarkdownText : Text.PlainText
     readonly property bool critical: modelData.urgency === NotificationUrgency.Critical
 
@@ -98,33 +82,11 @@ StyledRect {
                     id: icon
 
                     asynchronous: true
-                    active: root.hasImage || root.hasAppIcon
                     anchors.verticalCenter: parent.verticalCenter
                     width: Tokens.sizes.notifs.image
                     height: Tokens.sizes.notifs.image
 
-                    sourceComponent: IconImage {
-                        // hasImage/hasAppIcon are mutually exclusive (see
-                        // their definitions above), and appIconIsPath
-                        // sources the raw path/URI directly instead of
-                        // routing it through Quickshell.iconPath()'s
-                        // theme-name-only resolver, which silently fails
-                        // for that case -- see the property comments above
-                        // for the full reasoning.
-                        source: root.hasImage ? root.modelData.image : (root.appIconIsPath ? root.modelData.appIcon : Quickshell.iconPath(root.modelData.appIcon, "image-missing"))
-                        implicitSize: Tokens.sizes.notifs.image
-                    }
-                }
-
-                Loader {
-                    active: !root.hasImage && !root.hasAppIcon
-                    anchors.verticalCenter: parent.verticalCenter
-
-                    sourceComponent: MaterialIcon {
-                        text: Icons.getNotifIcon(root.modelData.summary, root.modelData.urgency)
-                        color: root.critical ? Colours.palette.m3onSurface : Colours.palette.m3primary
-                        fontStyle: Tokens.font.icon.medium
-                    }
+                    sourceComponent: root.hasImage ? notifImage : notifAppIcon
                 }
 
                 Column {
@@ -182,6 +144,28 @@ StyledRect {
 
                 onLinkActivated: link => Qt.openUrlExternally(link)
             }
+        }
+    }
+
+    Component {
+        id: notifImage
+
+        IconImage {
+            source: root.modelData.image
+            implicitSize: Tokens.sizes.notifs.image
+        }
+    }
+
+    Component {
+        id: notifAppIcon
+
+        AppIcon {
+            name: root.modelData.appIcon
+            appClass: root.modelData.appName
+            fallbackGlyph: Icons.getNotifIcon(root.modelData.summary, root.modelData.urgency)
+            size: Tokens.sizes.notifs.image
+            fontStyle: Tokens.font.icon.medium
+            colour: root.critical ? Colours.palette.m3onSurface : Colours.palette.m3primary
         }
     }
 }

--- a/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PersonalizationPane.qml
@@ -4,15 +4,43 @@ import QtQuick
 import QtQuick.Layouts
 import Quickshell
 import Quickshell.Io
+import Quickshell.Widgets
 import qs.config
 import qs.components
 import qs.services
+import qs.utils
 
 ColumnLayout {
     id: root
 
     readonly property var accentPresets: ["", "#4A5A52", "#669B04", "#3B82F6", "#EF4444", "#F59E0B", "#8B5CF6", "#EC4899", "#14B8A6"]
     readonly property var depthEffectsPresets: [{ value: "off", label: qsTr("Off") }, { value: "subtle", label: qsTr("Subtle") }, { value: "full", label: qsTr("Full") }]
+
+    readonly property var iconKindPresets: [{ value: "auto", label: qsTr("Auto") }, { value: "image", label: qsTr("Image") }, { value: "glyph", label: qsTr("Glyph") }]
+    // Running apps whose icon bottoms out on resolveAppIcon's final
+    // generic tier -- offered as one-click prompts so the WM_CLASS string
+    // never has to be guessed by hand.
+    readonly property var unresolvedApps: WindowList.classes().filter(c => {
+        const res = Icons.resolveAppIcon("", c.appClass, "");
+        return res.kind === "glyph" && res.value === "apps";
+    })
+
+    property string newIconPattern: ""
+    property string newIconKind: "auto"
+
+    function addIconOverride(): void {
+        const pattern = root.newIconPattern.trim();
+        const value = iconValueInput.text.trim();
+        if (pattern.length === 0 || value.length === 0)
+            return;
+        const entry = { name: pattern, icon: value };
+        if (root.newIconKind !== "auto")
+            entry.kind = root.newIconKind;
+        Settings.customAppIcons = [...Settings.customAppIcons, entry];
+        root.newIconPattern = "";
+        iconValueInput.text = "";
+        root.newIconKind = "auto";
+    }
 
     property var cursorThemes: []
     property var iconThemes: []
@@ -264,6 +292,247 @@ ColumnLayout {
         text: qsTr("Qt apps (qt5ct/qt6ct) follow this too, but only pick it up on next launch, not live.")
         color: Colours.palette.m3onSurfaceVariant
         font: Tokens.font.body.small
+    }
+
+    StyledText {
+        Layout.topMargin: Tokens.spacing.small
+        text: qsTr("App icons")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.medium
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        text: qsTr("Point an app at a different icon when the desktop entry gets it wrong or gives none at all. The match is an app class or desktop-entry name; the icon is an absolute path, an icon-theme name, or a Material Symbols glyph.")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.body.small
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        visible: root.unresolvedApps.length > 0
+        text: qsTr("These running apps have no icon of their own:")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.body.small
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+        visible: root.unresolvedApps.length > 0
+
+        Repeater {
+            model: root.unresolvedApps
+
+            SettingsRow {
+                id: unresolvedRow
+
+                required property var modelData
+
+                icon: "help"
+                label: unresolvedRow.modelData.appClass
+                description: unresolvedRow.modelData.title
+
+                StyledRect {
+                    implicitWidth: unresolvedLabel.implicitWidth + Tokens.padding.medium * 2
+                    implicitHeight: 32
+                    radius: Tokens.rounding.full
+                    color: "transparent"
+                    border.width: 1
+                    border.color: Colours.palette.m3outlineVariant
+
+                    StyledText {
+                        id: unresolvedLabel
+
+                        anchors.centerIn: parent
+                        text: qsTr("Add an override")
+                        font: Tokens.font.body.small
+                    }
+
+                    StateLayer {
+                        anchors.fill: parent
+                        radius: parent.radius
+                        onClicked: root.newIconPattern = unresolvedRow.modelData.appClass
+                    }
+                }
+            }
+        }
+    }
+
+    StyledText {
+        Layout.leftMargin: Tokens.padding.small
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        visible: Settings.customAppIcons.length === 0
+        text: qsTr("No overrides yet.")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.body.small
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+        visible: Settings.customAppIcons.length > 0
+
+        Repeater {
+            model: Settings.customAppIcons
+
+            SettingsRow {
+                id: overrideRow
+
+                required property var modelData
+                required property int index
+
+                readonly property var preview: Icons.resolveOverride(overrideRow.modelData)
+
+                icon: "swap_horiz"
+                label: overrideRow.modelData.regex ?? overrideRow.modelData.name ?? ""
+                description: overrideRow.modelData.icon
+
+                RowLayout {
+                    spacing: Tokens.spacing.medium
+
+                    Item {
+                        implicitWidth: 28
+                        implicitHeight: 28
+
+                        IconImage {
+                            anchors.centerIn: parent
+                            visible: overrideRow.preview.kind === "image"
+                            source: overrideRow.preview.kind === "image" ? overrideRow.preview.value : ""
+                            implicitSize: 28
+                        }
+
+                        MaterialIcon {
+                            anchors.centerIn: parent
+                            visible: overrideRow.preview.kind === "glyph"
+                            text: overrideRow.preview.kind === "glyph" ? overrideRow.preview.value : ""
+                            color: Colours.palette.m3onSurfaceVariant
+                            fontStyle: Tokens.font.icon.medium
+                        }
+                    }
+
+                    MaterialIcon {
+                        text: "delete"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.small
+
+                        StateLayer {
+                            anchors.fill: parent
+                            anchors.margins: -Tokens.padding.small
+                            radius: Tokens.rounding.full
+                            onClicked: Settings.customAppIcons = Settings.customAppIcons.filter((_, i) => i !== overrideRow.index)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+
+        SettingsRow {
+            icon: "pattern"
+            label: qsTr("App match")
+            description: qsTr("An app class or desktop-entry name")
+
+            StyledRect {
+                implicitWidth: 220
+                implicitHeight: 32
+                radius: Tokens.rounding.small
+                color: Colours.palette.m3surfaceContainerHigh
+
+                TextInput {
+                    id: patternInput
+
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.small
+                    font: Tokens.font.label.small
+                    color: Colours.palette.m3onSurface
+                    clip: true
+                    text: root.newIconPattern
+
+                    onTextChanged: root.newIconPattern = text
+
+                    StyledText {
+                        visible: patternInput.text.length === 0
+                        anchors.fill: parent
+                        verticalAlignment: Text.AlignVCenter
+                        text: qsTr("org.gnome.Nautilus")
+                        color: Colours.palette.m3onSurfaceVariant
+                        font: Tokens.font.label.small
+                    }
+                }
+            }
+        }
+
+        SettingsRow {
+            icon: "image"
+            label: qsTr("Icon")
+            description: qsTr("Path, theme name, or glyph name")
+
+            StyledRect {
+                implicitWidth: 220
+                implicitHeight: 32
+                radius: Tokens.rounding.small
+                color: Colours.palette.m3surfaceContainerHigh
+
+                TextInput {
+                    id: iconValueInput
+
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.small
+                    font: Tokens.font.label.small
+                    color: Colours.palette.m3onSurface
+                    clip: true
+
+                    StyledText {
+                        visible: iconValueInput.text.length === 0
+                        anchors.fill: parent
+                        verticalAlignment: Text.AlignVCenter
+                        text: qsTr("firefox")
+                        color: Colours.palette.m3onSurfaceVariant
+                        font: Tokens.font.label.small
+                    }
+                }
+            }
+        }
+
+        SettingsPresetRow {
+            icon: "category"
+            label: qsTr("Treat icon as")
+            description: qsTr("Auto picks an image when the value resolves to one")
+            presets: root.iconKindPresets
+            value: root.newIconKind
+            onSelected: value => root.newIconKind = value
+        }
+    }
+
+    StyledRect {
+        readonly property bool canAdd: root.newIconPattern.trim().length > 0 && iconValueInput.text.trim().length > 0
+
+        Layout.alignment: Qt.AlignRight
+        implicitWidth: addIconLabel.implicitWidth + Tokens.padding.large * 2
+        implicitHeight: 40
+        radius: Tokens.rounding.medium
+        color: canAdd ? Colours.palette.m3primary : Colours.tPalette.m3surfaceContainer
+
+        StyledText {
+            id: addIconLabel
+
+            anchors.centerIn: parent
+            text: qsTr("Add override")
+            color: parent.canAdd ? Colours.contrastOn(Colours.palette.m3primary) : Colours.palette.m3onSurfaceVariant
+            font: Tokens.font.body.medium
+        }
+
+        StateLayer {
+            anchors.fill: parent
+            radius: parent.radius
+            disabled: !parent.canAdd
+            onClicked: root.addIconOverride()
+        }
     }
 
     StyledText {

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -75,6 +75,12 @@ Singleton {
     // Array of desktop-entry ids (DesktopEntry.id, e.g. "firefox") pinned
     // to the Dock style regardless of whether they're currently running.
     property var dockPinnedApps: []
+    // Per-app icon overrides: [{ name | regex, flags, icon, kind }] --
+    // same matcher shape as GlobalConfig's windowIcons (Icons.matchIconConfig
+    // reads both), plus `kind` ("glyph" | "image", omitted means auto) so a
+    // value like "terminal", which exists in both Material Symbols and the
+    // icon theme, can be pinned to the one that was meant.
+    property var customAppIcons: []
     // macOS-style icon-proximity magnification on Dock's app row. Only
     // engages in horizontal placement (Settings.barHorizontal) -- side
     // placement has no real vertical-dock layout to magnify along.
@@ -322,6 +328,7 @@ Singleton {
             barStyleDefaultsApplied: root.barStyleDefaultsApplied,
             dockAutoHide: root.dockAutoHide,
             dockPinnedApps: root.dockPinnedApps,
+            customAppIcons: root.customAppIcons,
             dockMagnification: root.dockMagnification,
             taskbarGrouping: root.taskbarGrouping,
             minimalShowDnd: root.minimalShowDnd,
@@ -584,6 +591,7 @@ hyprctl switchxkblayout all 0 >/dev/null 2>&1`;
     onBarStyleDefaultsAppliedChanged: root._saveState()
     onDockAutoHideChanged: root._saveState()
     onDockPinnedAppsChanged: root._saveState()
+    onCustomAppIconsChanged: root._saveState()
     onDockMagnificationChanged: root._saveState()
     onTaskbarGroupingChanged: root._saveState()
     onMinimalShowDndChanged: root._saveState()
@@ -737,6 +745,8 @@ hyprctl switchxkblayout all 0 >/dev/null 2>&1`;
                     root.dockAutoHide = data.dockAutoHide;
                 if (Array.isArray(data.dockPinnedApps))
                     root.dockPinnedApps = data.dockPinnedApps;
+                if (Array.isArray(data.customAppIcons))
+                    root.customAppIcons = data.customAppIcons;
                 if (typeof data.dockMagnification === "boolean")
                     root.dockMagnification = data.dockMagnification;
                 if (typeof data.taskbarGrouping === "boolean")

--- a/Configs/quickshell/aphotic/services/WindowList.qml
+++ b/Configs/quickshell/aphotic/services/WindowList.qml
@@ -4,7 +4,6 @@ import QtQuick
 import Quickshell
 import Quickshell.Hyprland
 import qs.services
-import qs.utils
 
 Singleton {
     id: root
@@ -13,7 +12,6 @@ Singleton {
                 address: t.address,
                 title: t.title || t.lastIpcObject?.class || "",
                 appClass: t.lastIpcObject?.class ?? "",
-                icon: Icons.getAppIcon(t.lastIpcObject?.class, "application-x-executable"),
                 workspaceId: t.workspace?.id ?? 0,
                 workspaceName: t.workspace?.name ?? "",
                 focused: t.address === Hypr.activeToplevel?.address,
@@ -40,6 +38,17 @@ Singleton {
 
     function windowsForClass(appClass: string): var {
         return root.windows.filter(w => w.appClass === appClass);
+    }
+
+    // One entry per app class, first-seen order, without the per-window
+    // grouping payload -- Settings scans this to find classes whose icon
+    // does not resolve.
+    function classes(): var {
+        const seen = [];
+        for (const w of root.windows)
+            if (w.appClass && !seen.some(e => e.appClass === w.appClass))
+                seen.push({ appClass: w.appClass, title: w.title });
+        return seen;
     }
 
     function focus(address: string): void {

--- a/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
+++ b/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
@@ -1,3 +1,6 @@
+// Aphotic Resource Engine
+// Copyright (C) 2023-2026 Trevin Tindall. Licensed GPL-3.0-or-later.
+
 pragma Singleton
 pragma ComponentBehavior: Bound
 

--- a/Configs/quickshell/aphotic/utils/Icons.qml
+++ b/Configs/quickshell/aphotic/utils/Icons.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Services.Notifications
 import qs.config
+import qs.services
 
 Singleton {
     id: root
@@ -99,11 +100,81 @@ Singleton {
         return false;
     }
 
-    function getAppIcon(name: string, fallback: string): string {
-        const icon = DesktopEntries.heuristicLookup(name)?.icon;
-        if (fallback !== "undefined")
-            return Quickshell.iconPath(icon, fallback);
-        return Quickshell.iconPath(icon);
+    // Quickshell.iconPath()'s two-arg (icon, fallback) overload only
+    // resolves ICON-THEME NAMES via QIcon::fromTheme() -- confirmed by
+    // reading quickshell-mirror/quickshell's own
+    // src/core/iconimageprovider.cpp: the two-arg call never sets the
+    // separate `path=` parameter its own file-path fallback branch
+    // (`icon = QPixmap(path)`) depends on. Both the freedesktop
+    // notification spec's app_icon and the desktop-entry spec's Icon= key
+    // allow EITHER a themed icon name OR a file:// URI/absolute path --
+    // when an app uses the latter (common for Electron apps, some game
+    // launchers), the theme lookup fails silently and falls through to the
+    // fallback glyph. Detecting the path/URI case and sourcing it directly
+    // (Image accepts a plain absolute path or file:// URI natively), then
+    // probing the theme with the (name, check) boolean overload instead,
+    // fixes exactly that class of app. This is the only place in the app
+    // icon path allowed to call Quickshell.iconPath().
+    function _resolveImage(v: string): string {
+        if (!v)
+            return "";
+        if (v.startsWith("/") || v.startsWith("file://"))
+            return v;
+        return Quickshell.iconPath(v, true);
+    }
+
+    function resolveOverride(cfg: var): var {
+        if (cfg.kind === "glyph")
+            return ({ kind: "glyph", value: cfg.icon });
+        const img = root._resolveImage(cfg.icon);
+        if (img)
+            return ({ kind: "image", value: img });
+        return ({ kind: "glyph", value: cfg.icon });
+    }
+
+    function _candidateKeys(appClass: var): var {
+        const raw = Array.isArray(appClass) ? appClass : [appClass];
+        const keys = [];
+        for (const k of raw) {
+            if (!k)
+                continue;
+            keys.push(k);
+            const entry = DesktopEntries.heuristicLookup(k);
+            if (entry?.id)
+                keys.push(entry.id);
+            if (entry?.name)
+                keys.push(entry.name);
+        }
+        return keys.filter((k, i) => keys.indexOf(k) === i);
+    }
+
+    function resolveAppIcon(name: string, appClass: var, fallbackGlyph: string): var {
+        const keys = root._candidateKeys(appClass);
+
+        for (const cfg of Settings.customAppIcons)
+            for (const key of keys)
+                if (root.matchIconConfig(key, cfg))
+                    return root.resolveOverride(cfg);
+
+        const hints = [name];
+        for (const key of keys) {
+            const entryIcon = DesktopEntries.heuristicLookup(key)?.icon;
+            if (entryIcon)
+                hints.push(entryIcon);
+        }
+        for (const hint of hints) {
+            const img = root._resolveImage(hint);
+            if (img)
+                return ({ kind: "image", value: img });
+        }
+
+        for (const key of keys) {
+            const glyph = root.getAppCategoryIcon(key, "");
+            if (glyph)
+                return ({ kind: "glyph", value: glyph });
+        }
+
+        return ({ kind: "glyph", value: fallbackGlyph || "apps" });
     }
 
     function getAppCategoryIcon(name: string, fallback: string): string {

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,24 @@
+Aphotic
+Copyright (C) 2023-2026 Trevin Tindall
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+Third-party components retain their own licenses and copyright.
+
+The Resource Engine (Configs/quickshell/aphotic/services/profile/) is an
+original design and implementation. Its architecture is described in the
+project documentation. That description is published as prior art: it
+exists so the design stays available to everyone, including its authors.


### PR DESCRIPTION
## Problem

`LICENSE` is the stock GPL-3.0 text with the `<year> <name of author>`
boilerplate never filled in, and no copyright line appears anywhere else
in the repo. The license was present, but ownership was never asserted.

## Plan

Assert it in a `NOTICE` file rather than editing the GPL text itself,
which is meant to be reproduced verbatim. Add a header to the Resource
Engine, since that subsystem is the one most worth attributing.

Staying on GPL-3.0. The copyleft is what stops this being taken into a
proprietary product, which a permissive license would allow.

## Resolution

- `NOTICE` states copyright, the license, and that third-party components
  keep their own terms.
- `ResourceEngine.qml` gets a two-line header.
- Year range 2023-2026 matches the first and latest commits.

No code behavior changes. Verified the engine still loads and reports
`dormant=true` on a clean start.