### PR TITLE
overlay: a free anchor, for a surface the user drags

### DIFF
--- a/Configs/quickshell/aphotic/modules/overlay/PluginOverlayWindow.qml
+++ b/Configs/quickshell/aphotic/modules/overlay/PluginOverlayWindow.qml
@@ -29,6 +29,17 @@ import qs.services
 // fills the window and masking to it makes the entire declared box a dead
 // zone. A pet 86px wide in a 240px surface would otherwise cost the
 // desktop the other 154.
+//
+// `anchor = "free"` is the one budget that is not a box on an edge: the
+// surface takes the whole usable output and the plugin places itself
+// anywhere in it. That is for a surface the user drags around, where any
+// fixed box would be the thing being dragged and moving a layer surface
+// per pointer event is what rule 1 exists to prevent. The window stays
+// static; the content moves inside it. The mask still decides what takes
+// input, so a free overlay costs the desktop no more clicks than a boxed
+// one, and it is worth declaring only when the placement is genuinely the
+// user's -- an always-present transparent surface the size of the screen
+// is not free to composite.
 PanelWindow {
     id: root
 
@@ -47,10 +58,16 @@ PanelWindow {
     WlrLayershell.exclusiveZone: 0
     color: "transparent"
 
-    anchors.top: root.surface.anchor === "top"
-    anchors.bottom: root.surface.anchor === "bottom" || root.surface.anchor === ""
-    anchors.left: root.surface.anchor === "left"
-    anchors.right: root.surface.anchor === "right"
+    // Anchored on all four sides, a layer surface fills the output and
+    // the declared width/height stop meaning anything, which is exactly
+    // what a free surface wants. Exclusive zones are still respected, so
+    // "the whole output" is the part of it the bar has not claimed.
+    readonly property bool free: root.surface.anchor === "free"
+
+    anchors.top: root.free || root.surface.anchor === "top"
+    anchors.bottom: root.free || root.surface.anchor === "bottom" || root.surface.anchor === ""
+    anchors.left: root.free || root.surface.anchor === "left"
+    anchors.right: root.free || root.surface.anchor === "right"
 
     implicitWidth: root.surface.width
     implicitHeight: root.surface.height

--- a/tests/test_plugin_overlay_surface.sh
+++ b/tests/test_plugin_overlay_surface.sh
@@ -86,6 +86,22 @@ g="$(_aphotic_plugin_ui_json "$TESTHOME/gated.toml" | jq -c '.surfaces[0]')"
 [[ "$(jq -r '.width' <<<"$g")" == "0" ]]  || fail "absent width should read as 0, got $g"
 [[ "$(jq -r '.height' <<<"$g")" == "0" ]] || fail "absent height should read as 0, got $g"
 
+# --- "free" is an anchor like any other to the CLI ---------------------
+# The host reads it as "take the whole output and let the plugin place
+# itself", but nothing here interprets anchors: a token this parser
+# rewrote or rejected would be a second opinion on a value only the host
+# resolves.
+cat > "$TESTHOME/free.toml" <<'TOML'
+[plugin]
+name = "x"
+[ui.overlay]
+id = "y"
+component = "qml/Y.qml"
+anchor = "free"
+TOML
+f="$(_aphotic_plugin_ui_json "$TESTHOME/free.toml" | jq -c '.surfaces[0]')"
+[[ "$(jq -r '.anchor' <<<"$f")" == "free" ]] || fail "free anchor not passed through: $f"
+
 # --- a component-less declaration contributes no surface ---------------
 printf '[plugin]\nname = "x"\n\n[ui.overlay]\nid = "y"\n' > "$TESTHOME/partial.toml"
 [[ "$(_aphotic_plugin_ui_json "$TESTHOME/partial.toml")" == "null" ]] \


### PR DESCRIPTION
## Problem

An `overlay` surface is a fixed-budget box anchored to a screen edge.
That is right for a spectrum strip along the bottom, and wrong for
anything the user is meant to move. A pet the user drags cannot live in a
240x160 box: the box would be the thing being dragged, and moving a layer
surface once per pointer event is exactly what the static-geometry rule
exists to stop.

## Plan

Add one anchor token rather than a sixth surface kind. `anchor = "free"`
anchors the window on all four sides, so it covers the usable output and
the plugin places its own content in it. Core keeps owning the window and
still never resizes it, so the guarantee that a plugin cannot renegotiate
a layer surface holds unchanged.

The CLI already passes `anchor` through as an opaque string, so nothing
there needed teaching. A test pins that: a token this parser rewrote or
rejected would be a second opinion on a value only the host resolves.

## Resolution

`PluginOverlayWindow` gained a `free` check on its four anchor bindings.
Exclusion zones still apply, so "the whole output" means the part of it
the bar has not claimed, and a free overlay cannot be dragged under the
bar.

The mask is untouched. A free overlay takes clicks only where its
`maskItem` says, so it costs the desktop no more than a boxed one. The
header and the authoring playbook both say to declare it only when the
placement really is the user's: a screen-sized transparent surface is not
free to composite, and an edge box stays cheaper for anything that sits
still.

Tested with `tests/test_plugin_overlay_surface.sh` and the rest of the
suite. The pet plugin PR is the first caller.