### PR TITLE
settings: manage bar widgets from the Bar pane

### DIFF
--- a/Configs/quickshell/aphotic/modules/settings/SettingsPanel.qml
+++ b/Configs/quickshell/aphotic/modules/settings/SettingsPanel.qml
@@ -353,7 +353,9 @@ RowLayout {
     }
     Component {
         id: barComp
-        BarPane {}
+        BarPane {
+            screenState: root.screenState
+        }
     }
     Component {
         id: launcherComp

--- a/Configs/quickshell/aphotic/modules/settings/panes/BarPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/BarPane.qml
@@ -9,6 +9,8 @@ import qs.modules.settings
 ColumnLayout {
     id: root
 
+    required property ScreenState screenState
+
     spacing: Tokens.spacing.largeIncreased
 
     StyledText {
@@ -197,6 +199,15 @@ ColumnLayout {
             value: Settings.barSkin
             onSelected: value => Settings.barSkin = value
         }
+    }
+
+    // The entry list only drives the "full" style -- dock, taskbar,
+    // minimal and capsule each lay themselves out (see BarShell.qml), so
+    // the list would sit there doing nothing under any of them.
+    BarWidgetsSection {
+        Layout.fillWidth: true
+        visible: Settings.barStyle === "full"
+        screenState: root.screenState
     }
 
     ColumnLayout {

--- a/Configs/quickshell/aphotic/modules/settings/panes/BarWidgetsSection.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/BarWidgetsSection.qml
@@ -1,0 +1,172 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.components
+import qs.services
+
+// The bar's own widget list, editable in place: Settings.barEntries is the
+// same ordered [{ id, enabled }] array Bar.qml renders from, so a toggle or
+// a reorder here reaches the bar on the next binding pass with no restart.
+ColumnLayout {
+    id: root
+
+    required property ScreenState screenState
+
+    // Presentation for each id Bar.qml has a delegate for. `jump` names a
+    // Settings category to open, empty where the widget has nowhere of its
+    // own to go -- workspaces and statusIcons are configured by sections in
+    // this very pane, so sending the reader there would land them back on
+    // the page they are already reading.
+    //
+    // A plugin-contributed widget joins this list in a later pass, from
+    // PluginRegistry.surfacesFor("bar") -- the same call Bar.qml's
+    // `pluginEntries` already concats onto its own model. Nothing here
+    // reads it yet.
+    readonly property var catalog: ({
+            logo: { icon: "linux", label: qsTr("OS logo"), jump: "" },
+            workspaces: { icon: "workspaces", label: qsTr("Workspaces"), jump: "" },
+            activeWindow: { icon: "window", label: qsTr("Active window"), jump: "" },
+            media: { icon: "music_note", label: qsTr("Media"), jump: "" },
+            tray: { icon: "widgets", label: qsTr("System tray"), jump: "" },
+            clock: { icon: "schedule", label: qsTr("Clock"), jump: "clock" },
+            agent: { icon: "smart_toy", label: qsTr("Agent indicator"), jump: "ai" },
+            statusIcons: { icon: "tune", label: qsTr("Status icons"), jump: "" },
+            settings: { icon: "settings", label: qsTr("Settings button"), jump: "" },
+            power: { icon: "power_settings_new", label: qsTr("Power button"), jump: "power" },
+            spacer: { icon: "expand", label: qsTr("Flexible space"), jump: "" },
+            gap: { icon: "space_bar", label: qsTr("Fixed gap"), jump: "" }
+        })
+
+    // Every operation addresses an entry by array index, never by id:
+    // "spacer" legitimately appears more than once, so an id is not a key.
+    function describe(id: string): var {
+        return root.catalog[id] ?? ({
+                icon: "extension",
+                label: id,
+                jump: ""
+            });
+    }
+
+    function setEnabled(index: int, value: bool): void {
+        const next = Settings.barEntries.map((e, i) => i === index ? ({
+                    id: e.id,
+                    enabled: value
+                }) : e);
+        Settings.barEntries = next;
+    }
+
+    function move(from: int, to: int): void {
+        if (to < 0 || to >= Settings.barEntries.length || from === to)
+            return;
+        const next = Settings.barEntries.slice();
+        const moved = next.splice(from, 1)[0];
+        next.splice(to, 0, moved);
+        Settings.barEntries = next;
+    }
+
+    spacing: Tokens.spacing.small
+
+    StyledText {
+        text: qsTr("Widgets")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.medium
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        text: qsTr("Drag the handle to reorder. Disabled widgets leave no gap behind.")
+        wrapMode: Text.WordWrap
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.small
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+
+        Repeater {
+            model: Settings.barEntries
+
+            SettingsRow {
+                id: widgetRow
+
+                required property var modelData
+                required property int index
+
+                readonly property var info: root.describe(widgetRow.modelData.id)
+
+                icon: widgetRow.info.icon
+                label: widgetRow.info.label
+                description: widgetRow.modelData.enabled ? "" : qsTr("Hidden")
+                opacity: widgetRow.modelData.enabled ? 1 : 0.6
+
+                RowLayout {
+                    spacing: Tokens.spacing.small
+
+                    MaterialIcon {
+                        visible: widgetRow.info.jump.length > 0
+                        text: "open_in_new"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.small
+
+                        StateLayer {
+                            anchors.fill: parent
+                            anchors.margins: -Tokens.padding.small
+                            radius: Tokens.rounding.full
+                            onClicked: root.screenState.settingsCategory = widgetRow.info.jump
+                        }
+                    }
+
+                    MaterialIcon {
+                        text: widgetRow.modelData.enabled ? "toggle_on" : "toggle_off"
+                        fill: 1
+                        color: widgetRow.modelData.enabled ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+
+                        StateLayer {
+                            anchors.fill: parent
+                            anchors.margins: -Tokens.padding.small
+                            radius: Tokens.rounding.full
+                            onClicked: root.setEnabled(widgetRow.index, !widgetRow.modelData.enabled)
+                        }
+                    }
+
+                    // Only the handle drags. preventStealing keeps the
+                    // settings pane's own Flickable from claiming the
+                    // gesture and scrolling the page instead, which it
+                    // otherwise does the moment the pointer moves far
+                    // enough vertically to count as a flick.
+                    MaterialIcon {
+                        text: "drag_indicator"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.small
+
+                        MouseArea {
+                            anchors.fill: parent
+                            anchors.margins: -Tokens.padding.small
+                            preventStealing: true
+                            cursorShape: Qt.SizeVerCursor
+
+                            property real anchorY: 0
+
+                            onPressed: event => anchorY = mapToItem(null, event.x, event.y).y
+                            onPositionChanged: event => {
+                                const step = widgetRow.height;
+                                if (step <= 0)
+                                    return;
+                                const y = mapToItem(null, event.x, event.y).y;
+                                const delta = y - anchorY;
+                                if (Math.abs(delta) < step)
+                                    return;
+                                const dir = delta > 0 ? 1 : -1;
+                                root.move(widgetRow.index, widgetRow.index + dir);
+                                anchorY += step * dir;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/settings/qmldir
+++ b/Configs/quickshell/aphotic/modules/settings/qmldir
@@ -4,6 +4,7 @@ AiPane 1.0 panes/AiPane.qml
 AppearancePane 1.0 panes/AppearancePane.qml
 BarPane 1.0 panes/BarPane.qml
 BarStylePreviewCard 1.0 panes/BarStylePreviewCard.qml
+BarWidgetsSection 1.0 panes/BarWidgetsSection.qml
 CategoryRail 1.0 CategoryRail.qml
 ClockPane 1.0 panes/ClockPane.qml
 CommunityThemes 1.0 panes/CommunityThemes.qml


### PR DESCRIPTION
## Problem

Session 1 moved the bar's widget list into `settings.json` as
`Settings.barEntries`. Reordering the bar or hiding a widget still meant
opening a JSON file and restarting nothing in particular to see whether it
worked.

## Plan

Add a Widgets section to the Bar pane listing every entry in the array.

Rows use the shared `components/SettingsRow.qml` inside a `SettingsGroup`,
so they chain into the same connected card as every other settings list. The
trailing slot holds one `RowLayout` with a jump shortcut, an enable toggle,
and a drag handle, which is the arrangement `PluginsPane.qml` already uses
for installed plugin rows.

The shortcut appears only where the widget has somewhere of its own to go:
Clock, Agent indicator, Power button. Workspaces and Status icons are
configured by sections in the same pane, so a jump would land the reader back
on the page they are already reading.

Toggles and reorders rewrite `Settings.barEntries` directly. Both address
entries by array index rather than by id, since `spacer` appears twice in the
default list.

## Resolution

A headless probe confirms 13 rows for 13 entries, `first` and `last` stamped
on the right ones, and all 13 labels resolving from the catalog. Toggling
Clock flips the correct index. Moving Tray above Media reorders both. Moving
one spacer leaves two spacers, each independent. Out of range moves are
no-ops. An id the catalog does not know renders under its raw id rather than
vanishing, so a hand-edited array cannot lose entries it writes back.

The section hides unless the bar style is `full`. Dock, taskbar, minimal and
capsule each lay themselves out and never read the entry list, so the
controls would do nothing under any of them.

Two things worth knowing.

Rows snap to their new slot during a drag rather than gliding. Smooth
reordering means replacing `SettingsGroup` with a hand-positioned column for
this one section, which drops the shared container every other list uses.

`Settings._saveState()` has no debounce, so each swap rewrites the whole
file, around 2.5KB. A drag across the full list is roughly a dozen writes.
Adding a debounce means editing `Settings.qml`, which this session left
alone.

Plugin-contributed widgets are the next pass. `BarWidgetsSection.qml` names
`PluginRegistry.surfacesFor("bar")` as the concat point, matching what
`Bar.qml` already does for its own model. Nothing reads it yet.
