### PR TITLE
Safe mode, and a way back when the shell will not start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-# Claude Code working docs - not part of the shipped rice
+# Agent working docs - not part of the shipped rice
 docs/
 CLAUDE.md
+AGENTS.md
 .superpowers/
 .claude/
 

--- a/Configs/.local/lib/aphotic/commands/cmd_backup.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_backup.sh
@@ -5,7 +5,7 @@
 # @cmd.group: LIFECYCLE
 # @cmd.opt: create [--label <name>] | Snapshot current dotfiles state
 # @cmd.opt: list                     | List available snapshots
-# @cmd.opt: revert <id>              | Restore a specific snapshot
+# @cmd.opt: revert [--yes] <id>      | Restore a specific snapshot
 # @cmd.opt: clean [--keep N]         | Prune old snapshots (default keep 10)
 #
 # Distinct from `aphotic restore`: backup/revert deals in explicit,
@@ -66,9 +66,15 @@ _aphotic_backup_list() {
 }
 
 _aphotic_backup_revert() {
-    local id="${1:-}"
+    local id="" assume_yes=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -y|--yes) assume_yes=1; shift ;;
+            *) id="$1"; shift ;;
+        esac
+    done
     if [[ -z "$id" ]]; then
-        aphotic_err "usage: aphotic backup revert <id>"
+        aphotic_err "usage: aphotic backup revert [--yes] <id>"
         return 1
     fi
     local src="${APHOTIC_BACKUP_DIR}/${id}"
@@ -77,10 +83,16 @@ _aphotic_backup_revert() {
         return 1
     fi
 
-    aphotic_confirm "This overwrites your current config with backup '${id}'. Continue?" || {
-        aphotic_log "aborted"
-        return 1
-    }
+    # --yes exists for `aphotic recovery`, which runs this from a
+    # graphical button press with no terminal to prompt on. The
+    # pre-revert snapshot below still happens either way, so the revert
+    # stays reversible whichever path asked for it.
+    if [[ "$assume_yes" -eq 0 ]]; then
+        aphotic_confirm "This overwrites your current config with backup '${id}'. Continue?" || {
+            aphotic_log "aborted"
+            return 1
+        }
+    fi
 
     # Safety net: snapshot current state before reverting, so a revert
     # is itself always reversible.
@@ -139,7 +151,7 @@ Usage: aphotic backup <create|list|revert|clean> [args]
 
   create [--label <name>]   Snapshot current dotfiles state
   list                      List available snapshots
-  revert <id>               Restore a snapshot (auto-snapshots current state first)
+  revert [--yes] <id>       Restore a snapshot (auto-snapshots current state first)
   clean [--keep N]          Prune old snapshots, default keep 10
 EOF
             ;;

--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -715,6 +715,9 @@ _aphotic_plugin_registry_sync() {
        --argjson chat_provider "$chat_provider" \
        '.installed = ((.installed // {}) + {($n): {version: $version, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider}})' \
        "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp" && mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
+    # Every install and update funnels through here, so this is the one
+    # place that has to record "a plugin's code changed" for recovery.
+    aphotic_record_change "plugin-registered" "${name} ${version:-0.0.0}"
 }
 
 # Reverse of the above -- called from remove(). Deleting the registry
@@ -729,6 +732,7 @@ _aphotic_plugin_registry_remove() {
     tmp="$(mktemp)"
     jq --arg n "$name" 'if .installed then .installed |= del(.[$n]) else . end' \
        "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp" && mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
+    aphotic_record_change "plugin-removed" "$name"
 }
 
 # A `ui-surface` plugin's own QML files (AgentGraphTab.qml, etc.) need

--- a/Configs/.local/lib/aphotic/commands/cmd_recovery.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_recovery.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# aphotic recovery — diagnose a shell that will not start, and get out of it.
+# @cmd: recovery
+# @cmd.desc: Diagnose repeated shell startup failures and recover from them
+# @cmd.group: LIFECYCLE
+# @cmd.opt: status [--json]  | What failed, how often, and what is suspected
+# @cmd.opt: present          | Show the recovery surface (or a terminal menu)
+# @cmd.opt: menu             | The terminal menu on its own
+# @cmd.opt: apply <action>   | disable-suspect | safe-mode | restore-last | continue
+# @cmd.opt: record <r> <s>   | Record a unit exit (called by aphotic-shell.service)
+# @cmd.opt: clear            | Forget the recorded failures
+#
+# aphotic-shell.service records every failed exit here (ExecStopPost) and
+# fires `recovery present` once systemd gives up restarting (OnFailure,
+# i.e. StartLimitBurst exceeded). That is the whole trigger: nothing
+# polls, and a shell that crashes once and comes back never reaches this.
+#
+# Everything below has to work with no shell running at all, so the
+# diagnosis lives here in bash and both front ends -- the quickshell
+# recovery surface and the terminal menu -- read it from `status --json`.
+
+APHOTIC_RECOVERY_KEEP=10
+
+# ---- recording -------------------------------------------------------
+
+_aphotic_recovery_record() {
+    local result="${1:-unknown}" status="${2:-}" tmp
+    # A clean stop is a restart or a logout, not a failure.
+    [[ "$result" == "success" ]] && return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    [[ -f "$APHOTIC_RECOVERY_STATE_FILE" ]] || echo '{"failures": []}' > "$APHOTIC_RECOVERY_STATE_FILE"
+    tmp="$(mktemp)"
+    jq --arg at "$(date -Iseconds)" \
+       --arg result "$result" \
+       --arg status "$status" \
+       --argjson keep "$APHOTIC_RECOVERY_KEEP" \
+       '.failures = ((.failures // []) + [{at: $at, result: $result, status: $status}] | .[-$keep:])' \
+       "$APHOTIC_RECOVERY_STATE_FILE" > "$tmp" && mv "$tmp" "$APHOTIC_RECOVERY_STATE_FILE"
+    return 0
+}
+
+_aphotic_recovery_clear() {
+    echo '{"failures": []}' > "$APHOTIC_RECOVERY_STATE_FILE"
+    systemctl --user reset-failed aphotic-shell.service >/dev/null 2>&1 || true
+}
+
+_aphotic_recovery_failure_count() {
+    [[ -f "$APHOTIC_RECOVERY_STATE_FILE" ]] || { echo 0; return 0; }
+    jq -r '(.failures // []) | length' "$APHOTIC_RECOVERY_STATE_FILE" 2>/dev/null || echo 0
+}
+
+# ---- evidence --------------------------------------------------------
+
+# Whatever the last attempt printed. The service path logs to the
+# journal, a hand-started daemon to shell.log; try both rather than
+# assuming which one this machine uses.
+_aphotic_recovery_log_tail() {
+    local lines="${1:-200}" out=""
+    if command -v journalctl >/dev/null 2>&1; then
+        out="$(journalctl --user -u aphotic-shell.service -n "$lines" --no-pager -o cat 2>/dev/null || true)"
+    fi
+    if [[ -z "${out// /}" && -f "${APHOTIC_STATE_HOME}/shell.log" ]]; then
+        out="$(tail -n "$lines" "${APHOTIC_STATE_HOME}/shell.log" 2>/dev/null || true)"
+    fi
+    printf '%s\n' "$out"
+}
+
+# The strongest evidence there is: the failure output naming a file under
+# a plugin's own directory. Asked the other way round -- for each
+# installed plugin, does the output mention its directory -- so a stray
+# path in an unrelated line cannot invent a plugin that is not there, and
+# so no path escaping is involved. Core never names a plugin
+# (ARCHITECTURE section 3 rule 9); this reads one out of the crash.
+#
+# Latest mention wins. QML reports the failing component last, after
+# whatever loaded fine before it.
+_aphotic_recovery_suspect_plugin() {
+    local log name line best="" best_line=0
+
+    log="$(_aphotic_recovery_log_tail)"
+    [[ -n "${log//[[:space:]]/}" ]] || return 1
+
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        line="$(printf '%s\n' "$log" | grep -nF -- "${APHOTIC_PLUGINS_DIR}/${name}/" | tail -n 1 | cut -d: -f1)"
+        [[ -n "$line" ]] || continue
+        if [[ "$line" -ge "$best_line" ]]; then
+            best_line="$line"
+            best="$name"
+        fi
+    done < <(aphotic_plugin_names)
+
+    [[ -n "$best" ]] || return 1
+    printf '%s\n' "$best"
+}
+
+# Fallback when the crash names nothing: what changed most recently.
+# A shell that stopped starting right after a plugin went in is the
+# common case, and the ordering is the only evidence available.
+_aphotic_recovery_last_change() {
+    [[ -f "$APHOTIC_CHANGE_LOG" ]] || return 0
+    tail -n 1 "$APHOTIC_CHANGE_LOG" 2>/dev/null || true
+}
+
+_aphotic_recovery_latest_backup() {
+    [[ -d "$APHOTIC_BACKUP_DIR" ]] || return 0
+    find "$APHOTIC_BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' 2>/dev/null \
+        | sort | tail -n 1
+}
+
+_aphotic_recovery_unit_state() {
+    systemctl --user is-active aphotic-shell.service 2>/dev/null || true
+}
+
+# ---- status ----------------------------------------------------------
+
+_aphotic_recovery_status_json() {
+    aphotic_require jq || return 1
+    local suspect last_change backup safe_mode
+
+    suspect="$(_aphotic_recovery_suspect_plugin || true)"
+    last_change="$(_aphotic_recovery_last_change)"
+    backup="$(_aphotic_recovery_latest_backup)"
+    safe_mode=false
+    aphotic_safe_mode_active && safe_mode=true
+
+    jq -n \
+        --arg unit "$(_aphotic_recovery_unit_state)" \
+        --argjson failures "$(_aphotic_recovery_failure_count)" \
+        --arg suspectPlugin "$suspect" \
+        --arg lastChange "$last_change" \
+        --arg latestBackup "$backup" \
+        --argjson safeMode "$safe_mode" \
+        --arg logTail "$(_aphotic_recovery_log_tail 40)" \
+        --arg version "$APHOTIC_VERSION" \
+        '{unit: $unit, failures: $failures, suspectPlugin: $suspectPlugin,
+          lastChange: $lastChange, latestBackup: $latestBackup,
+          safeMode: $safeMode, logTail: $logTail, version: $version}'
+}
+
+_aphotic_recovery_status_text() {
+    local suspect last_change backup
+
+    echo "Aphotic recovery — aphotic ${APHOTIC_VERSION}"
+    echo
+    printf '  shell unit:        %s\n' "$(_aphotic_recovery_unit_state)"
+    printf '  recorded failures: %s\n' "$(_aphotic_recovery_failure_count)"
+    printf '  safe mode:         %s\n' "$(aphotic_safe_mode_active && echo on || echo off)"
+
+    suspect="$(_aphotic_recovery_suspect_plugin || true)"
+    if [[ -n "$suspect" ]]; then
+        printf '  suspected plugin:  %s (named in the failure output)\n' "$suspect"
+    else
+        printf '  suspected plugin:  none named in the failure output\n'
+    fi
+
+    last_change="$(_aphotic_recovery_last_change)"
+    [[ -n "$last_change" ]] && printf '  last change:       %s\n' "$last_change"
+
+    backup="$(_aphotic_recovery_latest_backup)"
+    [[ -n "$backup" ]] && printf '  latest backup:     %s\n' "$backup"
+
+    echo
+    echo "Last output:"
+    _aphotic_recovery_log_tail 20 | sed 's/^/  /'
+}
+
+# ---- actions ---------------------------------------------------------
+
+# systemd refuses to start a unit that tripped its own start limit until
+# the failure is cleared, so every action has to reset it before asking
+# for a restart -- otherwise the fix applies and the shell still does not
+# come up. Restart itself goes through `aphotic reload`, which is already
+# the single answer to "restart the shell" (orphan kill included).
+_aphotic_recovery_restart_shell() {
+    systemctl --user reset-failed aphotic-shell.service >/dev/null 2>&1 || true
+    source "${COMMANDS_DIR}/cmd_reload.sh"
+    aphotic_cmd_reload
+}
+
+_aphotic_recovery_apply() {
+    local action="${1:-}"
+
+    case "$action" in
+        disable-suspect)
+            local suspect
+            suspect="$(_aphotic_recovery_suspect_plugin || true)"
+            if [[ -z "$suspect" ]]; then
+                aphotic_err "nothing to disable: the failure output does not name a plugin"
+                aphotic_log "try 'aphotic recovery apply safe-mode' to hold all of them back instead"
+                return 1
+            fi
+            source "${COMMANDS_DIR}/cmd_plugin.sh"
+            aphotic_cmd_plugin disable "$suspect" || return 1
+            aphotic_record_change "recovery-disabled-plugin" "$suspect"
+            ;;
+        safe-mode)
+            source "${COMMANDS_DIR}/cmd_safemode.sh"
+            aphotic_safe_mode_set true "repeated startup failures" || return 1
+            aphotic_record_change "safe-mode-on" "recovery"
+            aphotic_ok "safe mode on — plugins are held back"
+            ;;
+        restore-last)
+            local backup
+            backup="$(_aphotic_recovery_latest_backup)"
+            if [[ -z "$backup" ]]; then
+                aphotic_err "no backup to restore (see 'aphotic backup list')"
+                return 1
+            fi
+            source "${COMMANDS_DIR}/cmd_backup.sh"
+            _aphotic_backup_revert --yes "$backup" || return 1
+            aphotic_record_change "recovery-restored-backup" "$backup"
+            ;;
+        continue)
+            aphotic_log "starting the shell unchanged"
+            ;;
+        ""|-h|--help)
+            aphotic_err "usage: aphotic recovery apply <disable-suspect|safe-mode|restore-last|continue>"
+            return 1
+            ;;
+        *)
+            aphotic_err "unknown recovery action: ${action}"
+            return 1
+            ;;
+    esac
+
+    _aphotic_recovery_clear
+    _aphotic_recovery_restart_shell
+}
+
+# ---- front ends ------------------------------------------------------
+
+_aphotic_recovery_menu() {
+    local suspect backup choice
+
+    _aphotic_recovery_status_text
+    suspect="$(_aphotic_recovery_suspect_plugin || true)"
+    backup="$(_aphotic_recovery_latest_backup)"
+
+    echo
+    echo "What would you like to do?"
+    echo "  1) Disable ${suspect:-the suspected plugin}${suspect:+ and restart}"
+    echo "  2) Start in safe mode (every plugin held back)"
+    echo "  3) Restore the last backup${backup:+ (${backup})}"
+    echo "  4) Start normally and leave everything alone"
+    echo "  5) Do nothing for now"
+    echo
+    read -r -p "Choice [1-5]: " choice
+
+    case "$choice" in
+        1) _aphotic_recovery_apply disable-suspect ;;
+        2) _aphotic_recovery_apply safe-mode ;;
+        3) _aphotic_recovery_apply restore-last ;;
+        4) _aphotic_recovery_apply continue ;;
+        *) aphotic_log "nothing changed — run 'aphotic recovery menu' again when you are ready" ;;
+    esac
+}
+
+# Last resort when the recovery surface itself cannot render: the user's
+# terminal, running the same menu. Worth having -- if quickshell or Qt is
+# what broke, a second quickshell config does not help.
+_aphotic_recovery_terminal() {
+    local term
+    for term in kitty foot alacritty wezterm xterm; do
+        command -v "$term" >/dev/null 2>&1 || continue
+        setsid "$term" -e aphotic recovery menu >/dev/null 2>&1 &
+        disown
+        return 0
+    done
+    aphotic_err "no terminal found to show the recovery menu in; run 'aphotic recovery menu' yourself"
+    return 1
+}
+
+_aphotic_recovery_present() {
+    local lock="${APHOTIC_RUNTIME_DIR}/recovery.pid" pid config
+
+    # Nothing good comes of two recovery surfaces stacked on one screen,
+    # and OnFailure can fire again while the first is still open.
+    if [[ -f "$lock" ]] && kill -0 "$(cat "$lock" 2>/dev/null || echo 0)" 2>/dev/null; then
+        aphotic_log "a recovery surface is already open"
+        return 0
+    fi
+
+    config="${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/aphotic-recovery"
+    if command -v qs >/dev/null 2>&1 && [[ -n "${WAYLAND_DISPLAY:-}" ]] && [[ -d "$config" ]]; then
+        setsid qs -c aphotic-recovery >> "${APHOTIC_STATE_HOME}/recovery.log" 2>&1 &
+        pid=$!
+        disown
+        echo "$pid" > "$lock"
+        # It either renders or it does not; three seconds is long enough
+        # to tell a running surface from a config that failed to load.
+        sleep 3
+        if kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        rm -f "$lock"
+        aphotic_warn "the recovery surface would not start either — falling back to a terminal"
+    fi
+
+    _aphotic_recovery_terminal
+}
+
+aphotic_cmd_recovery() {
+    local sub="${1:-status}"
+    shift || true
+    case "$sub" in
+        record)  _aphotic_recovery_record "${1:-}" "${2:-}" ;;
+        status)
+            if [[ "${1:-}" == "--json" ]]; then
+                _aphotic_recovery_status_json
+            else
+                _aphotic_recovery_status_text
+            fi
+            ;;
+        present) _aphotic_recovery_present ;;
+        menu)    _aphotic_recovery_menu ;;
+        apply)   _aphotic_recovery_apply "${1:-}" ;;
+        clear)   _aphotic_recovery_clear && aphotic_ok "recorded failures cleared" ;;
+        -h|--help)
+            cat <<EOF
+Usage: aphotic recovery <status|present|menu|apply|clear> [args]
+
+  status [--json]   What failed, how often, what is suspected
+  present           Show the recovery surface, or a terminal menu if it
+                    cannot render (SUPER+SHIFT+R, and what
+                    aphotic-recovery.service runs)
+  menu              The terminal menu on its own
+  apply <action>    disable-suspect | safe-mode | restore-last | continue
+  clear             Forget the recorded failures
+
+aphotic-shell.service records failed exits and fires 'present' once
+systemd stops retrying. See docs/playbooks/safe-mode-recovery.md.
+EOF
+            ;;
+        *)
+            aphotic_err "unknown recovery subcommand: ${sub}"
+            return 1
+            ;;
+    esac
+}

--- a/Configs/.local/lib/aphotic/commands/cmd_safemode.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_safemode.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# aphotic safemode — bring the shell up with every plugin held back.
+# @cmd: safemode
+# @cmd.desc: Hold every plugin back so the shell starts as core only
+# @cmd.group: LIFECYCLE
+# @cmd.opt: on [--reason <text>] | Hold plugins back and note why
+# @cmd.opt: off                  | Load plugins again
+# @cmd.opt: status               | Whether safe mode is on, and why
+#
+# The flag lives in one small JSON file that services/SafeMode.qml
+# watches, so this works in both directions the recovery path needs:
+# turning safe mode on does not need a running shell, and turning it off
+# is picked up by a running one without a restart.
+
+_aphotic_safemode_on() {
+    local reason=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --reason) reason="${2:-}"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+
+    aphotic_safe_mode_set true "$reason" || return 1
+    aphotic_record_change "safe-mode-on" "$reason"
+    aphotic_ok "safe mode on — plugins are held back${reason:+ (${reason})}"
+
+    if aphotic_shell_running; then
+        aphotic_log "the running shell drops them now; core surfaces are unaffected"
+    else
+        aphotic_log "starting the shell..."
+        source "${COMMANDS_DIR}/cmd_reload.sh"
+        aphotic_cmd_reload
+    fi
+    aphotic_log "leave it with 'aphotic safemode off'"
+}
+
+_aphotic_safemode_off() {
+    if ! aphotic_safe_mode_active; then
+        aphotic_log "safe mode is already off"
+        return 0
+    fi
+
+    aphotic_safe_mode_set false "" || return 1
+    aphotic_record_change "safe-mode-off" ""
+    aphotic_ok "safe mode off — plugins load again"
+
+    if aphotic_shell_running; then
+        aphotic_log "the running shell picks them back up now"
+    else
+        aphotic_log "starting the shell..."
+        source "${COMMANDS_DIR}/cmd_reload.sh"
+        aphotic_cmd_reload
+    fi
+}
+
+_aphotic_safemode_status() {
+    if aphotic_safe_mode_active; then
+        local reason since
+        reason="$(aphotic_safe_mode_reason)"
+        since="$(jq -r '.since // "unknown"' "$APHOTIC_SAFE_MODE_FILE" 2>/dev/null)"
+        echo "safe mode: ON since ${since}${reason:+ — ${reason}}"
+        echo "plugins held back: $(aphotic_plugin_names | wc -l)"
+        echo "leave it with 'aphotic safemode off'"
+    else
+        echo "safe mode: off"
+    fi
+}
+
+aphotic_cmd_safemode() {
+    local sub="${1:-status}"
+    shift || true
+    case "$sub" in
+        on)     _aphotic_safemode_on "$@" ;;
+        off)    _aphotic_safemode_off "$@" ;;
+        status) _aphotic_safemode_status ;;
+        -h|--help)
+            cat <<EOF
+Usage: aphotic safemode <on|off|status>
+
+  on [--reason <text>]   Hold every plugin back, note why, start the
+                         shell if it is not already up
+  off                    Load plugins again
+  status                 Whether safe mode is on, since when, and why
+
+Safe mode is the state 'aphotic recovery' puts a machine into when a
+plugin stops the shell from starting. Core surfaces (bar, launcher,
+settings, notifications) are untouched; nothing is uninstalled.
+EOF
+            ;;
+        *)
+            aphotic_err "unknown safemode subcommand: ${sub}"
+            return 1
+            ;;
+    esac
+}

--- a/Configs/.local/lib/aphotic/commands/cmd_theme.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_theme.sh
@@ -350,6 +350,10 @@ _aphotic_theme_apply() {
         return 1
     fi
 
+    # Applying a theme regenerates Colours.qml from a template, which is
+    # shell code -- so it belongs in the trail `aphotic recovery` reads.
+    aphotic_record_change "theme-applied" "$theme_name"
+
     if [[ -z "$wallpaper_file" ]]; then
         wallpaper_file="$(_aphotic_toml_get "${dir}/theme.toml" wallpaper default)"
     fi

--- a/Configs/.local/lib/aphotic/globalcontrol.sh
+++ b/Configs/.local/lib/aphotic/globalcontrol.sh
@@ -13,6 +13,13 @@ APHOTIC_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/aphotic"
 APHOTIC_CONFIG_FILE="${APHOTIC_CONFIG_HOME}/shell.json"
 APHOTIC_BACKUP_DIR="${APHOTIC_STATE_HOME}/backups"
 
+# Recovery + safe mode (docs/playbooks/safe-mode-recovery.md). The shell
+# reads safe-mode.json directly (services/SafeMode.qml watches it); the
+# other two are written here and read by `aphotic recovery`.
+APHOTIC_SAFE_MODE_FILE="${APHOTIC_STATE_HOME}/safe-mode.json"
+APHOTIC_RECOVERY_STATE_FILE="${APHOTIC_STATE_HOME}/recovery.json"
+APHOTIC_CHANGE_LOG="${APHOTIC_STATE_HOME}/changes.log"
+
 # Where the Aphotic-Hypr dots repo lives. Overridable via env for dev/CI.
 APHOTIC_DOTS_DIR="${APHOTIC_DOTS_DIR:-$HOME/Aphotic-Hypr}"
 
@@ -70,6 +77,7 @@ mkdir -p "$APHOTIC_CONFIG_HOME" "$APHOTIC_STATE_HOME" "$APHOTIC_DATA_HOME" \
 
 export APHOTIC_VERSION APHOTIC_CONFIG_HOME APHOTIC_STATE_HOME APHOTIC_DATA_HOME \
        APHOTIC_RUNTIME_DIR APHOTIC_CONFIG_FILE APHOTIC_BACKUP_DIR APHOTIC_DOTS_DIR \
+       APHOTIC_SAFE_MODE_FILE APHOTIC_RECOVERY_STATE_FILE APHOTIC_CHANGE_LOG \
        QUICKSHELL_CONFIG_DIR APHOTIC_PLUGINS_DIR APHOTIC_PLUGINS_STATE_FILE \
        APHOTIC_PLUGINS_REPO APHOTIC_PLUGINS_GIT_URL APHOTIC_PLUGINS_INDEX_URL APHOTIC_PLUGINS_SECURITY_INDEX_URL \
        APHOTIC_THEMES_REPO APHOTIC_THEMES_GIT_URL APHOTIC_THEMES_INDEX_URL
@@ -238,6 +246,47 @@ aphotic_shell_start() {
     disown
 }
 
+# ---- safe mode + change journal -------------------------------------------
+# Safe mode is one flag in one small file. PluginRegistry.qml holds every
+# plugin back while it is set, so the shell comes up as core-only -- which
+# is the state a machine needs to reach when a plugin is what stops it
+# starting. Written here, watched live by services/SafeMode.qml, so
+# turning it on does not require the shell to be running and turning it
+# off does not require a restart.
+aphotic_safe_mode_active() {
+    [[ -f "$APHOTIC_SAFE_MODE_FILE" ]] || return 1
+    jq -e '.active // false' "$APHOTIC_SAFE_MODE_FILE" >/dev/null 2>&1
+}
+
+aphotic_safe_mode_set() {
+    local active="$1" reason="${2:-}" tmp
+    aphotic_require jq || return 1
+    tmp="$(mktemp)"
+    jq -n --argjson active "$active" --arg reason "$reason" --arg since "$(date -Iseconds)" \
+        '{active: $active, reason: $reason, since: $since}' > "$tmp" \
+        && mv "$tmp" "$APHOTIC_SAFE_MODE_FILE"
+}
+
+aphotic_safe_mode_reason() {
+    [[ -f "$APHOTIC_SAFE_MODE_FILE" ]] || return 0
+    jq -r '.reason // ""' "$APHOTIC_SAFE_MODE_FILE" 2>/dev/null
+}
+
+# What changed, and when. `aphotic recovery` reads this to name a likely
+# culprit when the crash output does not name one itself -- a shell that
+# stopped starting right after a plugin went in is the common case, and
+# nothing else on the machine records that ordering.
+aphotic_record_change() {
+    local kind="$1" detail="${2:-}" tmp
+    printf '%s\t%s\t%s\n' "$(date -Iseconds)" "$kind" "$detail" >> "$APHOTIC_CHANGE_LOG" 2>/dev/null || return 0
+    # Bounded: this is a breadcrumb trail, not an audit log.
+    if [[ "$(wc -l < "$APHOTIC_CHANGE_LOG" 2>/dev/null || echo 0)" -gt 400 ]]; then
+        tmp="$(mktemp)"
+        tail -n 200 "$APHOTIC_CHANGE_LOG" > "$tmp" && mv "$tmp" "$APHOTIC_CHANGE_LOG"
+    fi
+    return 0
+}
+
 # ---- plugin helpers -------------------------------------------------------
 # List installed plugin directory names (each has a plugin.toml).
 aphotic_plugin_names() {
@@ -371,6 +420,7 @@ aphotic_plugin_set_enabled() {
         jq --arg n "$name" '.disabled = ((.disabled // []) + [$n] | unique)' "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp"
     fi
     mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
+    aphotic_record_change "plugin-$([[ "$enabled" == "true" ]] && echo enabled || echo disabled)" "$name"
 }
 
 # Whether the user has explicitly opted into seeing/installing

--- a/Configs/hypr/keybinds.lua
+++ b/Configs/hypr/keybinds.lua
@@ -16,6 +16,12 @@ hl.bind(mainMod .. " + CTRL + W", hl.dsp.exec_cmd("qs -c aphotic ipc call launch
 hl.bind(mainMod .. " + comma", hl.dsp.exec_cmd("aphotic theme prev"), { description = "Previous theme" })
 hl.bind(mainMod .. " + period", hl.dsp.exec_cmd("aphotic theme next"), { description = "Next theme" })
 hl.bind(mainMod .. " + B", hl.dsp.exec_cmd("systemctl --user restart aphotic-shell.service"), { description = "Restart Aphotic shell" })
+-- The manual way into the recovery surface. aphotic-shell.service fires
+-- the same thing on its own once systemd gives up restarting the shell,
+-- but a Hyprland bind is the one input path that still works when there
+-- is no shell at all -- which is exactly when this is wanted. Sits next
+-- to SUPER+B on purpose: B restarts, SHIFT+B recovers.
+hl.bind(mainMod .. " + SHIFT + B", hl.dsp.exec_cmd("aphotic recovery present"), { description = "Aphotic recovery (shell will not start)" })
 hl.bind(mainMod .. " + F", hl.dsp.exec_cmd("firefox"), { description = "Open Firefox" })
 hl.bind(mainMod .. " + C", hl.dsp.exec_cmd("code"), { description = "Open VS Code" })
 

--- a/Configs/quickshell/aphotic-recovery/ActionButton.qml
+++ b/Configs/quickshell/aphotic-recovery/ActionButton.qml
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+import QtQuick
+
+Rectangle {
+    id: root
+
+    property string label
+    property string detail
+    property bool primary: false
+    property bool enabledAction: true
+
+    signal activated
+
+    implicitHeight: column.implicitHeight + 24
+    radius: 10
+    color: !root.enabledAction ? Colours.surface : root.primary ? Colours.primary : mouse.containsMouse ? Colours.surfaceRaised : Colours.surface
+    border.width: 1
+    border.color: root.primary ? "transparent" : Colours.outline
+    opacity: root.enabledAction ? 1 : 0.45
+
+    Behavior on color {
+        ColorAnimation {
+            duration: 120
+        }
+    }
+
+    Column {
+        id: column
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: 18
+        anchors.rightMargin: 18
+        spacing: 3
+
+        Text {
+            width: parent.width
+            text: root.label
+            color: root.primary ? Colours.primaryTextColor : Colours.textColor
+            font.pixelSize: 15
+            font.weight: Font.DemiBold
+            elide: Text.ElideRight
+        }
+
+        Text {
+            width: parent.width
+            visible: root.detail.length > 0
+            text: root.detail
+            color: root.primary ? Colours.primaryTextColor : Colours.mutedTextColor
+            font.pixelSize: 12
+            opacity: root.primary ? 0.75 : 1
+            wrapMode: Text.WordWrap
+        }
+    }
+
+    MouseArea {
+        id: mouse
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: root.enabledAction ? Qt.PointingHandCursor : Qt.ArrowCursor
+        onClicked: {
+            if (root.enabledAction)
+                root.activated();
+        }
+    }
+}

--- a/Configs/quickshell/aphotic-recovery/Colours.qml
+++ b/Configs/quickshell/aphotic-recovery/Colours.qml
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma Singleton
+
+import QtQuick
+import Quickshell
+
+// Fixed, and deliberately not the user's theme. Applying a theme
+// rewrites the shell's own Colours.qml from a wallust/matugen template,
+// so the palette is one of the things that can be broken when this
+// screen is needed. Reading it here would put the recovery surface
+// behind the same failure it exists to recover from.
+//
+// Properties avoid a bare `onXxx` shape (textColor, not onSurface): QML
+// reserves any property identifier starting with "on" plus an uppercase
+// letter for signal handlers.
+Singleton {
+    readonly property color background: "#101015"
+    readonly property color surface: "#1b1b22"
+    readonly property color surfaceRaised: "#24242d"
+    readonly property color outline: "#3a3a46"
+    readonly property color textColor: "#e8e5ed"
+    readonly property color mutedTextColor: "#a5a2b0"
+    readonly property color primary: "#a9c7ff"
+    readonly property color primaryTextColor: "#00325a"
+    readonly property color warningColor: "#ffd98a"
+}

--- a/Configs/quickshell/aphotic-recovery/Diagnosis.qml
+++ b/Configs/quickshell/aphotic-recovery/Diagnosis.qml
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// The diagnosis itself lives in bash (`aphotic recovery`,
+// commands/cmd_recovery.sh) because it has to work with no shell running
+// at all -- the terminal menu is the same four choices off the same
+// evidence. This reads it and does nothing else clever.
+Singleton {
+    id: root
+
+    property bool loaded: false
+    property int failures: 0
+    property string unit: ""
+    property string suspectPlugin: ""
+    property string lastChange: ""
+    property string latestBackup: ""
+    property string logTail: ""
+    property string version: ""
+    property bool safeMode: false
+
+    // Set while an action is running, so the surface can say what it is
+    // doing instead of sitting there looking unresponsive for the second
+    // or two before it closes.
+    property string applying: ""
+
+    function refresh(): void {
+        statusProc.running = true;
+    }
+
+    // Hand off and get out of the way. The action restarts the shell
+    // itself, so this surface has no reason to still be on screen -- and
+    // every reason not to be, since it holds exclusive keyboard focus.
+    function apply(action: string): void {
+        if (root.applying)
+            return;
+        root.applying = action;
+        Quickshell.execDetached(["aphotic", "recovery", "apply", action]);
+        quitTimer.start();
+    }
+
+    Component.onCompleted: root.refresh()
+
+    Timer {
+        id: quitTimer
+        interval: 400
+        onTriggered: Qt.quit()
+    }
+
+    Process {
+        id: statusProc
+        command: ["aphotic", "recovery", "status", "--json"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const data = JSON.parse(text);
+                    root.failures = data.failures ?? 0;
+                    root.unit = data.unit ?? "";
+                    root.suspectPlugin = data.suspectPlugin ?? "";
+                    root.lastChange = data.lastChange ?? "";
+                    root.latestBackup = data.latestBackup ?? "";
+                    root.logTail = data.logTail ?? "";
+                    root.version = data.version ?? "";
+                    root.safeMode = data.safeMode === true;
+                } catch (e) {
+                    root.logTail = text;
+                }
+                root.loaded = true;
+            }
+        }
+        stderr: StdioCollector {
+            onStreamFinished: {
+                if (!root.loaded && text.trim().length > 0) {
+                    root.logTail = text.trim();
+                    root.loaded = true;
+                }
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic-recovery/RecoveryContent.qml
+++ b/Configs/quickshell/aphotic-recovery/RecoveryContent.qml
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+
+// Four choices, in the order a person should try them: the narrowest fix
+// that the evidence actually supports first, the broadest last. Nothing
+// here is applied automatically -- the shell is already down, and a
+// recovery screen that acts on its own is one more thing that can be
+// wrong.
+Item {
+    id: root
+
+    property int maxHeight: 720
+
+    implicitHeight: Math.min(root.maxHeight, card.implicitHeight)
+
+    Rectangle {
+        id: card
+        anchors.fill: parent
+        radius: 16
+        color: Colours.surface
+        border.width: 1
+        border.color: Colours.outline
+
+        implicitHeight: layout.implicitHeight + 56
+
+        ColumnLayout {
+            id: layout
+            anchors.fill: parent
+            anchors.margins: 28
+            spacing: 16
+
+            Text {
+                text: qsTr("Aphotic recovery")
+                color: Colours.textColor
+                font.pixelSize: 24
+                font.weight: Font.DemiBold
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: Diagnosis.failures > 0 ? qsTr("The shell failed to start %1 times in a row, so it has stopped trying.").arg(Diagnosis.failures) : qsTr("The shell is not running.")
+                color: Colours.mutedTextColor
+                font.pixelSize: 13
+                wrapMode: Text.WordWrap
+            }
+
+            // What the evidence actually is, stated plainly. A recovery
+            // screen that names a culprit without showing why is asking
+            // to be trusted on nothing.
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: evidence.implicitHeight + 24
+                visible: Diagnosis.suspectPlugin.length > 0 || Diagnosis.lastChange.length > 0
+                radius: 10
+                color: Colours.surfaceRaised
+
+                ColumnLayout {
+                    id: evidence
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.leftMargin: 16
+                    anchors.rightMargin: 16
+                    spacing: 4
+
+                    Text {
+                        Layout.fillWidth: true
+                        visible: Diagnosis.suspectPlugin.length > 0
+                        text: qsTr("Suspected plugin: %1").arg(Diagnosis.suspectPlugin)
+                        color: Colours.warningColor
+                        font.pixelSize: 13
+                        font.weight: Font.DemiBold
+                        wrapMode: Text.WordWrap
+                    }
+
+                    Text {
+                        Layout.fillWidth: true
+                        visible: Diagnosis.suspectPlugin.length > 0
+                        text: qsTr("Its files are named in the failure output below.")
+                        color: Colours.mutedTextColor
+                        font.pixelSize: 12
+                        wrapMode: Text.WordWrap
+                    }
+
+                    Text {
+                        Layout.fillWidth: true
+                        visible: Diagnosis.lastChange.length > 0
+                        text: qsTr("Last change: %1").arg(Diagnosis.lastChange)
+                        color: Colours.mutedTextColor
+                        font.pixelSize: 12
+                        wrapMode: Text.WordWrap
+                    }
+                }
+            }
+
+            Text {
+                text: qsTr("Last output")
+                color: Colours.mutedTextColor
+                font.pixelSize: 12
+                visible: Diagnosis.logTail.length > 0
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.minimumHeight: 90
+                Layout.maximumHeight: 180
+                visible: Diagnosis.logTail.length > 0
+                radius: 10
+                color: Colours.background
+                clip: true
+
+                Flickable {
+                    anchors.fill: parent
+                    anchors.margins: 12
+                    contentWidth: width
+                    contentHeight: logText.implicitHeight
+                    boundsBehavior: Flickable.StopAtBounds
+
+                    Text {
+                        id: logText
+                        width: parent.width
+                        text: Diagnosis.logTail
+                        color: Colours.mutedTextColor
+                        font.family: "monospace"
+                        font.pixelSize: 11
+                        wrapMode: Text.Wrap
+                    }
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: 4
+                spacing: 8
+
+                ActionButton {
+                    Layout.fillWidth: true
+                    primary: Diagnosis.suspectPlugin.length > 0
+                    enabledAction: Diagnosis.suspectPlugin.length > 0 && !Diagnosis.applying
+                    label: Diagnosis.suspectPlugin.length > 0 ? qsTr("Disable %1 and restart").arg(Diagnosis.suspectPlugin) : qsTr("Disable the suspected plugin")
+                    detail: Diagnosis.suspectPlugin.length > 0 ? qsTr("Keeps every other plugin. Re-enable it later from Settings > Plugins.") : qsTr("Nothing in the failure output names a plugin.")
+                    onActivated: Diagnosis.apply("disable-suspect")
+                }
+
+                ActionButton {
+                    Layout.fillWidth: true
+                    primary: Diagnosis.suspectPlugin.length === 0
+                    enabledAction: !Diagnosis.applying
+                    label: qsTr("Start in safe mode")
+                    detail: qsTr("Every plugin held back, core shell only. Nothing is uninstalled.")
+                    onActivated: Diagnosis.apply("safe-mode")
+                }
+
+                ActionButton {
+                    Layout.fillWidth: true
+                    enabledAction: Diagnosis.latestBackup.length > 0 && !Diagnosis.applying
+                    label: qsTr("Restore the last backup")
+                    detail: Diagnosis.latestBackup.length > 0 ? qsTr("%1. Your current config is snapshotted first.").arg(Diagnosis.latestBackup) : qsTr("No backup has been taken on this machine.")
+                    onActivated: Diagnosis.apply("restore-last")
+                }
+
+                ActionButton {
+                    Layout.fillWidth: true
+                    enabledAction: !Diagnosis.applying
+                    label: qsTr("Start normally")
+                    detail: qsTr("Change nothing and try again.")
+                    onActivated: Diagnosis.apply("continue")
+                }
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: Diagnosis.applying ? qsTr("Applying…") : qsTr("Every option here is also available as 'aphotic recovery' in a terminal.")
+                color: Colours.mutedTextColor
+                font.pixelSize: 11
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic-recovery/RecoveryWindow.qml
+++ b/Configs/quickshell/aphotic-recovery/RecoveryWindow.qml
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+
+// Same shape as the greeter's window, and for the same reason: there is
+// no desktop shell running to layer against, so a fullscreen,
+// keyboard-exclusive overlay is all this needs. Exclusive focus matters
+// here -- the bar and launcher are gone, and a recovery screen the user
+// can type past is a recovery screen they will lose behind a window.
+PanelWindow {
+    id: root
+
+    required property var modelData
+    screen: modelData
+
+    WlrLayershell.namespace: "aphotic-recovery"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+    WlrLayershell.exclusionMode: ExclusionMode.Ignore
+    color: Colours.background
+
+    anchors.top: true
+    anchors.bottom: true
+    anchors.left: true
+    anchors.right: true
+
+    RecoveryContent {
+        anchors.centerIn: parent
+        width: Math.min(720, root.width - 96)
+        maxHeight: root.height - 96
+    }
+}

--- a/Configs/quickshell/aphotic-recovery/shell.qml
+++ b/Configs/quickshell/aphotic-recovery/shell.qml
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+import Quickshell
+
+// A separate quickshell config from the desktop shell, on purpose. This
+// is what runs when `qs -c aphotic` will not stay up, so it can share
+// nothing with it: no qs.* import, no theme, no plugin, no settings
+// file. Everything it needs is in this directory, and everything it
+// knows comes from `aphotic recovery status --json`.
+//
+// It is not a fallback shell and must never grow into one. Four buttons,
+// one diagnosis, then it gets out of the way.
+ShellRoot {
+    Variants {
+        model: Quickshell.screens
+
+        RecoveryWindow {}
+    }
+}

--- a/Configs/quickshell/aphotic/modules/settings/panes/SystemPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/SystemPane.qml
@@ -116,6 +116,47 @@ ColumnLayout {
         }
     }
 
+    // Only on screen while safe mode is on. Without it the mode is
+    // invisible from inside the shell -- every plugin surface is simply
+    // absent, which reads as breakage rather than as a state someone
+    // chose. This is the way out that does not require remembering a
+    // command.
+    SettingsGroup {
+        Layout.fillWidth: true
+        visible: SafeMode.active
+
+        SettingsRow {
+            icon: "shield"
+            label: qsTr("Safe mode is on")
+            description: SafeMode.reason ? qsTr("Plugins are held back: %1").arg(SafeMode.reason) : qsTr("Plugins are held back. Nothing has been uninstalled.")
+
+            StyledRect {
+                Layout.preferredHeight: 32
+                Layout.preferredWidth: leaveSafeModeLabel.implicitWidth + Tokens.padding.large * 2
+                radius: Tokens.rounding.full
+                color: Colours.palette.m3secondaryContainer
+
+                StyledText {
+                    id: leaveSafeModeLabel
+                    anchors.centerIn: parent
+                    text: qsTr("Leave safe mode")
+                    color: Colours.palette.m3onSecondaryContainer
+                    font: Tokens.font.label.medium
+                }
+
+                StateLayer {
+                    anchors.fill: parent
+                    radius: parent.radius
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: SafeMode.leave()
+                }
+            }
+        }
+    }
+
     StyledText {
         text: qsTr("Overview")
         color: Colours.palette.m3onSurfaceVariant

--- a/Configs/quickshell/aphotic/services/PluginRegistry.qml
+++ b/Configs/quickshell/aphotic/services/PluginRegistry.qml
@@ -40,8 +40,15 @@ Singleton {
         return Object.prototype.hasOwnProperty.call(root._installed, name);
     }
 
+    // Safe mode answers false for every plugin, which is the one gate
+    // that has to hold for all of them at once: every registration list
+    // below asks this question, so holding plugins back is one condition
+    // rather than a check per surface kind. isInstalled() deliberately
+    // stays true -- the Plugins pane still lists what is installed and
+    // what the user themselves turned off, it just is not loading any of
+    // it. See services/SafeMode.qml.
     function isEnabled(name: string): bool {
-        return root.isInstalled(name) && !root._disabled.includes(name);
+        return !SafeMode.active && root.isInstalled(name) && !root._disabled.includes(name);
     }
 
     // Every enabled plugin's [ui.*] declarations, resolved to absolute

--- a/Configs/quickshell/aphotic/services/SafeMode.qml
+++ b/Configs/quickshell/aphotic/services/SafeMode.qml
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+
+// One flag, read from one file the CLI writes (`aphotic safemode`,
+// cmd_safemode.sh). While it is set, PluginRegistry hands out no
+// registrations at all, so the shell comes up as core only -- the state
+// a machine has to be able to reach when a plugin is what stops it
+// starting. See docs/playbooks/safe-mode-recovery.md.
+//
+// Watched rather than read once, so leaving safe mode brings plugins
+// back without a restart, and entering it drops them without one.
+//
+// The toast is the point of this being a singleton with behaviour rather
+// than a plain flag: safe mode is invisible otherwise, and a user whose
+// plugins are all missing with no explanation is worse off than one
+// looking at a broken plugin.
+Singleton {
+    id: root
+
+    readonly property string statePath: `${Quickshell.env("HOME")}/.local/state/aphotic/safe-mode.json`
+
+    property bool active: false
+    property string reason: ""
+    property string since: ""
+
+    property bool _announced: false
+
+    function leave(): void {
+        Quickshell.execDetached(["aphotic", "safemode", "off"]);
+    }
+
+    onActiveChanged: {
+        if (!root.active) {
+            root._announced = false;
+            return;
+        }
+        if (root._announced)
+            return;
+        root._announced = true;
+        Toaster.toast(qsTr("Safe mode"), root.reason ? qsTr("Plugins are held back: %1. Settings > System has the way out.").arg(root.reason) : qsTr("Plugins are held back. Settings > System has the way out."), "");
+    }
+
+    FileView {
+        path: root.statePath
+        watchChanges: true
+        onFileChanged: reload()
+        onLoaded: {
+            try {
+                const data = JSON.parse(text());
+                root.active = data.active === true;
+                root.reason = data.reason ?? "";
+                root.since = data.since ?? "";
+            } catch (e) {
+                root.active = false;
+            }
+        }
+        onLoadFailed: {
+            root.active = false;
+            root.reason = "";
+            root.since = "";
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -22,6 +22,7 @@ singleton PkgSearch 1.0 PkgSearch.qml
 singleton PluginRegistry 1.0 PluginRegistry.qml
 singleton Pomodoro 1.0 Pomodoro.qml
 singleton ProcessUsage 1.0 ProcessUsage.qml
+singleton SafeMode 1.0 SafeMode.qml
 singleton SessionLockState 1.0 SessionLockState.qml
 singleton Settings 1.0 Settings.qml
 singleton SystemUsage 1.0 SystemUsage.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -421,11 +421,13 @@ ShellRoot {
     // through the launcher and Gaming through the plugin registry;
     // WallpaperCycle owns the auto-cycle Timer the Appearance pane
     // already ships a toggle and an interval picker for; DevDrift watches
-    // DevProfile for a stale lockfile. Listing them here is what makes
-    // them exist. Anything added to services/ that runs on its own rather
-    // than answering a reader belongs in this list, and
-    // tests/test_singleton_reachability.py fails the build if it does not.
-    readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift]
+    // DevProfile for a stale lockfile; SafeMode raises the toast that is
+    // the only reason a user in safe mode knows why their plugins are
+    // gone. Listing them here is what makes them exist. Anything added to
+    // services/ that runs on its own rather than answering a reader
+    // belongs in this list, and tests/test_singleton_reachability.py
+    // fails the build if it does not.
+    readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift, SafeMode]
 
     // The profile substrate's inspection/drive surface (Phase 0 --
     // docs/APHOTIC_UNIFIED_VISION.md section 3.5). Lives here rather than

--- a/Configs/systemd/user/aphotic-recovery.service
+++ b/Configs/systemd/user/aphotic-recovery.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Aphotic shell recovery
+# Started by aphotic-shell.service's OnFailure=, which systemd only
+# reaches once that unit has burned through StartLimitBurst restarts --
+# so this is "the shell will not stay up", never "the shell crashed
+# once". Nothing enables or wants this unit; it is triggered or idle.
+
+[Service]
+Type=oneshot
+Environment=PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin
+# `recovery present` renders the aphotic-recovery quickshell config and
+# falls back to a terminal menu if that will not start either -- a second
+# quickshell config is no help when quickshell itself is what broke.
+ExecStart=%h/.local/bin/aphotic recovery present
+# It hands off to a detached surface and exits; leaving the unit
+# "active" would make a second failure look like a recovery already in
+# progress.
+RemainAfterExit=no

--- a/Configs/systemd/user/aphotic-shell.service
+++ b/Configs/systemd/user/aphotic-shell.service
@@ -19,5 +19,18 @@ ExecStart=/usr/bin/qs -c aphotic
 Restart=on-failure
 RestartSec=2
 
+# Every failed exit is recorded so `aphotic recovery` can say how often
+# and how recently the shell died -- systemd's own restart counter is
+# reset by anything that touches the unit, and the journal alone does not
+# survive a machine that is rebooting to try again. Leading `-` because a
+# recorder that fails must not itself put the unit into a failed state.
+ExecStopPost=-/bin/sh -c 'exec %h/.local/bin/aphotic recovery record "$SERVICE_RESULT" "$EXIT_STATUS"'
+
+# Fires only once systemd gives up, i.e. StartLimitBurst above is
+# exceeded and the unit enters `failed` -- a single crash that restarts
+# cleanly never reaches it. That is the whole trigger for the recovery
+# surface: no polling, no watchdog, no second supervisor.
+OnFailure=aphotic-recovery.service
+
 [Install]
 WantedBy=graphical-session.target

--- a/profiles/base/full.toml
+++ b/profiles/base/full.toml
@@ -3,7 +3,7 @@ name = "full"
 description = "Full install: today's complete package set"
 
 [packages]
-prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "procps-ng", "util-linux", "gawk"]
+prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "libnotify", "procps-ng", "util-linux", "gawk"]
 # tumbler and the three format helpers after `thunar` are Thunar's
 # thumbnailing stack, not extras: Thunar renders no thumbnails itself, it
 # asks the Tumbler D-Bus service, so without tumbler installed every file

--- a/profiles/base/minimal.toml
+++ b/profiles/base/minimal.toml
@@ -3,5 +3,5 @@ name = "minimal"
 description = "Bare Hyprland + Quickshell bar, no extras"
 
 [packages]
-prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "procps-ng", "util-linux", "gawk"]
+prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "libnotify", "procps-ng", "util-linux", "gawk"]
 main = ["quickshell", "qt6-shadertools", "kitty", "awww", "xdg-desktop-portal-hyprland", "wallust-git", "matugen", "openvpn", "swappy", "grim", "slurp", "brightnessctl", "swaylock-effects", "hypridle", "cava"]

--- a/tests/test_recovery.sh
+++ b/tests/test_recovery.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# tests/test_recovery.sh
+#
+# REL-01. The recovery path only earns its place if it works with no
+# shell running, so everything here drives the bash side directly with a
+# fake HOME and no quickshell anywhere.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not installed"; exit 0; }
+
+export HOME="$WORKDIR/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_STATE_HOME="$HOME/.local/state"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_RUNTIME_DIR="$WORKDIR/run"
+export APHOTIC_DOTS_DIR="$ROOT"
+mkdir -p "$HOME" "$XDG_RUNTIME_DIR"
+
+LIB_DIR="$ROOT/Configs/.local/lib/aphotic"
+COMMANDS_DIR="$LIB_DIR/commands"
+export LIB_DIR COMMANDS_DIR
+
+# shellcheck source=/dev/null
+source "$LIB_DIR/globalcontrol.sh"
+
+# Nothing in this test may reach the real systemd, the real journal or
+# the real shell -- a stubbed PATH is what keeps `apply` from restarting
+# anything on the machine running the tests.
+mkdir -p "$WORKDIR/bin"
+export CALL_LOG="$WORKDIR/calls.log"
+for stub in systemctl journalctl qs hyprctl; do
+    cat > "$WORKDIR/bin/$stub" <<EOF
+#!/usr/bin/env bash
+echo "$stub \$*" >> "\$CALL_LOG"
+exit 0
+EOF
+    chmod +x "$WORKDIR/bin/$stub"
+done
+export PATH="$WORKDIR/bin:$PATH"
+
+source "$COMMANDS_DIR/cmd_recovery.sh"
+
+# --- 1. a clean stop is not a failure --------------------------------
+aphotic_cmd_recovery record success 0
+[[ "$(_aphotic_recovery_failure_count)" == "0" ]] \
+    || fail "a successful exit must not be recorded as a failure"
+
+# --- 2. failed exits accumulate, bounded ------------------------------
+for _ in $(seq 1 12); do
+    aphotic_cmd_recovery record exit-code 1
+done
+count="$(_aphotic_recovery_failure_count)"
+[[ "$count" == "$APHOTIC_RECOVERY_KEEP" ]] \
+    || fail "expected the failure list capped at $APHOTIC_RECOVERY_KEEP, got $count"
+
+# --- 3. a plugin named in the failure output is the suspect -----------
+mkdir -p "$APHOTIC_PLUGINS_DIR/agent-graph" "$APHOTIC_PLUGINS_DIR/decoy"
+for p in agent-graph decoy; do
+    printf '[plugin]\nname = "%s"\nversion = "1.0.0"\n' "$p" > "$APHOTIC_PLUGINS_DIR/$p/plugin.toml"
+done
+cat > "$APHOTIC_STATE_HOME/shell.log" <<EOF
+file://$APHOTIC_PLUGINS_DIR/decoy/qml/Decoy.qml:1 loaded fine
+QQmlApplicationEngine failed to load component
+file://$APHOTIC_PLUGINS_DIR/agent-graph/qml/AgentGraphTab.qml:41 Type error
+EOF
+# journalctl is stubbed to print nothing, so the log file is the source.
+suspect="$(_aphotic_recovery_suspect_plugin || true)"
+[[ "$suspect" == "agent-graph" ]] \
+    || fail "expected agent-graph as the suspect (last plugin path in the output), got '${suspect:-none}'"
+
+# --- 4. a path that is not an installed plugin is never a suspect -----
+# The whole point of asking "does the output mention this installed
+# plugin" rather than "does this look like a plugin path".
+cat > "$APHOTIC_STATE_HOME/shell.log" <<EOF
+file://$APHOTIC_PLUGINS_DIR/never-installed/qml/Thing.qml:3 Type error
+EOF
+suspect="$(_aphotic_recovery_suspect_plugin || true)"
+[[ -z "$suspect" ]] \
+    || fail "a plugin directory that does not exist must not be named as a suspect, got '$suspect'"
+
+# --- 5. status --json is parseable and carries the diagnosis ----------
+cat > "$APHOTIC_STATE_HOME/shell.log" <<EOF
+file://$APHOTIC_PLUGINS_DIR/agent-graph/qml/AgentGraphTab.qml:41 Type error
+EOF
+aphotic_record_change "plugin-registered" "agent-graph 1.2.0"
+json="$(aphotic_cmd_recovery status --json)"
+echo "$json" | jq -e . >/dev/null 2>&1 || fail "status --json did not emit valid JSON"
+[[ "$(echo "$json" | jq -r .suspectPlugin)" == "agent-graph" ]] \
+    || fail "status --json did not carry the suspected plugin"
+[[ "$(echo "$json" | jq -r .safeMode)" == "false" ]] \
+    || fail "status --json reported safe mode on when it is off"
+echo "$json" | jq -r .lastChange | grep -q "agent-graph 1.2.0" \
+    || fail "status --json did not carry the last recorded change"
+
+# --- 6. safe mode round-trips through the file the shell watches ------
+source "$COMMANDS_DIR/cmd_safemode.sh"
+aphotic_safe_mode_active && fail "safe mode must start off"
+aphotic_safe_mode_set true "test" || fail "could not turn safe mode on"
+aphotic_safe_mode_active || fail "safe mode did not read back as on"
+[[ "$(aphotic_safe_mode_reason)" == "test" ]] || fail "safe mode reason did not round-trip"
+[[ "$(jq -r .active "$APHOTIC_SAFE_MODE_FILE")" == "true" ]] \
+    || fail "safe-mode.json is not the shape services/SafeMode.qml parses"
+aphotic_safe_mode_set false "" || fail "could not turn safe mode off"
+aphotic_safe_mode_active && fail "safe mode did not read back as off"
+
+# --- 7. apply safe-mode sets the flag, clears failures, restarts ------
+: > "$CALL_LOG"
+aphotic_cmd_recovery apply safe-mode >/dev/null 2>&1 || fail "apply safe-mode failed"
+aphotic_safe_mode_active || fail "apply safe-mode did not turn safe mode on"
+[[ "$(_aphotic_recovery_failure_count)" == "0" ]] \
+    || fail "apply must clear the recorded failures once it has acted"
+grep -q "systemctl .*reset-failed aphotic-shell.service" "$CALL_LOG" \
+    || fail "apply must clear the systemd start limit, or the restart is refused"
+grep -q "systemctl .*restart aphotic-shell.service" "$CALL_LOG" \
+    || fail "apply must restart the shell"
+
+# --- 8. apply disable-suspect refuses when nothing is suspected -------
+rm -f "$APHOTIC_STATE_HOME/shell.log"
+: > "$CALL_LOG"
+rc=0
+aphotic_cmd_recovery apply disable-suspect >/dev/null 2>&1 || rc=$?
+[[ "$rc" -ne 0 ]] || fail "disable-suspect must refuse when no plugin is suspected"
+grep -q "systemctl" "$CALL_LOG" && fail "a refused action must not touch the shell unit"
+
+# --- 9. an unknown action is refused, not guessed at ------------------
+rc=0
+aphotic_cmd_recovery apply demolish >/dev/null 2>&1 || rc=$?
+[[ "$rc" -ne 0 ]] || fail "an unknown recovery action must fail"
+
+echo "PASS: recovery record/suspect/status + safe mode round-trip + apply"


### PR DESCRIPTION
## Problem

The shell could stop starting and leave you with nothing. A bad plugin,
a broken generated palette, a QML error in core: `qs -c aphotic` exits,
`Restart=on-failure` retries five times in a minute, systemd hits the
start limit and gives up. You get a Hyprland session with no bar, no
launcher, no notification, and no record of what happened. Recovering
meant already knowing which log to read and which command to run.

This was the only S1 in `ISSUES.md`.

## Plan

Use systemd's own signal rather than adding a watchdog. With
`Restart=on-failure`, a unit reaches `failed` only after its start limit
is exceeded, so `OnFailure=` fires on "will not stay up" and stays quiet
for a crash that comes back. Nothing polls.

Put the diagnosis in bash, since it has to run with no shell up. The
recovery surface and a terminal menu are two front ends over one
`aphotic recovery status --json`, so they cannot disagree, and the
terminal path still works if quickshell itself is what broke.

Two decisions worth knowing, recorded as `D-11` and `D-12`:

- The recovery surface is its own quickshell config sharing nothing with
  the desktop shell. No `qs.*` import, no theme, no plugin, no settings
  file. Its palette is fixed, since applying a theme rewrites the shell's
  own `Colours.qml` and is one of the things that can be broken here.
- Safe mode gates at `PluginRegistry.isEnabled()`. Every registration
  list already asks that question, so it is one condition rather than a
  check per surface kind, and a future surface kind inherits it.
  `isInstalled()` stays true, so the Plugins pane still shows what you
  installed and what you turned off yourself.

## Resolution

`aphotic-shell.service` records failed exits through `ExecStopPost=` and
fires `aphotic-recovery.service` through `OnFailure=`. That runs
`aphotic recovery present`, which renders
`Configs/quickshell/aphotic-recovery/` and falls back to a terminal menu.
`SUPER+SHIFT+B` opens the same thing by hand, next to `SUPER+B` for
restart.

Four actions, narrowest first: disable the suspected plugin, start in
safe mode, restore the last backup, start unchanged. Each resets the
systemd start limit before restarting, or the fix lands on a unit systemd
still refuses to start.

Attribution asks, for each installed plugin, whether the failure output
mentions its directory. That way round a stray path cannot invent a
plugin that is not installed, and no path escaping is involved. Latest
mention wins, since QML reports the failing component last. When the
crash names nothing, a new change journal at
`~/.local/state/aphotic/changes.log` supplies the last thing that
changed; it is written from three central hooks rather than per call
site.

Safe mode lives in one watched file, so entering and leaving both apply
to a running shell with no restart, and entering needs no running shell.
It shows up as a startup toast and as a card at the top of Settings >
System with a Leave safe mode button.

Also here: `backup revert --yes` for the graphical path, `libnotify` in
both profiles for the toast, and `tests/test_recovery.sh`.

**Left out on purpose.** The recovery surface is not a fallback shell and
should not grow into one. `REL-02` Doctor is the next piece: safe mode is
where you send someone, Doctor is what you tell them to run.

**To verify.** `bash tests/test_recovery.sh` covers the bash side:
recording, bounding, attribution both ways, `status --json`, the safe
mode round trip, and that a refused action touches nothing. The QML side
is probed windowless in `docs/playbooks/safe-mode-recovery.md`, including
the safe mode gate proven on and off. Still wanted: a look at the
recovery surface on a real screen, and a dev-VM run, since this adds a
systemd unit and edits another.
