### PR TITLE
bar: a user-editable widget list, shaped for a plugin surface kind

### DIFF
--- a/Configs/quickshell/aphotic/config/PluginSurfaces.qml
+++ b/Configs/quickshell/aphotic/config/PluginSurfaces.qml
@@ -8,6 +8,7 @@ QtObject {
     readonly property var kinds: [
         { id: "dashboard", icon: "dashboard", description: qsTr("Adds a Dashboard tab: %1") },
         { id: "notch", icon: "expand_more", description: qsTr("Adds a notch tile: %1") },
+        { id: "bar", icon: "view_week", description: qsTr("Adds a bar widget: %1") },
         { id: "settings", icon: "tune", description: qsTr("Adds a Settings section: %1") },
         { id: "overlay", icon: "layers", description: qsTr("Adds an overlay: %1") },
         { id: "fullscreen-overlay", icon: "fullscreen", description: qsTr("Adds a fullscreen overlay: %1") }

--- a/Configs/quickshell/aphotic/modules/bar/Bar.qml
+++ b/Configs/quickshell/aphotic/modules/bar/Bar.qml
@@ -21,6 +21,37 @@ Item {
     readonly property int vPadding: Tokens.padding.large
     readonly property real spacing: Tokens.spacing.extraSmall
 
+    // Every id this build has a delegate for below. Kept beside the
+    // DelegateChooser so the two stay in step, and used to drop an id the
+    // build does not know -- a typo or a stale entry in a hand-edited
+    // list would otherwise resolve to the plugin fallback with no url,
+    // rendering a zero-width entry that still consumes a spacing slot and
+    // can still take the first/last vPadding. An unknown id is absent,
+    // not empty.
+    readonly property var builtinIds: ["spacer", "gap", "logo", "workspaces", "activeWindow", "media", "tray", "clock", "statusIcons", "settings", "agent", "power"]
+
+    // The bar's model, shaped like PluginRegistry.surfaceRegistrations so
+    // a "bar" surface kind concats straight onto it rather than needing a
+    // registry of its own -- the same arrangement Notch.qml uses for its
+    // tiles. A built-in record carries an empty componentUrl and resolves
+    // through the DelegateChooser by id; a plugin record carries a real
+    // one and falls through to the last DelegateChoice, so no plugin id
+    // ever appears in this file.
+    //
+    // The map() has to stay in this named property rather than moving
+    // inline into the ScriptModel binding below. ScriptModel diffs by
+    // object identity, so an inline map would mint fresh objects on every
+    // re-evaluation and rebuild every delegate -- resetting
+    // EntryWrapper.settled and replaying the grow-from-zero animations.
+    // Held here it re-evaluates only when the entry list or the plugin
+    // list actually changes.
+    readonly property var pluginEntries: PluginRegistry.surfacesFor("bar")
+    readonly property var entryRecords: Settings.barEntries.filter(e => e.enabled && root.builtinIds.includes(e.id)).map(e => ({
+                plugin: "",
+                id: e.id,
+                componentUrl: ""
+            })).concat(root.pluginEntries)
+
     // The active layout's Repeater, whichever orientation is live -- both
     // closeTray() and the along-axis helpers below hit-test/iterate through
     // this rather than root's own direct children, since the entries now
@@ -469,7 +500,7 @@ Item {
         id: repeater
 
         model: ScriptModel {
-            values: root.Config.bar.entries.values.filter(e => e.enabled)
+            values: root.entryRecords
         }
 
         DelegateChooser {
@@ -614,6 +645,20 @@ Item {
                     Power {
                         objectName: "taskbarPowerButton"
                         screenState: root.screenState
+                    }
+                }
+            }
+            // No roleValue: the fallback every record with an id this
+            // build has no built-in delegate for lands on. That is a
+            // plugin-supplied bar widget, loaded from the file:// url the
+            // registry resolved.
+            DelegateChoice {
+                delegate: EntryWrapper {
+                    id: pluginEntry
+
+                    Loader {
+                        active: pluginEntry.modelData.componentUrl.length > 0
+                        source: pluginEntry.modelData.componentUrl
                     }
                 }
             }

--- a/Configs/quickshell/aphotic/modules/bar/components/StatusIcons.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/StatusIcons.qml
@@ -58,7 +58,7 @@ Item {
     // instead of rendering as a visible line -- the pills' own gap does
     // that job.
     readonly property var groups: {
-        const values = root.Config.bar.statusIcons.values.filter(e => e.enabled);
+        const values = Settings.barStatusIcons.filter(e => e.enabled);
         const out = [];
         let current = [];
         for (const v of values) {

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -71,6 +71,18 @@ Singleton {
 
     readonly property string barStyle: ["dock", "taskbar", "minimal", "capsule"].includes(barSkin) ? barSkin : "full"
 
+    // Which built-in bar widgets render, and in what order: an ordered
+    // [{ id, enabled }] array, same shape as Config.qml's own defaults.
+    // Lives here rather than staying a compile-time Config value so it can
+    // be hand-edited in settings.json without touching QML. Once written,
+    // the persisted list wins over Config's default -- the same tradeoff
+    // workspaceProfiles already makes.
+    property var barEntries: Config.bar.entries.values
+    // The status-icon cluster's own ordered list, one level down: it is a
+    // single "statusIcons" bar entry whose contents split into pills at
+    // each "groupDivider".
+    property var barStatusIcons: Config.bar.statusIcons.values
+
     property bool dockAutoHide: false
     // Array of desktop-entry ids (DesktopEntry.id, e.g. "firefox") pinned
     // to the Dock style regardless of whether they're currently running.
@@ -396,6 +408,8 @@ Singleton {
             projectRoots: root.projectRoots,
             launcherStyle: root.launcherStyle,
             workspaceProfiles: root.workspaceProfiles,
+            barEntries: root.barEntries,
+            barStatusIcons: root.barStatusIcons,
             vpnConfigPath: root.vpnConfigPath,
             vpnAutoConnect: root.vpnAutoConnect,
             intelligenceEnabled: root.intelligenceEnabled,
@@ -699,6 +713,8 @@ hyprctl switchxkblayout all 0 >/dev/null 2>&1`;
     onProjectRootsChanged: root._saveState()
     onLauncherStyleChanged: root._saveState()
     onWorkspaceProfilesChanged: root._saveState()
+    onBarEntriesChanged: root._saveState()
+    onBarStatusIconsChanged: root._saveState()
     onVpnConfigPathChanged: root._saveState()
     onVpnAutoConnectChanged: root._saveState()
     onIntelligenceEnabledChanged: root._saveState()
@@ -885,6 +901,10 @@ hyprctl switchxkblayout all 0 >/dev/null 2>&1`;
                     root.launcherStyle = data.launcherStyle;
                 if (Array.isArray(data.workspaceProfiles))
                     root.workspaceProfiles = data.workspaceProfiles;
+                if (Array.isArray(data.barEntries))
+                    root.barEntries = data.barEntries;
+                if (Array.isArray(data.barStatusIcons))
+                    root.barStatusIcons = data.barStatusIcons;
                 if (typeof data.vpnConfigPath === "string")
                     root.vpnConfigPath = data.vpnConfigPath;
                 if (typeof data.vpnAutoConnect === "boolean")


### PR DESCRIPTION
## Problem

The bar's widget list was already ordered and config driven, in `Bar.qml`
rather than `BarWrapper.qml`. Two things were missing.

`Config.bar.entries.values` is a compile time `readonly property`, so
changing which widgets render or in what order meant editing QML source.
The status icon cluster one level down had the same problem.

The id to component mapping was a `DelegateChooser` rather than a list of
records, so a future `bar` surface kind had nowhere to concat. Adding one
would have meant a second registry beside `PluginRegistry`.

## Plan

Move both arrays into `Settings.qml`, defaulting from `Config.qml` and
persisting to `~/.local/state/aphotic/settings.json`. This follows the
`workspaceProfiles` pattern already in that file.

Reshape the model into records matching `PluginRegistry.surfaceRegistrations`,
then concat `PluginRegistry.surfacesFor("bar")` the way `Notch.qml` concats
its plugin tiles. Add a `bar` kind to `PluginSurfaces.qml` and a fallback
`DelegateChoice` that loads a record's `componentUrl`. No plugin id appears
in any core file.

`statusIcons` stays nested. Flattening it into top level entries would drop
the grouped pill chrome and the `groupDivider` splits.

## Resolution

Default order matches main. A headless probe instantiating `Bar.qml`
reports the same 13 entries in the same sequence, the same `contentExtent`,
and the same `activeWindowIndex`.

Removing an id closes the gap cleanly. Dropping `clock` gave 12 entries and
reclaimed exactly one `spacing` unit, since `entryCount` reads off the live
Repeater and the edge padding keys off first and last index.

An id this build has no delegate for gets filtered out of the record list.
Without that, a typo in a hand edited array would reach the plugin fallback
with no url and render a zero width entry that still consumed a spacing slot.

One tradeoff worth naming: once the list is written to `settings.json`, the
persisted copy wins, so a later change to the Config default will not reach
an existing install. Every other array setting in that file behaves the same
way.

Settings UI comes in a follow up. Editing the array by hand is the path for
now.
