### PR TITLE
Settings preset rows can show a choice that is not ready yet

### DIFF
--- a/Configs/quickshell/aphotic/components/SettingsPresetRow.qml
+++ b/Configs/quickshell/aphotic/components/SettingsPresetRow.qml
@@ -6,7 +6,10 @@ import qs.services
 SettingsRow {
     id: root
 
-    required property var presets // [{ value, label }]
+    // `enabled` is optional and defaults true. A preset that sets it
+    // false is drawn dimmed and does not take a click: the row still says
+    // the choice exists without pretending it is ready.
+    required property var presets // [{ value, label, enabled }]
     required property var value
 
     signal selected(value: var)
@@ -22,10 +25,12 @@ SettingsRow {
 
                 required property var modelData
                 readonly property bool active: presetPill.modelData.value === root.value
+                readonly property bool selectable: presetPill.modelData.enabled !== false
 
                 Layout.preferredHeight: 28
                 Layout.preferredWidth: presetLabel.implicitWidth + Tokens.padding.medium * 2
                 radius: Tokens.rounding.full
+                opacity: presetPill.selectable ? 1 : 0.45
                 color: presetPill.active ? Colours.palette.m3primary : Colours.layer(Colours.tPalette.m3surfaceContainer, 2)
 
                 Behavior on color {
@@ -43,10 +48,13 @@ SettingsRow {
                 StateLayer {
                     anchors.fill: parent
                     radius: parent.radius
+                    visible: presetPill.selectable
                 }
 
                 MouseArea {
                     anchors.fill: parent
+                    enabled: presetPill.selectable
+                    cursorShape: presetPill.selectable ? Qt.PointingHandCursor : Qt.ArrowCursor
                     onClicked: root.selected(presetPill.modelData.value)
                 }
             }


### PR DESCRIPTION
## Problem

`SettingsPresetRow` assumes every pill it draws can be picked. A pane
that wants to name a choice the shell knows about but has not built yet
has two bad options: hide it, and the user never learns it is coming, or
show it live and let the click do nothing.

The pet's backend row (`PETS.md` §5) is the first caller to hit this.
Mirroring the active harness is the only tier that exists; the local
Ollama assistant tier is designed and unbuilt.

## Plan

Give a preset an optional `enabled`. Leave it out and nothing changes.

## Resolution

A preset with `enabled: false` draws at 45% opacity, loses its state
layer, keeps the arrow cursor and takes no clicks. Nine lines in
`components/SettingsPresetRow.qml`, no new component, no caller
migration.

Probed windowless against `components/SettingsPresetRow.qml` with three
presets, one of them disabled: compiles, instantiates, no binding
errors, `selectable` reads true/true/false and opacity 100/100/45.