### PR TITLE
agent-events: wire UserPromptSubmit and PreCompact/PostCompact

### DIFF
--- a/Configs/.local/lib/aphotic/agent_hook.py
+++ b/Configs/.local/lib/aphotic/agent_hook.py
@@ -17,18 +17,24 @@ MAX_RUN_BYTES = 2 * 1024 * 1024
 
 EVENT_NAMES = {
     "SessionStart": "session_start",
+    "UserPromptSubmit": "user_prompt_submit",
     "PreToolUse": "pre_tool_use",
     "PostToolUse": "post_tool_use",
     "PostToolUseFailure": "post_tool_use_failure",
     "Notification": "notification",
+    "PreCompact": "pre_compact",
+    "PostCompact": "post_compact",
     "Stop": "stop",
     "SubagentStop": "subagent_stop",
     "SessionEnd": "session_end",
 }
 STATUS = {
+    "user_prompt_submit": "running",
     "pre_tool_use": "running",
     "post_tool_use": "completed",
     "post_tool_use_failure": "errored",
+    "pre_compact": "compacting",
+    "post_compact": "running",
 }
 
 

--- a/Configs/quickshell/aphotic/services/ai/AgentEvents.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentEvents.qml
@@ -131,7 +131,9 @@ Singleton {
             session.endedAt = 0;
             if (event.event === "notification")
                 session.status = "waiting";
-            else if (event.event === "pre_tool_use" || event.event === "post_tool_use" || event.event === "post_tool_use_failure")
+            else if (event.event === "pre_compact")
+                session.status = "compacting";
+            else if (event.event === "pre_tool_use" || event.event === "post_tool_use" || event.event === "post_tool_use_failure" || event.event === "user_prompt_submit" || event.event === "post_compact")
                 session.status = "running";
             else
                 session.status = "idle";


### PR DESCRIPTION
## Problem
Two real gaps in the harness event schema, found while scoping the pet's state machine (`PET-03`/`PET-14`): a turn with no tool call produces no event at all between one `Stop` and the next, and there is no compaction event anywhere in the pipeline, on any harness.

## Plan
Additive schema change, same shape as every other event already wired: `agent_hook.py` gains two more `EVENT_NAMES`/`STATUS` entries, `AgentEvents.applyTo()` picks up the two new event names. Actually wiring the Claude Code hook entries is a separate PR (`aphotic-plugins` #23, `claude-hooks`), since that plugin owns `~/.claude/settings.json` now, not this repo's installer.

Codex and OpenCode are untouched on purpose: Codex's own hook contract already says `PreCompact`/`PostCompact`/`UserPromptSubmit` don't map to anything there, and OpenCode's plugin API exposes no compaction concept at all.

## Resolution
`agent_hook.py`: `UserPromptSubmit` → `user_prompt_submit` (status `running`, same as a tool call), `PreCompact`/`PostCompact` → `pre_compact`/`post_compact` (status `compacting`/`running`). `AgentEvents.qml`'s `applyTo()` maps `pre_compact` to session status `compacting` and folds `user_prompt_submit`/`post_compact` into the existing `running` branch.

Verified: `tests/test_agent_hook.py` (30 passed) and `tests/test_agent_hook.sh` unchanged and green, `tests/test_singleton_reachability.py` clean, plus a headless probe exercising `AgentEvents.applyTo()` directly against synthetic `user_prompt_submit`/`pre_compact`/`post_compact` events. Not verified: an actual Claude Code session firing these hooks live, since this needs `claude-hooks` (#23 above) merged and installed first, and the wiring should get a DevVM pass before either of these merges, same as any other install/hook-surface change.

Built in an isolated `git worktree`, not this checkout: this machine's own live Claude Code hooks point straight at `agent_hook.sh` inside this repo's working tree, so editing it in place would have changed this very session's hook behavior mid-flight.