### PR TITLE
install: ship Qt's extra image decoders in both base profiles

### DIFF
--- a/profiles/base/full.toml
+++ b/profiles/base/full.toml
@@ -4,6 +4,13 @@ description = "Full install: today's complete package set"
 
 [packages]
 prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "libnotify", "procps-ng", "util-linux", "gawk"]
+# qt6-imageformats is what lets the shell decode WebP, TIFF, TGA and
+# JPEG 2000; Qt reads only PNG, JPEG, GIF and SVG without it. Desktop pet
+# sprite sheets are WebP wherever they come from, and an image Qt cannot
+# decode fails with "Unsupported image format" and nothing else, so the
+# surface using it just silently draws its fallback. In both profiles for
+# the same reason a shelled-out binary is: a feature that works on full
+# and quietly does nothing on minimal is worse than one that is absent.
 # tumbler and the three format helpers after `thunar` are Thunar's
 # thumbnailing stack, not extras: Thunar renders no thumbnails itself, it
 # asks the Tumbler D-Bus service, so without tumbler installed every file
@@ -12,4 +19,4 @@ prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcon
 # (they are pulled in by D-Bus activation and gdk-pixbuf), so don't prune
 # them as unused. ffmpegthumbnailer/poppler-glib cover video/PDF previews
 # and webp-pixbuf-loader covers .webp, which gdk-pixbuf can't read alone.
-main = ["kitty", "quickshell", "qt6-shadertools", "awww", "swaylock-effects", "hypridle", "zsh-theme-powerlevel10k-git", "zsh-autosuggestions", "oh-my-zsh-git", "zsh-syntax-highlighting", "xdg-desktop-portal-hyprland", "adw-gtk-theme", "openvpn", "papirus-folders", "bibata-cursor-theme", "swappy", "eza", "grim", "python-pyamdgpuinfo", "slurp", "thunar", "tumbler", "ffmpegthumbnailer", "poppler-glib", "webp-pixbuf-loader", "cava", "btop", "firefox", "mpv", "pamixer", "pavucontrol", "brightnessctl", "playerctl", "bluez", "bluez-utils", "blueman", "wallust-git", "matugen", "python-pywalfox", "python-pywayland", "network-manager-applet", "visual-studio-code-bin", "gvfs", "thunar-archive-plugin", "file-roller", "starship", "papirus-icon-theme", "ttf-jetbrains-mono-nerd", "ttf-material-symbols-variable", "inter-font", "noto-fonts-emoji", "lxappearance", "xfce4-settings", "nwg-look", "sddm", "greetd"]
+main = ["kitty", "quickshell", "qt6-shadertools", "qt6-imageformats", "awww", "swaylock-effects", "hypridle", "zsh-theme-powerlevel10k-git", "zsh-autosuggestions", "oh-my-zsh-git", "zsh-syntax-highlighting", "xdg-desktop-portal-hyprland", "adw-gtk-theme", "openvpn", "papirus-folders", "bibata-cursor-theme", "swappy", "eza", "grim", "python-pyamdgpuinfo", "slurp", "thunar", "tumbler", "ffmpegthumbnailer", "poppler-glib", "webp-pixbuf-loader", "cava", "btop", "firefox", "mpv", "pamixer", "pavucontrol", "brightnessctl", "playerctl", "bluez", "bluez-utils", "blueman", "wallust-git", "matugen", "python-pywalfox", "python-pywayland", "network-manager-applet", "visual-studio-code-bin", "gvfs", "thunar-archive-plugin", "file-roller", "starship", "papirus-icon-theme", "ttf-jetbrains-mono-nerd", "ttf-material-symbols-variable", "inter-font", "noto-fonts-emoji", "lxappearance", "xfce4-settings", "nwg-look", "sddm", "greetd"]

--- a/profiles/base/minimal.toml
+++ b/profiles/base/minimal.toml
@@ -4,4 +4,11 @@ description = "Bare Hyprland + Quickshell bar, no extras"
 
 [packages]
 prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "libnotify", "procps-ng", "util-linux", "gawk"]
-main = ["quickshell", "qt6-shadertools", "kitty", "awww", "xdg-desktop-portal-hyprland", "wallust-git", "matugen", "openvpn", "swappy", "grim", "slurp", "brightnessctl", "swaylock-effects", "hypridle", "cava"]
+# qt6-imageformats is what lets the shell decode WebP, TIFF, TGA and
+# JPEG 2000; Qt reads only PNG, JPEG, GIF and SVG without it. Desktop pet
+# sprite sheets are WebP wherever they come from, and an image Qt cannot
+# decode fails with "Unsupported image format" and nothing else, so the
+# surface using it just silently draws its fallback. In both profiles for
+# the same reason a shelled-out binary is: a feature that works on full
+# and quietly does nothing on minimal is worse than one that is absent.
+main = ["quickshell", "qt6-shadertools", "qt6-imageformats", "kitty", "awww", "xdg-desktop-portal-hyprland", "wallust-git", "matugen", "openvpn", "swappy", "grim", "slurp", "brightnessctl", "swaylock-effects", "hypridle", "cava"]

--- a/tests/test_profiles_real.py
+++ b/tests/test_profiles_real.py
@@ -35,6 +35,20 @@ def test_full_profile_ships_thunars_thumbnailer():
         assert pkg in result["main"], f"{pkg} missing -- Thunar previews will be broken"
 
 
+def test_both_profiles_ship_qt_image_decoders():
+    """Qt reads PNG, JPEG, GIF and SVG on its own and nothing else. A
+    format it cannot decode fails with "Unsupported image format" and no
+    other trace, so the surface asking for it silently draws its fallback
+    -- which is what a WebP desktop pet sprite sheet did before this
+    package was here. In both profiles for the same reason a shelled-out
+    binary is: a decoder present on full and absent on minimal makes the
+    same file work on one install and quietly do nothing on the other."""
+    for profile in ["full", "minimal"]:
+        result = merge_packages(str(ROOT / f"profiles/base/{profile}.toml"), [])
+        assert "qt6-imageformats" in result["main"], \
+            f"{profile} cannot decode WebP without qt6-imageformats"
+
+
 def test_minimal_profile_has_no_file_manager_or_thumbnailer():
     """minimal ships no thunar, so it has no reason to carry the
     thumbnailing stack either -- unlike a binary the Quickshell shell


### PR DESCRIPTION
## Problem

Qt decodes PNG, JPEG, GIF and SVG and nothing else without a plugin. An
image it cannot read fails with `Unsupported image format` and no other
trace, so whatever asked for it draws its fallback and says nothing. The
user gets a working shell and one feature that does nothing, with no
thread to pull.

The desktop pet found this. Every sprite-sheet generator worth using
exports WebP, so importing a pet meant converting the sheet first, and
nothing on screen or in the log said that was the problem.

## Plan

Add `qt6-imageformats` to both base profiles. It is a Qt plugin the shell
loads rather than a binary anything shells out to, but the rule that puts
those in both files applies for the same reason: a decoder on full and
not on minimal means the same pet folder works on one install and quietly
does nothing on the other.

## Resolution

One package in `packages.main` in `full.toml` and `minimal.toml`, next to
`qt6-shadertools`, with the reasoning in a comment above each list. It
covers WebP, TIFF, TGA, MNG, ICNS and JPEG 2000, and pulls in libwebp,
libtiff, libmng and jasper.

Arch's own description for the package lists TIFF, MNG, TGA and WBMP and
does not mention WebP, which is worth knowing before anyone reads it and
concludes this is the wrong package. It ships
`usr/lib/qt6/plugins/imageformats/libqwebp.so`; I checked the file list
rather than the summary.

`tests/test_profiles_real.py` gains a case asserting it in both, guarding
it against being pruned as unused the way the Thunar thumbnail stack
already is. Suite green, 61 passed, and the shell tests pass.

Paired with a plugin-side README change (aphotic-plugins #19) that stops
leading with the conversion workaround and keeps it only for installs
older than this.