### PR TITLE
settings: draw the Aphotic mark on the bar widget logo row

### DIFF
--- a/Configs/quickshell/aphotic/components/SettingsRow.qml
+++ b/Configs/quickshell/aphotic/components/SettingsRow.qml
@@ -12,6 +12,11 @@ StyledRect {
     required property string label
     property string description: ""
 
+    // A row whose subject has a real mark of its own rather than a
+    // Material glyph fills this instead of `icon`, and gets the same
+    // rounded plate around it.
+    property Component iconItem: null
+
     // Connected-list positioning: a standalone row defaults to fully rounded
     // on every corner (first=last=true). Rows placed inside a
     // SettingsGroup get these stamped automatically so consecutive rows
@@ -60,11 +65,19 @@ StyledRect {
             radius: Tokens.rounding.medium
             color: Colours.layer(Colours.tPalette.m3surfaceContainer, 3)
 
-            MaterialIcon {
+            Loader {
                 anchors.centerIn: parent
-                text: root.icon
-                color: Colours.palette.m3onSurfaceVariant
-                fontStyle: Tokens.font.icon.medium
+                sourceComponent: root.iconItem ?? glyphComp
+            }
+
+            Component {
+                id: glyphComp
+
+                MaterialIcon {
+                    text: root.icon
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
+                }
             }
         }
 

--- a/Configs/quickshell/aphotic/modules/settings/panes/BarWidgetsSection.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/BarWidgetsSection.qml
@@ -25,7 +25,7 @@ ColumnLayout {
     // `pluginEntries` already concats onto its own model. Nothing here
     // reads it yet.
     readonly property var catalog: ({
-            logo: { icon: "linux", label: qsTr("OS logo"), jump: "" },
+            logo: { icon: "", label: qsTr("Aphotic logo"), jump: "" },
             workspaces: { icon: "workspaces", label: qsTr("Workspaces"), jump: "" },
             activeWindow: { icon: "window", label: qsTr("Active window"), jump: "" },
             media: { icon: "music_note", label: qsTr("Media"), jump: "" },
@@ -68,6 +68,15 @@ ColumnLayout {
 
     spacing: Tokens.spacing.small
 
+    Component {
+        id: markComp
+
+        AphoticMark {
+            implicitWidth: 22
+            implicitHeight: 22
+        }
+    }
+
     StyledText {
         text: qsTr("Widgets")
         color: Colours.palette.m3onSurfaceVariant
@@ -97,6 +106,9 @@ ColumnLayout {
                 readonly property var info: root.describe(widgetRow.modelData.id)
 
                 icon: widgetRow.info.icon
+                // The logo entry draws the same mark the bar draws
+                // (see modules/bar/components/OsIcon.qml), not a glyph.
+                iconItem: widgetRow.modelData.id === "logo" ? markComp : null
                 label: widgetRow.info.label
                 description: widgetRow.modelData.enabled ? "" : qsTr("Hidden")
                 opacity: widgetRow.modelData.enabled ? 1 : 0.6


### PR DESCRIPTION
## Problem

The Widgets list in the Bar pane gave its logo row `"linux"` as an icon.
That is not a Material Symbols glyph, so the font had nothing to map it to
and rendered the word itself. It came out oversized and spilled past the
36x36 icon plate.

Measuring the rendered glyphs confirms it was the only bad name in the
catalog: `linux` came back at a 4.17 width-to-height ratio against 0.83 for
every real glyph.

## Plan

The bar widget behind that row draws `AphoticMark`, not a distro logo. See
`modules/bar/components/OsIcon.qml`. So the row should draw the same mark.

`SettingsRow` only accepted a glyph name, so it grew an optional
`iconItem` component slot. When it is null, which is every other row in
every pane, the row loads the same `MaterialIcon` it always did.

The row label changes from "OS logo" to "Aphotic logo" to match what it
actually is.

## Resolution

All 13 widget rows now share one height and one width, so no row is inflated
by overflowing icon text. The mark renders 22x22 inside the 36x36 plate.

Checked the shared row family for regressions, since `SettingsRow` backs
every settings list: `SettingsRow`, `SettingsToggleRow` and
`SettingsPresetRow` all keep a 60px height, a 36x36 plate, a centered glyph,
and correct first/last corner stamping in a `SettingsGroup`.

Fix for the pane added in #143, which merged before this landed.
