### PR TITLE
bar: stop the workspace pill clipping its own glow square

### DIFF
--- a/Configs/quickshell/aphotic/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -6,7 +6,7 @@ import qs.components
 import qs.components.effects
 import qs.services
 
-StyledRect {
+Item {
     id: root
 
     required property int activeWsId
@@ -49,40 +49,56 @@ StyledRect {
         cWs = currentWsIdx;
     }
 
-    clip: true
     x: Settings.barHorizontal ? offset + mask.x : 0
     y: Settings.barHorizontal ? 0 : offset + mask.y
     implicitWidth: Settings.barHorizontal ? size : (Settings.barInnerWidth - Tokens.padding.small)
     implicitHeight: Settings.barHorizontal ? (Settings.barInnerWidth - Tokens.padding.small) : size
-    radius: Tokens.rounding.full
-    color: Colours.palette.m3primary
 
+    // The pill has to clip: `colouriser` below renders the WHOLE workspace
+    // row and slides it under this window so only the active cell's glyph
+    // shows through. Item.clip is a rectangular scissor that ignores
+    // `radius`, though, so this used to be one StyledRect with clip:true
+    // holding both the glow and the glyph -- which sliced the glow's soft
+    // falloff off at the pill's square bounding box and read as a hard
+    // edge against every other soft-rounded thing on the bar.
+    //
+    // So the glow sits outside the clip now, and the clip itself is a
+    // rounded one. This is also the z-order BioluminescentGlow documents:
+    // glow first, target painting over it to hide the solid core.
     BioluminescentGlow {
-        target: root
+        target: pill
     }
 
-    Colouriser {
-        id: colouriser
+    StyledClippingRect {
+        id: pill
 
-        source: root.mask
-        sourceColor: Colours.palette.m3onSurface
-        colorizationColor: Colours.palette.m3onPrimary
+        anchors.fill: parent
+        radius: Tokens.rounding.full
+        color: Colours.palette.m3primary
 
-        x: Settings.barHorizontal ? -parent.offset : 0
-        y: Settings.barHorizontal ? 0 : -parent.offset
-        implicitWidth: root.mask.implicitWidth
-        implicitHeight: root.mask.implicitHeight
+        Colouriser {
+            id: colouriser
 
-        anchors.horizontalCenter: parent.horizontalCenter
+            source: root.mask
+            sourceColor: Colours.palette.m3onSurface
+            colorizationColor: Colours.palette.m3onPrimary
 
-        states: State {
-            name: "vertical"
-            when: Settings.barHorizontal
+            x: Settings.barHorizontal ? -root.offset : 0
+            y: Settings.barHorizontal ? 0 : -root.offset
+            implicitWidth: root.mask.implicitWidth
+            implicitHeight: root.mask.implicitHeight
 
-            AnchorChanges {
-                target: colouriser
-                anchors.horizontalCenter: undefined
-                anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            states: State {
+                name: "vertical"
+                when: Settings.barHorizontal
+
+                AnchorChanges {
+                    target: colouriser
+                    anchors.horizontalCenter: undefined
+                    anchors.verticalCenter: parent.verticalCenter
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

The active workspace indicator looked hard-edged and square against a bar
where everything else is fully rounded.

The shape was never the problem. `ActiveIndicator` was a single `StyledRect`
carrying `clip: true`, `radius: Tokens.rounding.full`, and the
`BioluminescentGlow` as a child. `Item.clip` is a rectangular scissor and
takes no notice of `radius`, so it sliced the glow's soft falloff off at the
pill's square bounding box. What read as a hard corner was the glow ending
in a straight line.

`HoverPill` uses the same glow with no clip and has never shown this.

## Plan

The glyph does need clipping. `colouriser` renders the entire workspace row
and slides it under the pill so only the active cell shows through, so
without a clip the whole row would draw over its neighbours.

Split the two jobs. The root becomes a plain `Item`, the glow sits outside
any clip, and the fill moves into a `StyledClippingRect` that clips on its
rounded shape rather than a square scissor. That ordering is also what
`BioluminescentGlow`'s own comment asks for: the glow first, the target
painting over it to hide the solid core. As a child of the old `StyledRect`
it was painting on top instead.

## Resolution

Walked the ancestor chain from the indicator up to `Bar`: nothing clips any
more, so the glow bleeds freely.

Geometry is identical to main. Probed both revisions with the same script:
workspaces 28x41, indicator 37x33 at 4,0 on each. The pill fills the
indicator exactly, at full rounding. Only the clipping and the z-order moved.
