### PR TITLE
Agent notch tile: quota bars, subagents, and a way into a waiting session

### DIFF
--- a/Configs/.local/lib/aphotic/agent_statusline.py
+++ b/Configs/.local/lib/aphotic/agent_statusline.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+# SPDX-FileCopyrightText: Aphotic-Hypr contributors
+"""aphotic agent statusline worker -- see agent_statusline.sh for why
+this is one process and why nothing in here is allowed to raise.
+
+Claude Code hands its statusLine command a JSON payload on stdin and
+prints whatever the command writes to stdout. That payload is the only
+place a harness states its own remaining quota: `rate_limits` carries the
+five-hour and seven-day windows as a used percentage plus the epoch the
+window resets at, and the context block carries how full the session's
+own context window is. Nothing else on this machine knows those numbers
+-- transcripts record tokens spent, never the share of an allowance --
+so this dumps them for the shell to read and prints a line back.
+
+Aggregate counters only. No prompt text, no tool arguments, no
+credentials, and no network.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+SCHEMA_VERSION = 1
+STATE = os.environ.get("APHOTIC_STATE_HOME", os.path.expanduser("~/.local/state/aphotic"))
+QUOTA = os.path.join(STATE, "agent-quota.json")
+
+
+def atomic_write(path: str, text: str) -> None:
+    """Write `text` to `path` via a same-directory temp file and rename."""
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    os.replace(tmp, path)
+
+
+def window(block: object) -> dict | None:
+    """Normalise one rate-limit window, or None when it says nothing.
+
+    `used_percentage` arrives 0-100 and is clamped, because a value the
+    shell renders as a bar has to be in range even if the payload is not.
+    `resets_at` is epoch seconds; 0 means the payload omitted it.
+    """
+    if not isinstance(block, dict):
+        return None
+    used = block.get("used_percentage")
+    if used is None:
+        return None
+    try:
+        percent = max(0.0, min(100.0, float(used)))
+    except (TypeError, ValueError):
+        return None
+    try:
+        resets = int(block.get("resets_at") or 0)
+    except (TypeError, ValueError):
+        resets = 0
+    return {"usedPercent": percent, "resetsAt": max(0, resets)}
+
+
+def context_window(payload: dict) -> dict | None:
+    """The session's own context fill, which is a quota like any other."""
+    block = payload.get("context_window")
+    if not isinstance(block, dict):
+        return None
+    used = block.get("used_percentage")
+    if used is None:
+        return None
+    try:
+        percent = max(0.0, min(100.0, float(used)))
+    except (TypeError, ValueError):
+        return None
+    record = {"usedPercent": percent, "resetsAt": 0}
+    size = block.get("context_window_size")
+    if isinstance(size, (int, float)) and size > 0:
+        record["size"] = int(size)
+    return record
+
+
+def build_record(payload: dict, now: float) -> dict:
+    """Build the quota record for one statusline invocation."""
+    limits = payload.get("rate_limits")
+    limits = limits if isinstance(limits, dict) else {}
+    windows = {}
+    for key, field in (("five_hour", "fiveHour"), ("seven_day", "sevenDay"), ("spend_limit", "spendLimit")):
+        parsed = window(limits.get(key))
+        if parsed:
+            windows[field] = parsed
+    parsed = context_window(payload)
+    if parsed:
+        windows["context"] = parsed
+
+    model = payload.get("model")
+    model = model if isinstance(model, dict) else {}
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "capturedAt": int(now),
+        "providers": {
+            "claude": {
+                "model": model.get("display_name") or model.get("id") or "",
+                "windows": windows,
+            }
+        },
+    }
+
+
+def merge(existing: object, record: dict) -> dict:
+    """Keep other providers' entries when writing this one.
+
+    The file is per-provider, and a second harness writing its own
+    section must not erase Claude's, or two live sessions would take
+    turns blanking each other's bars.
+    """
+    if not isinstance(existing, dict) or existing.get("schemaVersion") != SCHEMA_VERSION:
+        return record
+    providers = existing.get("providers")
+    if not isinstance(providers, dict):
+        return record
+    merged = dict(providers)
+    merged.update(record["providers"])
+    out = dict(record)
+    out["providers"] = merged
+    return out
+
+
+def format_line(record: dict) -> str:
+    """The line Claude Code prints in place of its default status line.
+
+    Aphotic claims this slot, so the line has to earn it: the model, then
+    whichever windows the payload actually reported. A window the harness
+    said nothing about is left out rather than shown as zero.
+    """
+    provider = record["providers"]["claude"]
+    parts = []
+    if provider["model"]:
+        parts.append(provider["model"])
+    windows = provider["windows"]
+    for field, label in (("fiveHour", "5h"), ("sevenDay", "7d"), ("context", "ctx")):
+        block = windows.get(field)
+        if block:
+            parts.append("%s %d%%" % (label, round(block["usedPercent"])))
+    return " · ".join(parts)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    record = build_record(payload, time.time())
+
+    try:
+        os.makedirs(STATE, exist_ok=True)
+        existing = None
+        try:
+            with open(QUOTA, "r", encoding="utf-8") as fh:
+                existing = json.load(fh)
+        except (OSError, ValueError):
+            pass
+        atomic_write(QUOTA, json.dumps(merge(existing, record), separators=(",", ":")))
+    except OSError:
+        pass
+
+    line = format_line(record)
+    if line:
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Configs/.local/lib/aphotic/agent_statusline.sh
+++ b/Configs/.local/lib/aphotic/agent_statusline.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# aphotic agent_statusline -- Claude Code's statusLine command, and the
+# only source on this machine for how much of a quota window a harness
+# has spent. Invoked once per turn with the session JSON on stdin; what
+# it prints becomes the status line the user sees, so it has to be both
+# fast and quiet about failure. Same shape as agent_hook.sh: exec into a
+# single python3 worker rather than spawning per field, and never exit
+# non-zero, because a failing statusLine command is a visible error in
+# the user's own terminal.
+set -u
+
+hook_dir="${BASH_SOURCE[0]%/*}"
+[[ "$hook_dir" == "${BASH_SOURCE[0]}" ]] && hook_dir="."
+
+exec python3 "$hook_dir/agent_statusline.py" || exit 0

--- a/Configs/quickshell/aphotic/services/AgentProviders.qml
+++ b/Configs/quickshell/aphotic/services/AgentProviders.qml
@@ -110,6 +110,23 @@ Singleton {
         Quickshell.execDetached(["kitty", "-e", ...provider.launchCmd]);
     }
 
+    // The same record `stats` is built from, kept ungated. `stats` only
+    // ever covers a harness whose hook plugin the user enabled, but the
+    // token counts are read out of transcripts on disk and are just as
+    // true for a harness that never fired a hook -- so a surface that
+    // wants "how much has this provider used today" asks here instead of
+    // indexing `stats` and getting a zero for the wrong reason.
+    property var _usageById: ({})
+
+    function usageOf(providerId: string): var {
+        const usage = root._usageById[providerId];
+        return {
+            availability: usage?.availability ?? "unavailable",
+            todayTokens: usage?.todayTokens ?? 0,
+            tokensByModel: usage?.tokensByModel ?? []
+        };
+    }
+
     function _findIndex(providerId: string): int {
         return root.providers.findIndex(p => p.id === providerId);
     }
@@ -209,6 +226,7 @@ Singleton {
                 const data = JSON.parse(text());
                 if (data.schemaVersion !== 1)
                     return;
+                root._usageById = data.providers ?? ({});
                 for (const p of root.providers) {
                     const usage = data.providers?.[p.id];
                     if (!usage)

--- a/Configs/quickshell/aphotic/services/AgentProviders.qml
+++ b/Configs/quickshell/aphotic/services/AgentProviders.qml
@@ -127,6 +127,25 @@ Singleton {
         };
     }
 
+    // Quota windows for one provider: `{ fiveHour, sevenDay, spendLimit,
+    // context }`, each `{ usedPercent, resetsAt }`, and any of them
+    // absent when the harness did not report it. Empty until a session
+    // runs -- the numbers only exist while one is live to state them.
+    property var _quotaById: ({})
+    property int _quotaCapturedAt: 0
+
+    readonly property int quotaCapturedAt: root._quotaCapturedAt
+
+    // Past this, the record describes a window that has probably rolled
+    // over since. Claude Code rewrites its status line continuously
+    // during a session and not at all between them, so age is the only
+    // signal that the numbers went stale.
+    readonly property int quotaMaxAgeSeconds: 1200
+
+    function quotaOf(providerId: string): var {
+        return root._quotaById[providerId]?.windows ?? ({});
+    }
+
     function _findIndex(providerId: string): int {
         return root.providers.findIndex(p => p.id === providerId);
     }
@@ -213,6 +232,32 @@ Singleton {
                 codexPgrep.exec(["pgrep", "-x", "-c", "codex"]);
             if (root._findIndex("opencode") !== -1)
                 opencodePgrep.exec(["pgrep", "-x", "-c", "opencode"]);
+        }
+    }
+
+    // Quota windows, written by the harness's own statusLine command
+    // (agent_statusline.py) rather than by the 15-minute usage timer.
+    // Different file because it is a different cadence and a different
+    // truth: the usage record counts tokens off transcripts, this one
+    // carries the share of an allowance the harness itself reports, and
+    // only while a session is live to report it.
+    FileView {
+        id: quotaFile
+        path: `${Quickshell.env("HOME")}/.local/state/aphotic/agent-quota.json`
+        watchChanges: true
+        onFileChanged: reload()
+        onLoaded: {
+            try {
+                const data = JSON.parse(text());
+                if (data.schemaVersion !== 1)
+                    return;
+                root._quotaById = data.providers ?? ({});
+                root._quotaCapturedAt = data.capturedAt ?? 0;
+            } catch (e) {
+                // Same rule as the usage record: a torn or missing file
+                // leaves the last-known windows alone rather than
+                // blanking bars the user was reading a second ago.
+            }
         }
     }
 

--- a/Configs/quickshell/aphotic/services/ai/AgentEvents.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentEvents.qml
@@ -49,6 +49,7 @@ Singleton {
 
     readonly property string activeHarness: root.activeSession?.harness ?? ""
     readonly property string phase: root.activeSession?.status ?? "idle"
+    readonly property var activeSubagents: root.activeSession?.subagents ?? []
 
     readonly property bool tailing: eventTail.running
 
@@ -108,6 +109,7 @@ Singleton {
                 model: event.model ?? "",
                 cwd: event.cwd ?? "",
                 tool: "",
+                subagents: [],
                 startedAt: event.t ?? 0,
                 updatedAt: event.t ?? 0,
                 endedAt: 0
@@ -127,13 +129,14 @@ Singleton {
         if (event.event === "session_end") {
             session.status = "ended";
             session.endedAt = event.t ?? 0;
+            session.subagents = [];
         } else {
             session.endedAt = 0;
             if (event.event === "notification")
                 session.status = "waiting";
             else if (event.event === "pre_compact")
                 session.status = "compacting";
-            else if (event.event === "pre_tool_use" || event.event === "post_tool_use" || event.event === "post_tool_use_failure" || event.event === "user_prompt_submit" || event.event === "post_compact")
+            else if (event.event === "pre_tool_use" || event.event === "post_tool_use" || event.event === "post_tool_use_failure" || event.event === "user_prompt_submit" || event.event === "post_compact" || event.event === "subagent_stop")
                 session.status = "running";
             else
                 session.status = "idle";
@@ -141,6 +144,32 @@ Singleton {
 
         if (event.tool)
             session.tool = event.tool;
+
+        // Subagents as identity and count only, never parentage: an
+        // event carrying `agentId` was written from inside a subagent,
+        // and `subagent_stop` is the one event that closes one out. The
+        // spawn link (`spawnedAgentId` on the parent's own tool result)
+        // is deliberately ignored here -- who spawned whom is a graph,
+        // and the graph lives in the Agent Graph plugin.
+        if (event.agentId) {
+            const agents = (session.subagents ?? []).slice();
+            const at = agents.findIndex(a => a.id === event.agentId);
+            if (event.event === "subagent_stop") {
+                if (at !== -1)
+                    agents.splice(at, 1);
+            } else if (at === -1) {
+                agents.push({
+                    id: event.agentId,
+                    type: event.agentType ?? ""
+                });
+            } else if (event.agentType && !agents[at].type) {
+                agents[at] = {
+                    id: event.agentId,
+                    type: event.agentType
+                };
+            }
+            session.subagents = agents;
+        }
 
         sessions[index] = session;
         return sessions;

--- a/tests/test_agent_statusline.py
+++ b/tests/test_agent_statusline.py
@@ -1,0 +1,99 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "Configs" / ".local" / "lib" / "aphotic"))
+from agent_statusline import build_record, format_line, merge, window
+
+NOW = 1788700000.0
+
+# The field names below are Claude Code's, not ours: the statusLine
+# command's stdin payload nests the windows under `rate_limits` with a
+# 0-100 `used_percentage` and an epoch-seconds `resets_at`, and reports
+# context fill under `context_window`. Verified against the installed
+# binary, so a rename upstream should break these tests loudly rather
+# than quietly zero the bars.
+PAYLOAD = {
+    "model": {"id": "claude-opus-5", "display_name": "Opus 5"},
+    "context_window": {
+        "total_input_tokens": 120000,
+        "context_window_size": 1000000,
+        "used_percentage": 12.4,
+        "remaining_percentage": 87.6,
+    },
+    "rate_limits": {
+        "five_hour": {"used_percentage": 54.2, "resets_at": 1788710000},
+        "seven_day": {"used_percentage": 46, "resets_at": 1789026800},
+    },
+}
+
+
+def test_real_payload_shape_yields_both_windows_and_context():
+    record = build_record(PAYLOAD, NOW)
+    windows = record["providers"]["claude"]["windows"]
+    assert windows["fiveHour"] == {"usedPercent": 54.2, "resetsAt": 1788710000}
+    assert windows["sevenDay"] == {"usedPercent": 46.0, "resetsAt": 1789026800}
+    assert windows["context"]["usedPercent"] == 12.4
+    assert windows["context"]["size"] == 1000000
+    assert record["providers"]["claude"]["model"] == "Opus 5"
+    assert record["capturedAt"] == int(NOW)
+
+
+def test_missing_rate_limits_is_empty_not_zero():
+    # Claude Code omits `rate_limits` entirely when it has no window to
+    # report. Zeroed windows would render as empty bars, which reads as
+    # "you have used nothing" -- the opposite of "we don't know".
+    record = build_record({"model": {"id": "claude-opus-5"}}, NOW)
+    assert record["providers"]["claude"]["windows"] == {}
+    assert record["providers"]["claude"]["model"] == "claude-opus-5"
+
+
+def test_spend_limit_window_is_carried_when_present():
+    payload = dict(PAYLOAD)
+    payload["rate_limits"] = dict(PAYLOAD["rate_limits"])
+    payload["rate_limits"]["spend_limit"] = {"used_percentage": 5, "resets_at": 1789000000}
+    windows = build_record(payload, NOW)["providers"]["claude"]["windows"]
+    assert windows["spendLimit"] == {"usedPercent": 5.0, "resetsAt": 1789000000}
+
+
+def test_percentages_are_clamped_and_bad_input_drops_the_window():
+    assert window({"used_percentage": 140})["usedPercent"] == 100.0
+    assert window({"used_percentage": -3})["usedPercent"] == 0.0
+    assert window({"used_percentage": "nope"}) is None
+    assert window({"resets_at": 123}) is None
+    assert window("not a dict") is None
+
+
+def test_unparseable_reset_falls_back_to_zero():
+    assert window({"used_percentage": 10, "resets_at": "soon"})["resetsAt"] == 0
+    assert window({"used_percentage": 10})["resetsAt"] == 0
+
+
+def test_merge_keeps_another_providers_section():
+    existing = {
+        "schemaVersion": 1,
+        "capturedAt": 1,
+        "providers": {"codex": {"model": "gpt", "windows": {"fiveHour": {"usedPercent": 3.0, "resetsAt": 0}}}},
+    }
+    merged = merge(existing, build_record(PAYLOAD, NOW))
+    assert set(merged["providers"]) == {"claude", "codex"}
+    assert merged["providers"]["codex"]["model"] == "gpt"
+
+
+def test_merge_discards_a_record_from_a_different_schema():
+    existing = {"schemaVersion": 99, "providers": {"codex": {}}}
+    merged = merge(existing, build_record(PAYLOAD, NOW))
+    assert set(merged["providers"]) == {"claude"}
+
+
+def test_status_line_names_the_model_and_every_reported_window():
+    assert format_line(build_record(PAYLOAD, NOW)) == "Opus 5 · 5h 54% · 7d 46% · ctx 12%"
+
+
+def test_status_line_omits_what_was_not_reported():
+    assert format_line(build_record({"model": {"display_name": "Opus 5"}}, NOW)) == "Opus 5"
+    assert format_line(build_record({}, NOW)) == ""
+
+
+def test_record_is_json_serialisable():
+    json.dumps(build_record(PAYLOAD, NOW))


### PR DESCRIPTION
## Problem

The agent notch tile showed harness, phase, cwd and a waiting badge. It
said nothing about usage, and there was no way to act on a session that
had stopped for input beyond finding its terminal yourself.

Quota was the harder half. Scoping said the numbers did not exist: the
usage record only ever computed today's token total, and the one quota
object in a transcript (`quotaLimits`) shows up only on requests the API
already rejected, carrying a reset time and no utilisation figure. A
weekly bar built on that would have been a token sum the shell invented.

The numbers do exist, on a channel nobody had looked at. Claude Code
hands its `statusLine` command a JSON payload carrying `rate_limits`
(five-hour and seven-day, each a used percentage and a reset epoch) and
`context_window`. Confirmed against the installed binary, not a
description of it.

## Plan

Read the quota off the statusLine payload, keep the token counts where
they were, and let the tile draw both. Add subagents to the event fold,
since the feed already carried them.

Reuse `AgentWindowFocus` for the waiting-session action rather than
deriving a second way to match a session to a window. It resolves a cwd
to a window and does nothing when the match is ambiguous, which is the
right answer for a click that would otherwise focus a stranger's
terminal.

The action copies rather than types. Synthetic keystrokes into a window
matched by working directory cannot be taken back when the match is
wrong, so the paste stays the user's.

## Resolution

`agent_statusline.py` reads the payload on stdin, writes the windows to
`~/.local/state/aphotic/agent-quota.json`, and prints a line back for
the terminal. Merged per provider, so a second harness writing its own
section will not erase this one. `AgentProviders` serves it through
`quotaOf()` alongside a new `usageOf()`, which answers for any provider
in the usage record instead of only those with a hook plugin enabled.

Two properties of the source shape the reader. An absent window stays
absent rather than becoming a zero, because a zero reads as "spent
nothing". And Claude Code writes the status line only while a session
runs, so `quotaMaxAgeSeconds` marks the point where a reading stopped
describing now.

`AgentEvents` folds a `subagents` array onto each session, `{id, type}`
per live one, opened by an `agentId` and closed by `subagent_stop`.
Count and identity only; the spawn graph stays in Agent Graph.
`subagent_stop` now counts as activity, which fixes a session with three
subagents going idle when the first finished.

The plugin half is T-Crypt/aphotic-plugins#25: the bars themselves,
and the `claude-hooks` change that claims the statusLine slot when it is
free.

Left out: Codex and OpenCode. The schema is already per-provider, so
`NOTCH-02` is a data-source problem rather than a schema one. Codex has
an equivalent behind `codex app-server`'s `account/rateLimits/read`, but
spawning it takes seconds, so it needs a cached poll and not a per-turn
hook.

## Verify

`python3 -m pytest tests/` (71 pass, 10 of them new). Headless probe
compiles and instantiates the tile with quota, usage and waiting rows
seeded, no binding loops. Then the live look: open the notch with a
Claude session running and check the bars read something sane. They stay
hidden until `claude-hooks` from the paired PR is reinstalled, since
nothing writes the quota file before then.