### PR TITLE
wallpaper picker: preview the wallpaper the strip is centred on

### DIFF
--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperBackdrop.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperBackdrop.qml
@@ -19,12 +19,25 @@ Item {
     readonly property string bandSource: root.active ? root.source : ""
     readonly property real fadeStop: root.bandHeight > 0 ? root.fadeExtent / root.bandHeight : 0
 
-    onBandSourceChanged: {
-        if (bleed.current === one)
-            two.path = root.bandSource;
-        else
-            one.path = root.bandSource;
+    // The band cross-fades by loading into whichever of the two images is
+    // not on screen and swapping to it once it is ready. Scrolling back to a
+    // wallpaper the spare still holds assigns it the path it already has,
+    // which raises no status change to swap on, so that case swaps directly.
+    // Without it the band kept showing the previous wallpaper whenever the
+    // strip moved back and forth between two.
+    function _show(path: string): void {
+        if (path.length === 0 || bleed.current.path === path)
+            return;
+        const spare = bleed.current === one ? two : one;
+        if (spare.path === path) {
+            if (spare.status === Image.Ready)
+                bleed.current = spare;
+            return;
+        }
+        spare.path = path;
     }
+
+    onBandSourceChanged: root._show(root.bandSource)
 
     Item {
         id: band
@@ -45,7 +58,7 @@ Item {
         Item {
             id: bleed
 
-            property Image current: one
+            property Img current: one
 
             width: root.width
             height: root.height
@@ -132,7 +145,7 @@ Item {
         opacity: bleed.current === img ? 1 : 0
 
         onStatusChanged: {
-            if (img.status === Image.Ready)
+            if (img.status === Image.Ready && img.path === root.bandSource)
                 bleed.current = img;
         }
 

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperCard.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperCard.qml
@@ -26,14 +26,12 @@ Item {
     readonly property int chamfer: Math.max(10, Math.round(root.height * 0.14))
     readonly property int corner: Math.max(4, Math.round(root.height * 0.04))
 
+    property bool hovered: false
+
     property real _punch: 0
-    property bool _hovered: false
     property real _lift: root.active ? -root.height * 0.07 : 0
 
-    signal activated
-    signal requested
-
-    scale: (root._hovered && !root.active ? 1.05 : 1) * (1 + 0.06 * root._punch)
+    scale: (root.hovered && !root.active ? 1.05 : 1) * (1 + 0.06 * root._punch)
 
     onLockedChanged: {
         if (root.locked)
@@ -164,15 +162,6 @@ Item {
         opacity: 0.25 + 0.35 * root.closeness
         chamfer: root.chamfer
         corner: root.corner
-    }
-
-    MouseArea {
-        anchors.fill: parent
-        hoverEnabled: true
-        cursorShape: Qt.PointingHandCursor
-        onEntered: root._hovered = true
-        onExited: root._hovered = false
-        onClicked: root.active ? root.activated() : root.requested()
     }
 
     component BevelPath: Shape {

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
@@ -16,8 +16,12 @@ Item {
     readonly property int slotPitch: cellWidth + cellSpacing
     readonly property real centerScale: 1.35
     readonly property int visibleSlots: 5
-    readonly property int stripWidth: Math.min(slotPitch * visibleSlots, Math.max(cellWidth, Math.round(root.width * 0.86)))
-    readonly property real centerOffset: (stripWidth - cellWidth) / 2
+    // Wide enough for every slot it draws, even when that overruns the
+    // screen. The strip does not clip, so the outermost cards were already
+    // painted out there; capping the width only stopped them receiving
+    // clicks, and a click on one fell through to the dismiss handler behind.
+    readonly property int stripWidth: slotPitch * visibleSlots
+    readonly property real centerOffset: (stripWidth - slotPitch) / 2
 
     readonly property int heroHeight: Math.round(cellHeight * centerScale)
     readonly property int stripHeight: heroHeight + Math.round(cellHeight * 0.5)
@@ -122,16 +126,24 @@ Item {
         return Math.max(-root.maxFlickVelocity, Math.min(root.maxFlickVelocity, v));
     }
 
+    // Both conversions go through originX. A ListView shifts its content
+    // origin once the model is long enough, and a delegate then sits at
+    // originX + index * slotPitch. Reading it as index * slotPitch put every
+    // index-to-position conversion out by however many slots originX had
+    // grown to, so a click resolved to a delegate tens of slots away from the
+    // one under the pointer. The short unrepeated model never moved originX
+    // off zero, which is why this only appeared once the strip started
+    // wrapping.
     function _indexAtCenter(): int {
         if (strip.count === 0)
             return -1;
-        const slot = Math.round((strip.contentX + root.centerOffset) / root.slotPitch);
+        const slot = Math.round((strip.contentX - strip.originX + root.centerOffset) / root.slotPitch);
         return Math.max(0, Math.min(slot, strip.count - 1));
     }
 
     function _targetContentX(index: int): real {
         const clamped = Math.max(0, Math.min(index, strip.count - 1));
-        return clamped * root.slotPitch - root.centerOffset;
+        return strip.originX + clamped * root.slotPitch - root.centerOffset;
     }
 
     // Anchor into the middle copy rather than wherever the view happens to
@@ -276,7 +288,7 @@ Item {
             width: root.stripWidth
             height: root.stripHeight
             orientation: ListView.Horizontal
-            spacing: root.cellSpacing
+            spacing: 0
             leftMargin: root.centerOffset
             rightMargin: root.centerOffset
             cacheBuffer: root.slotPitch * 2
@@ -309,8 +321,16 @@ Item {
             }
 
             onMovementStarted: root.settledIndex = -1
+            // _goToIndex cancels the flick before it starts the glide, so
+            // this runs with glideAnim.running still false and used to settle
+            // anyway. That left the settle spring and the glide both driving
+            // contentX: the spring won the landing while the glide had already
+            // committed the preview to the slot it aimed at, so the picker
+            // previewed one wallpaper and highlighted its neighbour.
+            // _pendingIndex is set before the cancel, so it is the signal that
+            // a glide owns the strip.
             onMovementEnded: {
-                if (glideAnim.running)
+                if (glideAnim.running || root._pendingIndex >= 0)
                     return;
                 root._settle();
             }
@@ -356,48 +376,71 @@ Item {
                 onWheel: event => root._wheelImpulse(event.angleDelta.y < 0 ? 1 : -1)
             }
 
+            // The delegate is exactly one slot wide and carries no transform
+            // of its own, so the hit areas tile the strip with no gaps and no
+            // overlap however far the artwork inside is scaled up. Clicking
+            // anywhere in a slot's column picks that wallpaper. Scaling the
+            // delegate itself made the enlarged centre card cover its
+            // neighbours, and the outermost cards fell outside every hit area
+            // and dismissed the picker instead of selecting anything.
             delegate: Item {
                 id: delegate
 
                 required property int index
 
+                property bool hovered: false
+
                 readonly property real itemCenterX: x + width / 2
                 readonly property real viewCenterX: strip.contentX + strip.width / 2
                 readonly property real distance: (itemCenterX - viewCenterX) / root.slotPitch
 
-                width: root.cellWidth
+                width: root.slotPitch
                 height: strip.height
-                scale: Math.max(0.42, root.centerScale - Math.abs(distance) * 0.34)
-                opacity: Math.max(0, 1 - Math.abs(distance) * 0.38)
 
-                transform: Rotation {
-                    origin.x: delegate.width / 2
-                    origin.y: delegate.height / 2
-                    axis {
-                        x: 0
-                        y: 1
-                        z: 0
+                Item {
+                    id: art
+
+                    anchors.fill: parent
+
+                    scale: Math.max(0.42, root.centerScale - Math.abs(delegate.distance) * 0.34)
+                    opacity: Math.max(0, 1 - Math.abs(delegate.distance) * 0.38)
+
+                    transform: Rotation {
+                        origin.x: art.width / 2
+                        origin.y: art.height / 2
+                        axis {
+                            x: 0
+                            y: 1
+                            z: 0
+                        }
+                        angle: Math.max(-32, Math.min(32, delegate.distance * -26))
                     }
-                    angle: Math.max(-32, Math.min(32, delegate.distance * -26))
+
+                    WallpaperCard {
+                        anchors.centerIn: parent
+
+                        width: root.cellWidth
+                        height: root.cellHeight
+
+                        source: root._pathFor(delegate.index)
+                        decodeWidth: root.cellWidth
+                        decodeHeight: root.cellHeight
+                        matteWidth: root.matteWidth
+                        matteHeight: root.matteHeight
+                        distance: delegate.distance
+                        hovered: delegate.hovered
+                        active: delegate.index === strip.currentIndex
+                        locked: delegate.index === root.settledIndex
+                    }
                 }
 
-                WallpaperCard {
-                    anchors.centerIn: parent
-
-                    width: root.cellWidth
-                    height: root.cellHeight
-
-                    source: root._pathFor(delegate.index)
-                    decodeWidth: root.cellWidth
-                    decodeHeight: root.cellHeight
-                    matteWidth: root.matteWidth
-                    matteHeight: root.matteHeight
-                    distance: delegate.distance
-                    active: delegate.index === strip.currentIndex
-                    locked: delegate.index === root.settledIndex
-
-                    onActivated: root._commit()
-                    onRequested: root._goToIndex(delegate.index)
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: delegate.hovered = true
+                    onExited: delegate.hovered = false
+                    onClicked: delegate.index === strip.currentIndex ? root._commit() : root._goToIndex(delegate.index)
                 }
             }
         }


### PR DESCRIPTION
## Problem

Scrolling the picker left the live preview on the desktop showing one
wallpaper while the centred card highlighted a different one. It missed
often enough to look random.

Two causes, and one fix that never reached main.

`_goToIndex` calls `cancelFlick()` before it starts the glide. That fires
`movementEnded`, whose guard read `if (glideAnim.running) return` and
missed, because the glide had not started. `_settle()` ran, and its spring
and the glide then both drove `contentX`. The spring won the landing
position while `glideAnim.onFinished` had committed `_previewIndex` and
`settledIndex` to the slot the glide aimed at. An arrow key or a card
click during a coasting flick hits it, and at the current deceleration a
hard flick coasts about 4.8s, so the window is wide.

`WallpaperBackdrop` cross-fades by loading into whichever of its two
images sits off screen and swapping when that one reports Ready. Scroll
back to a wallpaper the spare still holds and it gets assigned the path it
holds already. Qt raises no status change on that, so the swap never ran
and the band kept the old image. Moving back and forth between two
wallpapers hit it every time.

PR #136 merged at `c848394`. Its title says "fix click targeting", but the
commit that did it landed on the branch after the merge, so main never got
it. Without it both index-to-position conversions ignore `originX`, which
a ListView shifts once the model grows.

## Plan

Guard the settle with `_pendingIndex`. `_goToIndex` sets it before it
cancels the flick, so it says a glide owns the strip when
`glideAnim.running` cannot yet.

Give the backdrop a `_show()` that swaps to the spare when the spare holds
the target, and guard the Ready handler so a stale load cannot take the
band.

Cherry-pick the lost commit rather than rewrite it.

## Resolution

Verified with a headless filmstrip driven through the real paths: flick,
wheel, arrow, card click, and each interrupted mid-flight. The centred
delegate's own `distance` gives ground truth for which card the user sees,
and the probe captures what `_applyPreview` would set.

```
before   highlighted slot 230 = ...image31.png   preview = ...dock.png   MISMATCH
after    highlighted slot 229 = ...dock.png      preview = ...dock.png   CONSISTENT
```

The backdrop swap has its own before and after on an A to B to A walk:
before, step 3 wanted `lofi-girl` and the band still showed `lofi-cafe`.

Bash suite green, 60 pytest pass, singleton reachability clean. The
filmstrip and card instantiate with no warnings and no binding loops on a
462-slot strip.

`originX` measured 0 across programmatic and real scrolling, so the
cherry-picked hunk fixes click targeting rather than this preview bug. It
rides along because it belongs on main.

Wants a visual pass: the centred card, its glow, the band, and the desktop
behind should all name the same wallpaper.
