### PR TITLE
wallpaper picker: commit the wallpaper the strip is heading for

### DIFF
--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperFilmstrip.qml
@@ -107,7 +107,14 @@ Item {
         root._previewIndex = -1;
     }
 
+    // The wallpaper being chosen is whatever the strip is heading for, which
+    // is not what _previewIndex holds while the strip is still moving:
+    // _goToIndex clears it on purpose, and a coasting flick never sets it at
+    // all. Reading it directly meant Enter or a click during any movement
+    // closed the picker having applied nothing, leaving the desktop on the
+    // wallpaper before last.
     function _commit(): void {
+        root._previewIndex = root._logical(root._focusIndex);
         root._applyPreview();
         root.screenState.wallpaperPicker = false;
     }
@@ -440,7 +447,7 @@ Item {
                     cursorShape: Qt.PointingHandCursor
                     onEntered: delegate.hovered = true
                     onExited: delegate.hovered = false
-                    onClicked: delegate.index === strip.currentIndex ? root._commit() : root._goToIndex(delegate.index)
+                    onClicked: delegate.index === root._focusIndex ? root._commit() : root._goToIndex(delegate.index)
                 }
             }
         }


### PR DESCRIPTION
## Problem

Pick a wallpaper while the strip is still moving and the picker closes
having applied nothing. The desktop keeps the wallpaper before last while
the card you chose sits centred and glowing, so the preview names one
wallpaper and the strip names another.

#148 fixed the arrow and click paths through `_goToIndex` and left the
commit alone. `_commit()` reads `_previewIndex`, which only `_settle()`
and the glide's `onFinished` ever set, 300ms after the strip comes to
rest. `_goToIndex` clears it on the way in, and a coasting flick never
arms it. So every commit during motion ran `_applyPreview()` on -1 and
returned.

## Plan

Resolve the choice at commit time from `_focusIndex`, which already holds
the glide target while one is in flight and the centred slot otherwise.
`_applyPreview()` still skips the work when that wallpaper is already
active, so committing a strip at rest costs no extra wallust run.

Make a click on the card the strip is gliding toward commit it as well,
rather than hitting `_goToIndex`'s early return.

## Resolution

A headless probe drives the real filmstrip, calls `_commit()` 120ms into
a glide, and reads back `Themes.activeWallpaper`:

```
before   choosing=toast.png    applied=swirls.jpg   WRONG
after    choosing=swirls.jpg   applied=swirls.jpg   OK
```

Same probe, same sequence, only the fix differs. The unfixed run also
missed on Enter after two arrows and on Enter mid-coast, three for three.

Checked along the way and consistent both before and after: the centred
delegate against `_indexAtCenter()` across flick, wheel, arrow and click,
each interrupted mid-flight; `originX` measured 0 throughout; the
backdrop cross-fade over forward and backward coasts and repeated
back-and-forth steps. The strip's index tracking and the band were
already right, which is why #148 did not land this.

71 pytest pass, singleton reachability clean. The filmstrip instantiates
and drives with no warnings and no binding loops.

Wants a visual pass: arrow to a wallpaper and press Enter before the
strip stops, and the desktop should land on the card that was centred.