### PR TITLE
Aphotic Actions, and the notch's Commands tab

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -38,8 +38,8 @@ _aphotic_plugin_dir() { printf '%s/%s' "$APHOTIC_PLUGINS_DIR" "$1"; }
 # is reported as unhosted, which is the safe direction to fail -- a
 # surface silently dropped is the failure this exists to catch.
 # ---------------------------------------------------------------------
-APHOTIC_PLUGIN_HOSTED_SURFACES="dashboard notch settings overlay fullscreen-overlay"
-APHOTIC_PLUGIN_HOSTED_CAPABILITIES="ui-surface theme-hook project-hook workspace-hook harness-hook profile cli chat-provider"
+APHOTIC_PLUGIN_HOSTED_SURFACES="dashboard notch settings overlay fullscreen-overlay pet_action"
+APHOTIC_PLUGIN_HOSTED_CAPABILITIES="ui-surface theme-hook project-hook workspace-hook harness-hook profile cli chat-provider action"
 
 # Exact word match against a space-separated list. Not `grep -w`: grep
 # counts `-` as a word boundary, so `-w profile` matches "profile-hook"
@@ -343,6 +343,58 @@ _aphotic_plugin_chat_provider_json() {
         '{id: $id, label: $label, backend: $backend, state: $state, requires_layer: $requires_layer, requires_data: $requires_data}'
 }
 
+# The `action` capability (manifest v3.7, `ACT-01`). An action is a named
+# thing a user can ask for -- switch the pet, cycle the theme -- declared
+# once and reachable from every surface that offers actions, rather than
+# re-registered per surface. The component is headless, same shape as a
+# pet_action's: a plain QtObject that does its work in
+# `Component.onCompleted` and is torn down again immediately.
+#
+# Actions are the first capability where one plugin plausibly declares
+# several, so it takes five numbered sections rather than pet_action's
+# three. The shared TOML reader (globalcontrol.sh's `aphotic_toml_get`)
+# is flat, single-section-match, no arrays-of-tables; five is the room
+# this capability is given before that reader has to grow, and the sixth
+# action a plugin wants is the trigger to revisit it.
+_aphotic_plugin_action_entry_json() {
+    local manifest="$1" section="$2" id component icon label layer data
+    id="$(aphotic_toml_get "$manifest" "$section" id)"
+    component="$(aphotic_toml_get "$manifest" "$section" component)"
+    if [[ -z "$id" ]] || [[ -z "$component" ]]; then
+        return 1
+    fi
+
+    icon="$(aphotic_toml_get "$manifest" "$section" icon)"
+    label="$(aphotic_toml_get "$manifest" "$section" label)"
+    layer="$(aphotic_toml_get "$manifest" "$section" requires_layer)"
+    data="$(aphotic_toml_get "$manifest" "$section" requires_data)"
+
+    jq -n \
+        --arg id "$id" \
+        --arg icon "${icon:-}" \
+        --arg label "${label:-$id}" \
+        --arg component "$component" \
+        --arg requires_layer "${layer:-}" \
+        --arg requires_data "${data:-}" \
+        '{id: $id, icon: $icon, label: $label, component: $component, requires_layer: $requires_layer, requires_data: $requires_data}'
+}
+
+_aphotic_plugin_actions_json() {
+    local manifest="$1" entries=() entry section
+    for section in action action_2 action_3 action_4 action_5; do
+        if entry="$(_aphotic_plugin_action_entry_json "$manifest" "$section")"; then
+            entries+=("$entry")
+        fi
+    done
+
+    if [[ ${#entries[@]} -eq 0 ]]; then
+        echo 'null'
+        return 0
+    fi
+
+    printf '%s\n' "${entries[@]}" | jq -s .
+}
+
 _aphotic_plugin_describe() {
     local name="$1" dir manifest display desc version category caps enabled missing bin
     dir="$(_aphotic_plugin_dir "$name")"
@@ -378,7 +430,8 @@ _aphotic_plugin_describe() {
         --argjson profile "$(_aphotic_plugin_profile_json "$manifest")" \
         --argjson cli "$(_aphotic_plugin_cli_json "$manifest")" \
         --argjson chat_provider "$(_aphotic_plugin_chat_provider_json "$manifest")" \
-        '{name: $name, display_name: $display_name, description: $description, version: $version, category: $category, capabilities: $capabilities, enabled: $enabled, missing_binaries: $missing_binaries, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider}')"
+        --argjson actions "$(_aphotic_plugin_actions_json "$manifest")" \
+        '{name: $name, display_name: $display_name, description: $description, version: $version, category: $category, capabilities: $capabilities, enabled: $enabled, missing_binaries: $missing_binaries, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider, actions: $actions}')"
 
     # The registry entry the shell actually reads is written by
     # _aphotic_plugin_registry_sync out of these same four manifest
@@ -391,7 +444,7 @@ _aphotic_plugin_describe() {
     # second time is deliberate: a second description of that shape is the
     # class of bug the flag exists to catch.
     local stored expected drifted="false"
-    expected="$(jq -cS '{version, capabilities, owns, ui, profile, cli, chat_provider}' <<<"$entry")"
+    expected="$(jq -cS '{version, capabilities, owns, ui, profile, cli, chat_provider, actions}' <<<"$entry")"
     # Missing keys are filled with the same null a fresh sync would write
     # BEFORE comparing. Without this, every entry on disk reports drift the
     # moment the registry schema grows a field -- one did (`profile`,
@@ -399,7 +452,7 @@ _aphotic_plugin_describe() {
     # upgrade is noise that trains people to ignore the signal. A plugin
     # that genuinely gained a profile block still differs from null, so the
     # real case is unaffected.
-    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else {profile: null, cli: null, chat_provider: null} + . end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
+    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else {profile: null, cli: null, chat_provider: null, actions: null} + . end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
     [[ "$expected" != "$stored" ]] && drifted="true"
 
     jq --argjson drifted "$drifted" '. + {drifted: $drifted}' <<<"$entry"
@@ -707,7 +760,7 @@ _aphotic_plugin_install_deps() {
 # don't touch it, since aphotic_plugin_is_enabled already layers on top
 # via the same file's "disabled" array.
 _aphotic_plugin_registry_sync() {
-    local name="$1" dir manifest version caps owns ui profile cli chat_provider tmp
+    local name="$1" dir manifest version caps owns ui profile cli chat_provider actions tmp
     aphotic_require jq || return 1
     dir="$(_aphotic_plugin_dir "$name")"
     manifest="${dir}/plugin.toml"
@@ -720,6 +773,7 @@ _aphotic_plugin_registry_sync() {
     profile="$(_aphotic_plugin_profile_json "$manifest")"
     cli="$(_aphotic_plugin_cli_json "$manifest")"
     chat_provider="$(_aphotic_plugin_chat_provider_json "$manifest")"
+    actions="$(_aphotic_plugin_actions_json "$manifest")"
 
     [[ -f "$APHOTIC_PLUGINS_STATE_FILE" ]] || echo '{"disabled": []}' > "$APHOTIC_PLUGINS_STATE_FILE"
     tmp="$(mktemp)"
@@ -731,7 +785,8 @@ _aphotic_plugin_registry_sync() {
        --argjson profile "$profile" \
        --argjson cli "$cli" \
        --argjson chat_provider "$chat_provider" \
-       '.installed = ((.installed // {}) + {($n): {version: $version, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider}})' \
+       --argjson actions "$actions" \
+       '.installed = ((.installed // {}) + {($n): {version: $version, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider, actions: $actions}})' \
        "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp" && mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
     # Every install and update funnels through here, so this is the one
     # place that has to record "a plugin's code changed" for recovery.

--- a/Configs/quickshell/aphotic/components/SettingsRow.qml
+++ b/Configs/quickshell/aphotic/components/SettingsRow.qml
@@ -27,6 +27,14 @@ StyledRect {
 
     default property alias trailing: trailingSlot.data
 
+    // A row that IS the control -- one option in a list being picked from,
+    // rather than a label with a switch on the end. Off by default,
+    // because most rows carry their own trailing control and a click
+    // anywhere else on them should do nothing.
+    property bool activatable: false
+
+    signal activated
+
     Layout.fillWidth: true
     Layout.preferredHeight: rowLayout.implicitHeight + Tokens.padding.medium * 2
     implicitHeight: rowLayout.implicitHeight + Tokens.padding.medium * 2
@@ -48,6 +56,19 @@ StyledRect {
     }
     Behavior on bottomRightRadius {
         Anim { type: Anim.DefaultEffects }
+    }
+
+    // Under the content, so a trailing control's own StateLayer still
+    // takes its clicks first rather than the row swallowing them.
+    StateLayer {
+        anchors.fill: parent
+        visible: root.activatable
+        disabled: !root.activatable
+        topLeftRadius: root.topLeftRadius
+        topRightRadius: root.topRightRadius
+        bottomLeftRadius: root.bottomLeftRadius
+        bottomRightRadius: root.bottomRightRadius
+        onClicked: root.activated()
     }
 
     RowLayout {

--- a/Configs/quickshell/aphotic/config/Config.qml
+++ b/Configs/quickshell/aphotic/config/Config.qml
@@ -248,6 +248,25 @@ QtObject {
         readonly property int processCount: 6
     }
 
+    // The command palette's shipped slots -- the same ordered
+    // [{ id, enabled }] shape the bar's own widget list uses, over
+    // action ids from services/Actions.qml. Deliberately a short default:
+    // the catalog is large and grows with every plugin, and a palette
+    // that opened with forty rows would be a menu, not a palette.
+    // Settings.paletteEntries takes over the moment the user edits it.
+    readonly property QtObject palette: QtObject {
+        readonly property QtObject entries: QtObject {
+            readonly property var values: [
+                { id: "settings.open", enabled: true },
+                { id: "keybinds.cheatsheet", enabled: true },
+                { id: "theme.cycle", enabled: true },
+                { id: "settings.appearance", enabled: true },
+                { id: "settings.bar", enabled: true },
+                { id: "settings.plugins", enabled: true }
+            ]
+        }
+    }
+
     readonly property QtObject launcher: QtObject {
         readonly property string emojiListPath: `${Quickshell.env("HOME")}/.config/quickshell/aphotic/data/emoji.txt`
         readonly property string wallpaperDir: `${Quickshell.env("HOME")}/.config/awww`

--- a/Configs/quickshell/aphotic/modules/notch/Notch.qml
+++ b/Configs/quickshell/aphotic/modules/notch/Notch.qml
@@ -16,17 +16,22 @@ StyledRect {
     property bool dockHorizontal: true
     property bool growsPositive: true
 
-    // Processes is the base shell's tile and is the only one this file
-    // knows the name of: the notch ships with the base layer, so a plain
-    // install has exactly one tile and no switcher at all (see
-    // `switchable`). Every other tile is a plugin's notch surface,
-    // supplied by PluginRegistry and gated by that plugin's own manifest
-    // -- its profile layer enabled AND the plugin installed and enabled.
+    required property ScreenState screenState
+
+    // Processes and the palette are the base shell's own tiles and the
+    // only two this file knows the names of. Every other tile is a
+    // plugin's notch surface, supplied by PluginRegistry and gated by
+    // that plugin's own manifest -- its profile layer enabled AND the
+    // plugin installed and enabled.
     // Neither condition met means the tile is absent, not present and
     // empty. Adding, removing or rotating a tile is a plugin install,
     // with no edit here. See docs/PLUGIN_LAYER_MODEL.md.
     readonly property var pluginTiles: PluginRegistry.surfacesFor("notch")
 
+    // The base shell's own tiles. Both are core: the notch ships with the
+    // base layer and every install has them, which is what makes the
+    // palette a settings question (which actions are in it) rather than an
+    // install one (whether it exists at all).
     readonly property var tiles: [
         {
             plugin: "",
@@ -34,12 +39,20 @@ StyledRect {
             icon: "monitoring",
             label: qsTr("Processes"),
             componentUrl: ""
+        },
+        {
+            plugin: "",
+            id: "palette",
+            icon: "bolt",
+            label: qsTr("Commands"),
+            componentUrl: ""
         }
     ].concat(root.pluginTiles)
 
-    // A base install has one tile, so there is nothing to switch between:
-    // the name stops being a button and the switcher strip is gone
-    // entirely rather than sitting there as a single dead segment.
+    // Kept as a condition rather than assumed: core ships two tiles
+    // today, but a build with the palette or Processes taken out has one
+    // and nothing to switch between, and the switcher strip should be
+    // gone entirely rather than sitting there as a single dead segment.
     readonly property bool switchable: root.tiles.length > 1
 
     readonly property var activeTile: root.tiles.find(t => t.id === root.shownTileId) ?? null
@@ -240,6 +253,7 @@ StyledRect {
 
             tiles: root.tiles
             pluginTiles: root.pluginTiles
+            screenState: root.screenState
             switchable: root.switchable
             expanded: root.expanded
             shownTileId: root.shownTileId

--- a/Configs/quickshell/aphotic/modules/notch/NotchBody.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchBody.qml
@@ -11,6 +11,7 @@ ColumnLayout {
 
     required property var tiles
     required property var pluginTiles
+    required property var screenState
     required property bool switchable
     required property bool expanded
     required property string shownTileId
@@ -131,7 +132,9 @@ ColumnLayout {
 
         readonly property Item shownItem: {
             if (root.shownTileId === "processes")
-                return baseTileLoader;
+                return processTileLoader;
+            if (root.shownTileId === "palette")
+                return paletteTileLoader;
             const count = pluginRepeater.count;
             const i = root.pluginTiles.findIndex(t => t.id === root.shownTileId);
             if (i < 0 || i >= count)
@@ -140,14 +143,25 @@ ColumnLayout {
         }
 
         Loader {
-            id: baseTileLoader
+            id: processTileLoader
 
             width: tileHost.width
             y: (1 - tileHost.enterT) * Tokens.spacing.medium
             active: root.shownTileId === "processes"
-            visible: baseTileLoader.active
+            visible: processTileLoader.active
 
             sourceComponent: processComp
+        }
+
+        Loader {
+            id: paletteTileLoader
+
+            width: tileHost.width
+            y: (1 - tileHost.enterT) * Tokens.spacing.medium
+            active: root.shownTileId === "palette"
+            visible: paletteTileLoader.active
+
+            sourceComponent: paletteComp
         }
 
         // Every gated-in plugin tile is built, not just the shown one: a
@@ -192,5 +206,18 @@ ColumnLayout {
     Component {
         id: processComp
         NotchProcessTile {}
+    }
+
+    Component {
+        id: paletteComp
+
+        NotchPaletteTile {
+            screenState: root.screenState
+
+            // An action is a thing that happens somewhere else. Staying
+            // open over the surface it just opened would leave the notch
+            // covering the answer.
+            onInvoked: root.dismissed()
+        }
     }
 }

--- a/Configs/quickshell/aphotic/modules/notch/NotchPaletteTile.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchPaletteTile.qml
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.components
+import qs.services
+
+// The command palette: the user's own slots, in their own order, over
+// ACT-01's action list. Core tile, like Processes -- every install has
+// one, and what is in it is a settings question, not an install question.
+//
+// This file knows no action's id. It renders Settings.paletteEntries
+// against whatever Actions.actions currently resolves, so a plugin's
+// action appears here the moment that plugin is installed and disappears
+// again when it is removed, with no edit anywhere.
+ColumnLayout {
+    id: root
+
+    // A slot whose action does not resolve is dropped from the tile
+    // rather than drawn dead, and kept in settings.json regardless -- see
+    // Settings.paletteEntries. Disabling a plugin for an afternoon should
+    // empty a row, not delete it.
+    readonly property var rows: Settings.paletteEntries.filter(e => e.enabled && Actions.has(e.id)).map(e => Actions.find(e.id))
+
+    signal invoked
+
+    required property var screenState
+
+    spacing: Tokens.spacing.extraSmall
+
+    StyledText {
+        Layout.fillWidth: true
+        Layout.bottomMargin: Tokens.spacing.extraSmall
+        visible: root.rows.length === 0
+        wrapMode: Text.WordWrap
+        text: qsTr("No actions yet. Settings › Bar › Command palette picks what lands here.")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.small
+    }
+
+    Repeater {
+        model: root.rows
+
+        StyledRect {
+            id: actionRow
+
+            required property var modelData
+
+            Layout.fillWidth: true
+            implicitHeight: 32
+            radius: Tokens.rounding.small
+            color: Colours.layer(Colours.palette.m3surfaceContainerHigh, 2)
+
+            StateLayer {
+                radius: parent.radius
+                onClicked: {
+                    Actions.invoke(actionRow.modelData.id, {
+                        screenState: root.screenState
+                    });
+                    root.invoked();
+                }
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: Tokens.padding.small
+                anchors.rightMargin: Tokens.padding.small
+                spacing: Tokens.spacing.small
+
+                MaterialIcon {
+                    text: actionRow.modelData.icon
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.small
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: actionRow.modelData.label
+                    elide: Text.ElideRight
+                    font: Tokens.font.body.medium
+                }
+
+                // Says an action came from a plugin without naming which
+                // one: the label is the plugin's own words already, and a
+                // second copy of the plugin name in every row is noise.
+                MaterialIcon {
+                    visible: actionRow.modelData.plugin.length > 0
+                    text: "extension"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.small
+                }
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/notch/NotchWindow.qml
+++ b/Configs/quickshell/aphotic/modules/notch/NotchWindow.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Quickshell
 import Quickshell.Wayland
+import qs.components
 import qs.config
 import qs.services
 
@@ -11,6 +12,12 @@ PanelWindow {
 
     required property var modelData
     screen: modelData
+
+    // The palette tile's actions open surfaces owned by other windows on
+    // this same screen, so the notch carries the shared per-screen state
+    // rather than an action reaching for whichever screen enumerates
+    // first. See services/Actions.qml.
+    required property ScreenState screenState
 
     readonly property Notch notch: notch
 
@@ -69,6 +76,7 @@ PanelWindow {
 
         dockHorizontal: root.dockHorizontal
         growsPositive: root.growsPositive
+        screenState: root.screenState
 
         // Plain x/y rather than anchors: BarWrapper.qml and DockWindow.qml
         // both document why an orientation-dependent `cond ? parent.X :

--- a/Configs/quickshell/aphotic/modules/notch/qmldir
+++ b/Configs/quickshell/aphotic/modules/notch/qmldir
@@ -5,3 +5,4 @@ NotchBody 1.0 NotchBody.qml
 NotchIdleStrip 1.0 NotchIdleStrip.qml
 NotchSwitcher 1.0 NotchSwitcher.qml
 NotchProcessTile 1.0 NotchProcessTile.qml
+NotchPaletteTile 1.0 NotchPaletteTile.qml

--- a/Configs/quickshell/aphotic/modules/settings/panes/BarPane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/BarPane.qml
@@ -210,6 +210,15 @@ ColumnLayout {
         screenState: root.screenState
     }
 
+    // The notch's palette lives in the Bar pane because the notch docks to
+    // the bar's own edge and is configured with it -- not because it is a
+    // bar widget. It is here under every bar style, unlike the widget list
+    // above, since the notch is its own surface and does not care which
+    // style the bar is wearing.
+    PaletteSection {
+        Layout.fillWidth: true
+    }
+
     ColumnLayout {
         Layout.fillWidth: true
         visible: Settings.barStyle === "dock"

--- a/Configs/quickshell/aphotic/modules/settings/panes/PaletteSection.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/PaletteSection.qml
@@ -1,0 +1,253 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.components
+import qs.services
+
+// The command palette's own slot list, editable in place: the notch tile
+// renders Settings.paletteEntries directly, so a toggle, a reorder or a
+// remap here reaches it on the next binding pass with no restart.
+//
+// Same ordered [{ id, enabled }] shape the bar's widget list uses, over
+// action ids instead of widget ids -- and one thing the bar's list does
+// not do, because a bar widget is a fixed set core ships: a slot can be
+// pointed at any action in the catalog, core or plugin. That is what
+// makes the palette the user's, rather than a fixed list they can only
+// hide rows of.
+ColumnLayout {
+    id: root
+
+    // Which slot the picker is assigning to. -1 with the picker open
+    // means it is appending a new one.
+    property int pickIndex: -1
+    property bool picking: false
+
+    // Actions not already in the list. A palette with the same action
+    // twice is legal (nothing breaks) but never what someone meant, so
+    // the picker stops offering one already placed.
+    readonly property var available: Actions.actions.filter(a => !Settings.paletteEntries.some(e => e.id === a.id))
+
+    function describe(id: string): var {
+        return Actions.find(id) ?? ({
+                id: id,
+                icon: "help",
+                label: id,
+                plugin: ""
+            });
+    }
+
+    function setEnabled(index: int, value: bool): void {
+        Settings.paletteEntries = Settings.paletteEntries.map((e, i) => i === index ? ({
+                    id: e.id,
+                    enabled: value
+                }) : e);
+    }
+
+    function assign(index: int, id: string): void {
+        if (index < 0) {
+            Settings.paletteEntries = Settings.paletteEntries.concat([
+                {
+                    id: id,
+                    enabled: true
+                }
+            ]);
+            return;
+        }
+        Settings.paletteEntries = Settings.paletteEntries.map((e, i) => i === index ? ({
+                    id: id,
+                    enabled: e.enabled
+                }) : e);
+    }
+
+    function remove(index: int): void {
+        Settings.paletteEntries = Settings.paletteEntries.filter((e, i) => i !== index);
+    }
+
+    function move(from: int, to: int): void {
+        if (to < 0 || to >= Settings.paletteEntries.length || from === to)
+            return;
+        const next = Settings.paletteEntries.slice();
+        const moved = next.splice(from, 1)[0];
+        next.splice(to, 0, moved);
+        Settings.paletteEntries = next;
+    }
+
+    function openPicker(index: int): void {
+        root.pickIndex = index;
+        root.picking = true;
+    }
+
+    spacing: Tokens.spacing.small
+
+    StyledText {
+        text: qsTr("Command palette")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.medium
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        text: qsTr("What the notch's Commands tab offers, in this order. Drag the handle to reorder, or swap a slot for any other action. Installing a plugin adds its actions to the list to choose from.")
+        wrapMode: Text.WordWrap
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.small
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+        visible: Settings.paletteEntries.length > 0
+
+        Repeater {
+            model: Settings.paletteEntries
+
+            SettingsRow {
+                id: slotRow
+
+                required property var modelData
+                required property int index
+
+                readonly property var info: root.describe(slotRow.modelData.id)
+                // A slot outlives the plugin that supplied its action, on
+                // purpose -- see Settings.paletteEntries. It says so here
+                // rather than disappearing, which is the only place the
+                // user can act on it.
+                readonly property bool resolved: Actions.has(slotRow.modelData.id)
+
+                icon: slotRow.info.icon
+                label: slotRow.info.label
+                description: !slotRow.resolved ? qsTr("Not available right now") : (slotRow.modelData.enabled ? "" : qsTr("Hidden"))
+                opacity: slotRow.modelData.enabled && slotRow.resolved ? 1 : 0.6
+
+                RowLayout {
+                    spacing: Tokens.spacing.small
+
+                    MaterialIcon {
+                        text: "swap_horiz"
+                        color: root.picking && root.pickIndex === slotRow.index ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.small
+
+                        StateLayer {
+                            anchors.fill: parent
+                            anchors.margins: -Tokens.padding.small
+                            radius: Tokens.rounding.full
+                            onClicked: root.openPicker(slotRow.index)
+                        }
+                    }
+
+                    MaterialIcon {
+                        text: "close"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.small
+
+                        StateLayer {
+                            anchors.fill: parent
+                            anchors.margins: -Tokens.padding.small
+                            radius: Tokens.rounding.full
+                            onClicked: root.remove(slotRow.index)
+                        }
+                    }
+
+                    MaterialIcon {
+                        text: slotRow.modelData.enabled ? "toggle_on" : "toggle_off"
+                        fill: 1
+                        color: slotRow.modelData.enabled ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+
+                        StateLayer {
+                            anchors.fill: parent
+                            anchors.margins: -Tokens.padding.small
+                            radius: Tokens.rounding.full
+                            onClicked: root.setEnabled(slotRow.index, !slotRow.modelData.enabled)
+                        }
+                    }
+
+                    // Only the handle drags, and it keeps the pane's own
+                    // Flickable from claiming the gesture -- the same
+                    // reasoning, and the same shape, as the bar's widget
+                    // list.
+                    MaterialIcon {
+                        text: "drag_indicator"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.small
+
+                        MouseArea {
+                            anchors.fill: parent
+                            anchors.margins: -Tokens.padding.small
+                            preventStealing: true
+                            cursorShape: Qt.SizeVerCursor
+
+                            property real anchorY: 0
+
+                            onPressed: event => anchorY = mapToItem(null, event.x, event.y).y
+                            onPositionChanged: event => {
+                                const step = slotRow.height;
+                                if (step <= 0)
+                                    return;
+                                const y = mapToItem(null, event.x, event.y).y;
+                                const delta = y - anchorY;
+                                if (Math.abs(delta) < step)
+                                    return;
+                                const dir = delta > 0 ? 1 : -1;
+                                root.move(slotRow.index, slotRow.index + dir);
+                                anchorY += step * dir;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+
+        SettingsRow {
+            icon: "add"
+            label: qsTr("Add an action")
+            description: root.available.length === 0 ? qsTr("Every action is already in the list") : ""
+            opacity: root.available.length === 0 ? 0.6 : 1
+            activatable: root.available.length > 0
+            onActivated: root.openPicker(-1)
+        }
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        visible: root.picking
+        text: root.pickIndex < 0 ? qsTr("Pick an action to add") : qsTr("Pick what this slot runs instead")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.medium
+    }
+
+    SettingsGroup {
+        Layout.fillWidth: true
+        visible: root.picking
+
+        Repeater {
+            // Everything unused, plus whatever the slot being remapped
+            // already runs -- that one is filtered out of `available` by
+            // its own presence in the list, and leaving it out would make
+            // cancelling a remap impossible.
+            model: root.picking ? root.available.concat(root.pickIndex >= 0 ? [root.describe(Settings.paletteEntries[root.pickIndex]?.id ?? "")] : []) : []
+
+            SettingsRow {
+                id: choiceRow
+
+                required property var modelData
+
+                icon: choiceRow.modelData.icon
+                label: choiceRow.modelData.label
+                description: choiceRow.modelData.plugin.length > 0 ? qsTr("From a plugin") : ""
+                activatable: true
+
+                onActivated: {
+                    root.assign(root.pickIndex, choiceRow.modelData.id);
+                    root.picking = false;
+                    root.pickIndex = -1;
+                }
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/settings/qmldir
+++ b/Configs/quickshell/aphotic/modules/settings/qmldir
@@ -5,6 +5,7 @@ AppearancePane 1.0 panes/AppearancePane.qml
 BarPane 1.0 panes/BarPane.qml
 BarStylePreviewCard 1.0 panes/BarStylePreviewCard.qml
 BarWidgetsSection 1.0 panes/BarWidgetsSection.qml
+PaletteSection 1.0 panes/PaletteSection.qml
 CategoryRail 1.0 CategoryRail.qml
 ClockPane 1.0 panes/ClockPane.qml
 CommunityThemes 1.0 panes/CommunityThemes.qml

--- a/Configs/quickshell/aphotic/services/Actions.qml
+++ b/Configs/quickshell/aphotic/services/Actions.qml
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Aphotic-Hypr contributors
+
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import qs.config
+import qs.services
+
+// ACT-01. One list of everything a user can ask the shell to do, and one
+// way to ask for it.
+//
+// An action is a named, invokable thing -- not a surface. Core ships a
+// static set every install has; a plugin declaring `[action]` in its
+// manifest contributes more, present only while that plugin is installed,
+// enabled and past its own gate. Both end up in `actions`, in one list
+// rather than two beside each other, for the same reason AiProviders
+// merges plugin pills into its own provider list: two lists would make
+// every consumer choose which one it meant, and choose wrong somewhere.
+//
+// The palette notch tile is the first consumer. It is deliberately not
+// the only shape this supports -- `invoke()` is callable from anything,
+// including `qs ipc call aphotic action <id>` (shell.qml), which is what
+// makes an action reachable from a keybind and the CLI without a second
+// registration. A launcher mode, the dashboard and the assistant are the
+// remaining consumers, and they add a call site here, not a list.
+//
+// Invocation takes a context rather than reaching for a window itself: a
+// ScreenState is per-monitor, and an action fired from the palette should
+// land on the monitor the palette is on, not on whichever screen
+// enumerates first. A caller with no context (an IPC call arriving from a
+// keybind) resolves the focused screen's state and passes that.
+Singleton {
+    id: root
+
+    // Which Settings pane each `settings.*` action opens, derived from the
+    // rail's own category list rather than restated here -- a category
+    // added there is an action here with no edit, and the two cannot
+    // drift into disagreeing about what a pane is called.
+    readonly property var _settingsActions: SettingsCategories.list.map(c => ({
+        id: `settings.${c.id}`,
+        icon: c.icon,
+        label: qsTr("Settings: %1").arg(c.label),
+        plugin: ""
+    }))
+
+    readonly property var coreActions: [
+        {
+            id: "settings.open",
+            icon: "settings",
+            label: qsTr("Open Settings"),
+            plugin: ""
+        },
+        {
+            id: "keybinds.cheatsheet",
+            icon: "keyboard",
+            label: qsTr("Keyboard shortcuts"),
+            plugin: ""
+        },
+        {
+            id: "theme.cycle",
+            icon: "palette",
+            label: qsTr("Next theme"),
+            plugin: ""
+        }
+    ].concat(root._settingsActions)
+
+    readonly property var pluginActions: PluginRegistry.actionRegistrations.map(a => ({
+        id: a.id,
+        icon: a.icon,
+        label: a.label,
+        plugin: a.plugin,
+        componentUrl: a.componentUrl
+    }))
+
+    // The one list every action surface reads.
+    readonly property var actions: root.coreActions.concat(root.pluginActions)
+
+    function find(id: string): var {
+        return root.actions.find(a => a.id === id) ?? null;
+    }
+
+    // Whether an action id still resolves. A palette slot naming a plugin
+    // action outlives the plugin being removed -- the slot stays in the
+    // user's settings.json so re-installing the plugin brings it back
+    // rather than silently dropping it -- so every consumer has to be able
+    // to ask, and to render the gap rather than an empty row.
+    function has(id: string): bool {
+        return root.find(id) !== null;
+    }
+
+    function invoke(id: string, context: var): void {
+        const action = root.find(id);
+        if (!action) {
+            console.warn(`aphotic action: unknown id '${id}'`);
+            return;
+        }
+
+        if (action.plugin.length > 0) {
+            root._runPluginAction(action);
+            return;
+        }
+
+        const handler = root._coreHandlers[id] ?? (id.startsWith("settings.") ? root._openSettingsCategory : null);
+        if (handler)
+            handler(context ?? ({}), id);
+    }
+
+    // A plugin's action component is headless: it does its work in
+    // `Component.onCompleted` and has nothing to show, so it is built,
+    // allowed to run, and torn down in the same call. Same contract as a
+    // pet_action's component (PetActionMenu.qml), built without a Loader
+    // because this singleton has no visual tree to put one in -- and
+    // because an action has to be invokable from IPC, where there is no
+    // surface on screen at all.
+    function _runPluginAction(action: var): void {
+        const component = Qt.createComponent(action.componentUrl);
+        if (component.status === Component.Error) {
+            console.warn(`aphotic action: ${action.id} failed to load: ${component.errorString()}`);
+            component.destroy();
+            return;
+        }
+
+        const instance = component.createObject(null);
+        if (instance)
+            instance.destroy();
+        else
+            console.warn(`aphotic action: ${action.id} produced no object`);
+        component.destroy();
+    }
+
+    readonly property var _coreHandlers: ({
+        "settings.open": context => root._openSettings(context, ""),
+        "keybinds.cheatsheet": context => {
+            if (context.screenState)
+                context.screenState.keybindsCheatsheet = true;
+        },
+        // Cycles the installed themes rather than opening a picker: the
+        // palette is the place a thing happens, not a route to the place
+        // it happens. Themes.setTheme picks the theme's own default
+        // wallpaper when handed an empty one.
+        "theme.cycle": () => {
+            const themes = Themes.themes;
+            if (themes.length < 2)
+                return;
+            const i = themes.findIndex(t => t.name === Themes.activeTheme);
+            Themes.setTheme(themes[(i + 1) % themes.length].name, "");
+        }
+    })
+
+    function _openSettingsCategory(context: var, id: string): void {
+        root._openSettings(context, id.slice("settings.".length));
+    }
+
+    function _openSettings(context: var, category: string): void {
+        if (!context.screenState)
+            return;
+        if (category.length > 0)
+            context.screenState.settingsCategory = category;
+        context.screenState.settings = true;
+    }
+}

--- a/Configs/quickshell/aphotic/services/PluginRegistry.qml
+++ b/Configs/quickshell/aphotic/services/PluginRegistry.qml
@@ -142,6 +142,41 @@ Singleton {
         return providers;
     }
 
+    // Plugins that declare `[action]` -- the `action` capability, ACT-01's
+    // substrate. An action is a named thing a user can ask for, not a
+    // surface: it draws nothing, and every surface that offers actions
+    // reads the one list rather than each plugin registering per surface.
+    //
+    // The registry id is namespaced with the plugin's own name, so two
+    // plugins declaring `switch` are two distinct actions and the palette
+    // can address either by id. Core actions carry their own namespaces
+    // (`theme.`, `settings.`), so a plugin cannot shadow one either. No
+    // core file names a plugin: the prefix is the install key, read at
+    // runtime.
+    readonly property var actionRegistrations: {
+        const actions = [];
+        for (const name of Object.keys(root._installed)) {
+            if (!root.isEnabled(name))
+                continue;
+            for (const action of (root._installed[name]?.actions ?? [])) {
+                if (!action || !action.id || !action.component)
+                    continue;
+                const entry = {
+                    plugin: name,
+                    id: `${name}.${action.id}`,
+                    label: action.label || action.id,
+                    icon: action.icon || "bolt",
+                    requiresLayer: action.requires_layer ?? "",
+                    requiresData: action.requires_data ?? "",
+                    componentUrl: `file://${root.pluginsDir}/${name}/${action.component}`
+                };
+                if (root._gateSatisfied(entry))
+                    actions.push(entry);
+            }
+        }
+        return actions;
+    }
+
     // A pre-`ui.surfaces` registry entry (written by a CLI older than the
     // surface unification) still carries a bare `dashboard_tab` object.
     // Reading it as one ungated dashboard surface keeps an install that

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -83,6 +83,14 @@ Singleton {
     // each "groupDivider".
     property var barStatusIcons: Config.bar.statusIcons.values
 
+    // The command palette's ordered slots: [{ id, enabled }] over action
+    // ids (services/Actions.qml), same shape and same persistence as
+    // barEntries. A slot naming an action that does not resolve right now
+    // is KEPT rather than pruned -- it is usually a plugin the user
+    // disabled for the afternoon, and silently rewriting their list on
+    // the way past would lose the slot for good.
+    property var paletteEntries: Config.palette.entries.values
+
     property bool dockAutoHide: false
     // Array of desktop-entry ids (DesktopEntry.id, e.g. "firefox") pinned
     // to the Dock style regardless of whether they're currently running.
@@ -410,6 +418,7 @@ Singleton {
             workspaceProfiles: root.workspaceProfiles,
             barEntries: root.barEntries,
             barStatusIcons: root.barStatusIcons,
+            paletteEntries: root.paletteEntries,
             vpnConfigPath: root.vpnConfigPath,
             vpnAutoConnect: root.vpnAutoConnect,
             intelligenceEnabled: root.intelligenceEnabled,
@@ -715,6 +724,7 @@ hyprctl switchxkblayout all 0 >/dev/null 2>&1`;
     onWorkspaceProfilesChanged: root._saveState()
     onBarEntriesChanged: root._saveState()
     onBarStatusIconsChanged: root._saveState()
+    onPaletteEntriesChanged: root._saveState()
     onVpnConfigPathChanged: root._saveState()
     onVpnAutoConnectChanged: root._saveState()
     onIntelligenceEnabledChanged: root._saveState()
@@ -905,6 +915,8 @@ hyprctl switchxkblayout all 0 >/dev/null 2>&1`;
                     root.barEntries = data.barEntries;
                 if (Array.isArray(data.barStatusIcons))
                     root.barStatusIcons = data.barStatusIcons;
+                if (Array.isArray(data.paletteEntries))
+                    root.paletteEntries = data.paletteEntries;
                 if (typeof data.vpnConfigPath === "string")
                     root.vpnConfigPath = data.vpnConfigPath;
                 if (typeof data.vpnAutoConnect === "boolean")

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -1,4 +1,5 @@
 module qs.services
+singleton Actions 1.0 Actions.qml
 singleton AgentProviders 1.0 AgentProviders.qml
 singleton Audio 1.0 Audio.qml
 singleton Brightness 1.0 Brightness.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -66,6 +66,21 @@ ShellRoot {
         return variants.instances[0] ?? null;
     }
 
+    // The ScreenState of the monitor being looked at -- same match on the
+    // Wayland output name focusedInstance() documents at length, against
+    // the shared per-screen states rather than one window's instances.
+    function focusedScreenState(): ScreenState {
+        const name = Hypr.focusedMonitor?.name;
+        if (name) {
+            for (let i = 0; i < screenStates.instances.length; i++) {
+                const s = screenStates.instances[i];
+                if (s.modelData?.name === name)
+                    return s;
+            }
+        }
+        return screenStates.instances[0] ?? null;
+    }
+
     // One shared ScreenState per screen — every window below is given the
     // SAME instance for its screen, so a toggle from one module (e.g. the
     // bar's power button setting screenState.session) is actually observed
@@ -117,7 +132,9 @@ ShellRoot {
     Variants {
         model: Quickshell.screens
 
-        NotchWindow {}
+        NotchWindow {
+            screenState: root.screenStateFor(modelData)
+        }
     }
 
     Variants {
@@ -263,6 +280,19 @@ ShellRoot {
                 fn();
             else
                 console.warn(`aphotic toggle: unknown name '${name}'`);
+        }
+
+        // ACT-01's other entry point: `qs -c aphotic ipc call aphotic
+        // action <id>` runs the same action the palette runs, so a
+        // keybind or a script reaches every action -- core and plugin --
+        // without anything being registered a second time. The focused
+        // screen's state goes with it, for the same reason every toggle
+        // above resolves one: an action that opens a surface should open
+        // it on the monitor being looked at.
+        function action(id: string): void {
+            Actions.invoke(id, {
+                screenState: root.focusedScreenState()
+            });
         }
     }
 

--- a/tests/test_plugin_action_capability.sh
+++ b/tests/test_plugin_action_capability.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# tests/test_plugin_action_capability.sh
+# Manifest v3.7's `action` capability (ACT-01): a plugin declares named
+# actions that turn up wherever the shell offers actions, rather than
+# registering per surface. Covers the manifest parse, the five numbered
+# sections, the registry round-trip, drift, and the host gate.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+COMMANDS_DIR="$ROOT/Configs/.local/lib/aphotic/commands"
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_plugin.sh"
+
+# --- manifest parse ----------------------------------------------------
+
+PLUGDIR="$APHOTIC_PLUGINS_DIR/scratch-action"
+mkdir -p "$PLUGDIR/qml/actions"
+cat > "$PLUGDIR/plugin.toml" <<'TOML'
+[plugin]
+name = "scratch-action"
+display_name = "Scratch Action"
+description = "test action plugin"
+version = "1.0.0"
+category = "productivity"
+capabilities = ["action"]
+
+[action]
+id = "switchThing"
+icon = "swap_horiz"
+label = "Switch thing"
+component = "qml/actions/SwitchThing.qml"
+
+[action_2]
+id = "resetThing"
+component = "qml/actions/ResetThing.qml"
+TOML
+
+actions="$(_aphotic_plugin_actions_json "$PLUGDIR/plugin.toml")"
+[[ "$(jq 'length' <<<"$actions")" == "2" ]]                  || fail "expected two actions: $actions"
+[[ "$(jq -r '.[0].id' <<<"$actions")" == "switchThing" ]]    || fail "id not parsed: $actions"
+[[ "$(jq -r '.[0].icon' <<<"$actions")" == "swap_horiz" ]]   || fail "icon not parsed: $actions"
+[[ "$(jq -r '.[0].label' <<<"$actions")" == "Switch thing" ]] || fail "label not parsed: $actions"
+[[ "$(jq -r '.[0].component' <<<"$actions")" == "qml/actions/SwitchThing.qml" ]] \
+    || fail "component not parsed: $actions"
+
+# Order is the manifest's own numbered order, so a plugin controls which
+# of its actions a picker offers first.
+[[ "$(jq -r '.[1].id' <<<"$actions")" == "resetThing" ]] || fail "action_2 not second: $actions"
+
+# An action with no label falls back to its id rather than to empty --
+# a nameless row in a palette is a row nobody can pick on purpose.
+[[ "$(jq -r '.[1].label' <<<"$actions")" == "resetThing" ]] || fail "label fallback lost: $actions"
+# The icon does NOT fall back here: PluginRegistry substitutes one, the
+# same place it defaults every other surface's icon.
+[[ "$(jq -r '.[1].icon' <<<"$actions")" == "" ]] || fail "icon should default in the shell: $actions"
+
+# --- five numbered sections, and no sixth ------------------------------
+# Actions are the first capability where one plugin plausibly declares
+# several. The cap is bounded room, not a parser: a manifest declaring a
+# sixth gets five, silently, which is what the cap being documented is
+# for.
+{
+    echo '[plugin]'
+    echo 'name = "many"'
+    for n in "" _2 _3 _4 _5 _6; do
+        printf '\n[action%s]\nid = "a%s"\ncomponent = "qml/A.qml"\n' "$n" "${n:-_1}"
+    done
+} > "$TESTHOME/many.toml"
+[[ "$(_aphotic_plugin_actions_json "$TESTHOME/many.toml" | jq 'length')" == "5" ]] \
+    || fail "expected the documented cap of five actions"
+
+# --- an incomplete declaration contributes nothing ---------------------
+printf '[plugin]\nname = "x"\n\n[action]\nid = "y"\n' > "$TESTHOME/partial.toml"
+[[ "$(_aphotic_plugin_actions_json "$TESTHOME/partial.toml")" == "null" ]] \
+    || fail "an [action] with no component should contribute nothing"
+printf '[plugin]\nname = "x"\n\n[action]\ncomponent = "qml/Y.qml"\n' > "$TESTHOME/noid.toml"
+[[ "$(_aphotic_plugin_actions_json "$TESTHOME/noid.toml")" == "null" ]] \
+    || fail "an [action] with no id should contribute nothing"
+
+# A manifest declaring no actions at all reads as null, the same "absent
+# capability" shape profile/cli/chat_provider already write -- the drift
+# comparison fills exactly that value in for an entry stored before this
+# field existed.
+printf '[plugin]\nname = "x"\n' > "$TESTHOME/none.toml"
+[[ "$(_aphotic_plugin_actions_json "$TESTHOME/none.toml")" == "null" ]] \
+    || fail "a manifest with no actions should read as null"
+
+# --- gates parse, so an action can be layer-scoped ---------------------
+cat > "$TESTHOME/gated.toml" <<'TOML'
+[plugin]
+name = "x"
+[action]
+id = "y"
+component = "qml/Y.qml"
+requires_layer = "gaming"
+requires_data = "harness"
+TOML
+g="$(_aphotic_plugin_actions_json "$TESTHOME/gated.toml" | jq -c '.[0]')"
+[[ "$(jq -r '.requires_layer' <<<"$g")" == "gaming" ]]  || fail "layer gate lost: $g"
+[[ "$(jq -r '.requires_data' <<<"$g")" == "harness" ]]  || fail "data gate lost: $g"
+
+# --- registry round-trip: what the shell actually reads ----------------
+
+_aphotic_plugin_registry_sync scratch-action || fail "registry sync failed"
+entry="$(jq -c '.installed["scratch-action"].actions' "$APHOTIC_PLUGINS_STATE_FILE")"
+[[ "$(jq 'length' <<<"$entry")" == "2" ]] \
+    || fail "registry did not record the actions: $entry"
+[[ "$(jq -r '.[0].id' <<<"$entry")" == "switchThing" ]] \
+    || fail "registry lost the action id: $entry"
+
+# --- drift -------------------------------------------------------------
+
+[[ "$(_aphotic_plugin_describe scratch-action | jq -r '.drifted')" == "false" ]] \
+    || fail "a freshly synced plugin should not report drift"
+
+sed -i 's/^label = "Switch thing"/label = "Swap thing"/' "$PLUGDIR/plugin.toml"
+[[ "$(_aphotic_plugin_describe scratch-action | jq -r '.drifted')" == "true" ]] \
+    || fail "editing [action] in place should report drift"
+sed -i 's/^label = "Swap thing"/label = "Switch thing"/' "$PLUGDIR/plugin.toml"
+
+# An entry stored before this field existed must not read as drifted --
+# the whole reason the comparison null-fills. Same case `profile` and
+# `cli` each hit when they were added.
+tmp="$(mktemp)"
+jq 'del(.installed["scratch-action"].actions)' "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp"
+mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
+[[ "$(_aphotic_plugin_describe scratch-action | jq -r '.drifted')" == "true" ]] \
+    || fail "a plugin that genuinely declares actions should drift against an entry missing them"
+
+# --- host gate ---------------------------------------------------------
+
+_aphotic_plugin_in_list "action" "$APHOTIC_PLUGIN_HOSTED_CAPABILITIES" \
+    || fail "this build hosts the action capability but the gate does not say so"
+for cap in ui-surface profile cli chat-provider; do
+    _aphotic_plugin_in_list "$cap" "$APHOTIC_PLUGIN_HOSTED_CAPABILITIES" \
+        || fail "adding action dropped '$cap' from the hosted list"
+done
+
+echo "PASS: tests/test_plugin_action_capability.sh"


### PR DESCRIPTION
## Problem

The notch has one tile. `NOTCH-06` asked for a command palette as its
next one, scoped as a small preview with an action list of its own, to
be migrated onto `ACT-01`'s substrate later.

The list that tab needs is `ACT-01`: entries core ships on every
install, entries a plugin contributes while it is installed, and a
per-user order and selection over both. Building the preview would have
meant two action lists for as long as the migration took, and `PET-13`
is already waiting on the same substrate.

## Plan

Ship `ACT-01`, with the palette as its first consumer.

An action is a capability, so `[action]` sits at the manifest's top
level beside `[profile]` and `[chat_provider]` rather than under
`[ui.*]`. A surface is a place a plugin draws and one host mounts it. An
action draws nothing, and every consumer that offers actions reads the
same one. It takes five numbered sections, `[action]` through
`[action_5]`, the trick `pet_action` already uses, because the shared
TOML reader has no arrays-of-tables.

Plugin action ids carry the install name, so pet's `switchPet` is
`pet.switchPet`. Palette slots address actions by id and are stored per
user, so two plugins declaring `switch` would collide in someone's
settings file. Core actions carry their own namespaces, so a plugin
cannot shadow one.

Slots persist as `Settings.paletteEntries`, the ordered
`[{ id, enabled }]` shape `barEntries` already uses, plus one addition:
a slot can be pointed at any action in the catalog. A base install has
19 core actions and the tab holds six, so picking which ones land there
is the point.

## Resolution

New: `services/Actions.qml`, the notch's Commands tile, a Command
palette section in the Bar settings pane, the `[action]` manifest
capability, and `tests/test_plugin_action_capability.sh`.

Core actions are open Settings, the keyboard cheatsheet, next theme, and
one per Settings category generated off `SettingsCategories.list`, so a
category added there becomes an action here with no edit.

Two consumers: the notch tile, and
`qs -c aphotic ipc call aphotic action <id>`, which hands keybinds and
scripts every action. The launcher, dashboard and assistant consumers
are `ACT-02`.

Left out: `NOTCH-05`, the keybinds tab, is untouched and still open.

Also fixed: #150 added `pet_action`'s host without adding it to
`APHOTIC_PLUGIN_HOSTED_SURFACES`, so every pet install since has
reported `partial: pet_action surface` for a plugin that works.

To verify: the notch's Commands tab, and Settings > Bar > Command
palette. The pet plugin's own first `[action]` is a companion PR in the
plugins repo.
