### PR TITLE
pet_action surface + session-to-window focus

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -210,6 +210,24 @@ _aphotic_plugin_ui_json() {
     if entry="$(_aphotic_plugin_surface_json "$manifest" ui.notch_tile notch)"; then
         entries+=("$entry")
     fi
+    # Three slots, not a loop over however many a manifest declares: the
+    # shared TOML reader (`aphotic_toml_get`, globalcontrol.sh) is
+    # deliberately flat, single-section-match, no arrays-of-tables --
+    # shared with theme.toml, not worth risking for this. Every other
+    # surface kind only ever needs one entry per plugin; `pet_action` is
+    # the first that doesn't (the pet's own MVP list is terminal + VS
+    # Code, PETS.md §7.1), so it gets bounded room to grow instead of a
+    # real parser change. Raise the cap (and PLUGIN_SYSTEM.md's note on
+    # it) the day a plugin actually needs a fourth.
+    if entry="$(_aphotic_plugin_surface_json "$manifest" ui.pet_action pet_action)"; then
+        entries+=("$entry")
+    fi
+    if entry="$(_aphotic_plugin_surface_json "$manifest" ui.pet_action_2 pet_action)"; then
+        entries+=("$entry")
+    fi
+    if entry="$(_aphotic_plugin_surface_json "$manifest" ui.pet_action_3 pet_action)"; then
+        entries+=("$entry")
+    fi
     if entry="$(_aphotic_plugin_surface_json "$manifest" ui.settings_pane settings)"; then
         entries+=("$entry")
     fi

--- a/Configs/quickshell/aphotic/services/ai/AgentWindowFocus.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentWindowFocus.qml
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+
+// There is no session-to-window link anywhere in this codebase -- a
+// harness event carries a `cwd` (agent_hook.py forwards Claude Code's own
+// hook payload field) and nothing else that names a surface a human is
+// looking at. This answers one narrow question with what that leaves us:
+// "is exactly one open window's foreground process sitting in this
+// directory?" Built for the pet's `attentionRequired` click-to-focus
+// (`PETS.md` PET-03's deferred item), but it names no plugin and reads
+// no pet state, so anything else wanting "jump to the window behind this
+// session" -- the AI notch tab's planned context-injection rework, for
+// one -- calls the same `focusByCwd()`.
+//
+// A Hyprland client's own pid is the terminal emulator (or editor), never
+// the shell/harness running inside it -- so the match walks each
+// candidate's descendants looking for one whose cwd is the target
+// exactly. `pgrep -P` one level at a time, breadth-first, the same
+// child-walk `aphotic_shell_stop` (globalcontrol.sh) already uses rather
+// than reading /proc/<pid>/task/<pid>/children directly.
+//
+// Ambiguity fails silent, not loud: resolves to nothing rather than a
+// guess. Verified against a live desktop with `hyprctl clients -j` and a
+// hand-run copy of the script below: two kitty windows parked in this
+// repo were both real, correct matches, but a long-lived, unrelated GUI
+// process launched from a shell that happened to be sitting in the same
+// directory matched too, purely because it inherited that cwd at launch
+// and never left it. That is not a bug to chase -- cwd is genuinely all
+// a session's event carries, and a stray match here is exactly the
+// ambiguity case, which already resolves to doing nothing. There is no
+// UI here for "which one did you mean" and building one is a real
+// feature, not a fallback path worth improvising into this.
+Singleton {
+    id: root
+
+    property Process _match: Process {
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const addresses = text.split("\n").map(l => l.trim()).filter(l => l.length > 0);
+                if (addresses.length === 1)
+                    WindowList.focus(addresses[0]);
+            }
+        }
+    }
+
+    // Walks the process tree under each Hyprland client's pid looking for
+    // a descendant whose cwd resolves to exactly `cwd`. Reads Hyprland
+    // state that is already live (`Hypr.toplevels`) rather than shelling
+    // out to `hyprctl clients` a second time for data this shell already
+    // has.
+    // One JS string, deliberately kept to a single line: QML's plain
+    // `"..."` string can't hold a raw newline (that needs a backtick
+    // template literal, and this script is full of bash's own `${...}`/
+    // `$(...)`, which a template literal would try to evaluate as JS).
+    // Semicolons stand in for the newlines a normal script would have.
+    readonly property string _script: "target=\"$1\"; shift; while [ \"$#\" -ge 2 ]; do addr=\"$1\"; pid=\"$2\"; shift 2; queue=(\"$pid\"); matched=0; while [ \"${#queue[@]}\" -gt 0 ]; do p=\"${queue[0]}\"; queue=(\"${queue[@]:1}\"); if [ \"$(readlink -f \"/proc/$p/cwd\" 2>/dev/null)\" = \"$target\" ]; then matched=1; break; fi; while IFS= read -r child; do [ -n \"$child\" ] && queue+=(\"$child\"); done < <(pgrep -P \"$p\" 2>/dev/null); done; [ \"$matched\" = \"1\" ] && printf '%s\\n' \"$addr\"; done"
+
+    // No-op while a match is already in flight -- a second click before
+    // the first resolves would otherwise queue a second Process onto the
+    // same object mid-run.
+    function focusByCwd(cwd: string): void {
+        if (!cwd || root._match.running)
+            return;
+        const pairs = Hypr.toplevels.values.map(t => [t.address, t.lastIpcObject?.pid ?? 0]).filter(([, pid]) => pid > 0);
+        if (pairs.length === 0)
+            return;
+        const args = ["bash", "-c", root._script, "bash", cwd];
+        for (const [address, pid] of pairs)
+            args.push(address, String(pid));
+        root._match.command = args;
+        root._match.running = true;
+    }
+}

--- a/Configs/quickshell/aphotic/services/ai/qmldir
+++ b/Configs/quickshell/aphotic/services/ai/qmldir
@@ -1,5 +1,6 @@
 module qs.services.ai
 singleton AgentEvents 1.0 AgentEvents.qml
+singleton AgentWindowFocus 1.0 AgentWindowFocus.qml
 singleton AgentRoles 1.0 AgentRoles.qml
 singleton AiConfig 1.0 AiConfig.qml
 singleton AiKeys 1.0 AiKeys.qml

--- a/tests/test_singleton_reachability.py
+++ b/tests/test_singleton_reachability.py
@@ -24,7 +24,18 @@ QML_ROOT = Path(__file__).resolve().parent.parent / "Configs" / "quickshell" / "
 # aphotic-plugins repo, say) belongs here with the reason. Empty on
 # purpose: nothing qualifies today, and an entry is a claim someone has
 # to justify.
-ALLOWED_UNREFERENCED: dict[str, str] = {}
+ALLOWED_UNREFERENCED: dict[str, str] = {
+    "AgentWindowFocus": (
+        "Consumed only by the pet plugin's Pet.qml (aphotic-plugins), "
+        "not by any file in this repo -- core exposes the service, the "
+        "plugin calls it, same direction AgentEvents already serves "
+        "plugins in. It has no timers/Connections/Component.onCompleted "
+        "of its own to fail to run either way: focusByCwd() only does "
+        "anything when a caller invokes it, so being unreferenced here "
+        "does not risk the silent-no-op failure this test exists to "
+        "catch."
+    ),
+}
 
 
 def _code(path: Path) -> str:


### PR DESCRIPTION
## Problem

Two gaps in the pet's click behavior, both without a mechanism to fix
them:

- Every plugin-registered surface kind (dashboard tab, notch tile,
  settings pane, overlay) has a `[ui.*]` block and a line in
  `cmd_plugin.sh`. The pet's own action menu (terminal, VS Code, and
  eventually domain siblings like Gaming's library) had no equivalent.
- The pet's `ATTENTION_REQUIRED` badge shows when a harness session is
  waiting on the user, but clicking it did nothing beyond the ordinary
  poke reaction. There's no way in this codebase to go from a session
  to the window it's running in.

## Plan

Add `pet_action` as a surface kind, following the existing generic
registry pattern exactly (`PluginRegistry.surfacesFor()` already loops
over surface kinds without branching on which one it's reading, so this
needed nothing there).

One wrinkle: the pet's own MVP list is two actions (terminal, VS Code)
from one plugin, and every other surface kind only ever needed one
entry per plugin. The shared TOML reader (`aphotic_toml_get`) is
deliberately flat with no arrays-of-tables, shared with `theme.toml`,
so this uses a small closed set of numbered sections instead
(`ui.pet_action`, `_2`, `_3`) rather than teaching the reader real
array syntax.

For the focus behavior: a harness event only ever carries a `cwd`, never
a window handle. `AgentWindowFocus` turns that into a window by walking
the process tree under every Hyprland client's own pid looking for a
descendant whose cwd matches, and focuses it only when exactly one
candidate matches. Ambiguous or no match does nothing rather than
guessing.

## Resolution

- `cmd_plugin.sh`: `pet_action` added to `_aphotic_plugin_ui_json`,
  three numbered slots.
- New singleton `services/ai/AgentWindowFocus.qml`: `focusByCwd(cwd)`.
  Named and scoped so anything else wanting the same "jump to the
  window behind this session" behavior can call it too, not just the
  pet.
- Verified with the headless probe: compiled and instantiated, ran the
  bash correlation script by hand against this machine's real
  `hyprctl clients -j` output.
- Companion plugin PR: T-Crypt/aphotic-plugins#24, adds the pet's own
  two actions and wires the click behavior.