### PR TITLE
Record which harness and model answered

### DIFF
--- a/Configs/.local/lib/aphotic/agent_hook.py
+++ b/Configs/.local/lib/aphotic/agent_hook.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Aphotic-Hypr contributors
 """aphotic agent hook worker -- see agent_hook.sh for why this is one
 process and why nothing in here is allowed to raise."""
-import json, os, sys, time
+import json, os, re, sys, time
 
 STATE = os.environ.get("APHOTIC_STATE_HOME", os.path.expanduser("~/.local/state/aphotic"))
 SESSIONS = os.path.join(STATE, "agent-sessions")
@@ -14,6 +14,7 @@ KEEP_LINES = 1000
 STALE_SECONDS = 12 * 60 * 60
 MAX_RUNS = 25
 MAX_RUN_BYTES = 2 * 1024 * 1024
+MODEL_TAIL_BYTES = 64 * 1024
 
 EVENT_NAMES = {
     "SessionStart": "session_start",
@@ -101,6 +102,39 @@ def trim():
     atomic_write(EVENTS, "".join(lines))
 
 
+def model_from_transcript(path):
+    """Last model named in the harness transcript, or "" if there is none.
+
+    SessionStart states `model` only when the session started fresh. A
+    session that began with /clear reports no model on any event, so the
+    only local record of what is answering is the transcript the payload
+    points at. Reads the tail rather than the file: transcripts reach
+    hundreds of KB and this runs inside a hook on every tool call.
+    """
+    if not path:
+        return ""
+    try:
+        size = os.path.getsize(path)
+        with open(path, "rb") as fh:
+            if size > MODEL_TAIL_BYTES:
+                fh.seek(size - MODEL_TAIL_BYTES)
+            chunk = fh.read().decode("utf-8", "replace")
+    except OSError:
+        return ""
+    seen = re.findall(r'"model"\s*:\s*"([^"]+)"', chunk)
+    return seen[-1] if seen else ""
+
+
+def cached_session(path):
+    """The last session file written for this session, or {}."""
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 def main():
     try:
         payload = json.load(sys.stdin)
@@ -134,6 +168,27 @@ def main():
             record[field] = value
 
     harness = payload.get("harness") or "claude"
+
+    # The default has to reach the record, not just the session file below.
+    # Claude Code sends no `harness` of its own (the adapters for other
+    # harnesses do), so without this every Claude event is untagged and a
+    # reader cannot tell "this is Claude" from "nobody said".
+    record["harness"] = harness
+
+    session_file = os.path.join(SESSIONS, "%s.json" % session_id)
+    known = cached_session(session_file)
+
+    # Model identity has to outlive the one event that states it: a graph
+    # labels a session node by its model for the session's whole life, and
+    # only SessionStart-from-startup ever carries it. Resolve it once, then
+    # re-state it in the log only when it is new or has changed, so a
+    # long session does not repeat it on every tool call.
+    model = (record.get("model") or known.get("model")
+             or model_from_transcript(payload.get("transcript_path")))
+    if model and model != known.get("model"):
+        record["model"] = model
+    elif "model" in record:
+        del record["model"]
 
     # The Agent tool's own PostToolUse response is the only place Claude Code
     # states which agent id a Task/Agent call spawned. Capturing it here is what
@@ -180,7 +235,6 @@ def main():
     except OSError:
         pass
 
-    session_file = os.path.join(SESSIONS, "%s.json" % session_id)
     try:
         if event == "session_end":
             os.remove(session_file)
@@ -190,6 +244,7 @@ def main():
                 "tool": record.get("tool", ""),
                 "updatedAt": stamp,
                 "harness": harness,
+                "model": model,
             }, separators=(",", ":")) + "\n")
     except OSError:
         pass

--- a/Configs/quickshell/aphotic/services/ai/AgentRoles.qml
+++ b/Configs/quickshell/aphotic/services/ai/AgentRoles.qml
@@ -103,6 +103,75 @@ Singleton {
     // AI-chat-surface audit item in APHOTIC_UNIFIED_VISION.md §4.1.
     readonly property bool hasConfiguredHarness: AiProviders.claudeAvailable || AiProviders.codexAvailable
 
+    // Display casing for harness codename models. A codename cannot be
+    // derived from its id -- "sol" is styled SOL and "luna" is styled Luna
+    // -- so the ones we have seen are listed and anything new falls back to
+    // title case rather than being rendered wrong with confidence.
+    readonly property var _codenames: ({
+        "sol": "SOL",
+        "luna": "Luna",
+        "terra": "Terra",
+        "astra": "Astra"
+    })
+
+    // Suffixes that size a model rather than name it. These read as
+    // "GPT-5.4 mini", never "Mini 5.4", so they must not be mistaken for a
+    // codename.
+    readonly property var _tiers: ["mini", "nano", "pro", "codex", "turbo", "preview"]
+
+    function labelFor(id: string): string {
+        return (root.entries.find(e => e.id === id) ?? {}).label ?? id;
+    }
+
+    // A model id turned into what a person calls the thing. Pure string
+    // work on purpose: the shell has no network and cannot ask a provider
+    // for a display name, so this has to hold up on ids released long
+    // after it was written. `provider` is the backend actually serving the
+    // weights, "" when nothing is known about it.
+    function modelDisplayName(raw: string, provider: string): string {
+        const id = (raw ?? "").trim();
+        if (!id)
+            return "";
+
+        // Locally served weights are named by the weights, not by a vendor
+        // family: the provider is the useful half of "who is answering",
+        // since the same GGUF can be served by any of them.
+        if (provider && root.localityFor(provider) === "local") {
+            let base = id.split(":")[0];
+            const slash = base.lastIndexOf("/");
+            if (slash !== -1)
+                base = base.slice(slash + 1);
+            return base ? `${provider}/${base}` : provider;
+        }
+
+        // Trailing context-window variant, e.g. "[1m]". It is a property of
+        // the session, not of the model, and it shows in the raw id on hover.
+        const bare = id.replace(/\[[^\]]*\]\s*$/, "");
+
+        const claude = bare.match(/^claude-([a-z]+)-(.+)$/i);
+        if (claude) {
+            const family = claude[1];
+            // A dated snapshot suffix is release bookkeeping, not a version.
+            const version = claude[2].replace(/-\d{6,8}$/, "").split("-").join(".");
+            return `${family.charAt(0).toUpperCase()}${family.slice(1)} ${version}`;
+        }
+
+        const gpt = bare.match(/^gpt-([0-9]+(?:\.[0-9]+)*)(?:-(.+))?$/i);
+        if (gpt) {
+            const version = gpt[1];
+            const suffix = (gpt[2] ?? "").toLowerCase();
+            if (!suffix)
+                return `GPT-${version}`;
+            if (root._tiers.includes(suffix))
+                return `GPT-${version} ${suffix}`;
+            const named = root._codenames[suffix]
+                ?? `${suffix.charAt(0).toUpperCase()}${suffix.slice(1)}`;
+            return `${named} ${version}`;
+        }
+
+        return bare;
+    }
+
     FileView {
         path: `${Quickshell.env("HOME")}/Aphotic-Hypr/aphotic.toml`
         watchChanges: true

--- a/tests/test_agent_hook.py
+++ b/tests/test_agent_hook.py
@@ -604,3 +604,163 @@ class TestIntegration:
 if __name__ == "__main__":
     import pytest
     pytest.main([__file__, "-v"])
+
+
+class TestHarnessAndModelIdentity:
+    """Every event says which harness produced it and, once known, which
+    model answered. Both used to be missing: the `claude` default never
+    reached the record, and a session started by /clear reported no model
+    on any event, so a graph could only label it by its session id."""
+
+    def _drive(self, tmp_path, payload, monkeypatch):
+        """Run main() against an isolated state dir and return its events."""
+        state = tmp_path / "state"
+        sessions = state / "agent-sessions"
+        runs = state / "agent-runs"
+        events = state / "agent-events.jsonl"
+        sessions.mkdir(parents=True, exist_ok=True)
+        runs.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(agent_hook, "STATE", str(state))
+        monkeypatch.setattr(agent_hook, "SESSIONS", str(sessions))
+        monkeypatch.setattr(agent_hook, "RUNS", str(runs))
+        monkeypatch.setattr(agent_hook, "EVENTS", str(events))
+
+        import io
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        try:
+            agent_hook.main()
+        except SystemExit:
+            pass
+
+        if not events.exists():
+            return [], sessions
+        lines = [l for l in events.read_text().splitlines() if l]
+        return [json.loads(l) for l in lines], sessions
+
+    def test_claude_events_are_tagged_with_the_default_harness(self, tmp_path, monkeypatch):
+        """Claude Code sends no `harness`, so the default has to be written."""
+        records, _ = self._drive(tmp_path, {
+            "session_id": "s1",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+        }, monkeypatch)
+        assert records[-1]["harness"] == "claude"
+
+    def test_an_adapter_supplied_harness_is_preserved(self, tmp_path, monkeypatch):
+        """A non-Claude adapter states its own harness and keeps it."""
+        records, _ = self._drive(tmp_path, {
+            "session_id": "s1",
+            "hook_event_name": "PreToolUse",
+            "harness": "codex",
+            "tool_name": "Bash",
+        }, monkeypatch)
+        assert records[-1]["harness"] == "codex"
+
+    def test_model_from_payload_is_recorded_and_cached(self, tmp_path, monkeypatch):
+        records, sessions = self._drive(tmp_path, {
+            "session_id": "s1",
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+            "model": "claude-opus-5",
+        }, monkeypatch)
+        assert records[-1]["model"] == "claude-opus-5"
+        cached = json.loads((sessions / "s1.json").read_text())
+        assert cached["model"] == "claude-opus-5"
+
+    def test_model_is_recovered_from_the_transcript_when_absent(self, tmp_path, monkeypatch):
+        """The /clear case: SessionStart names no model, the transcript does."""
+        transcript = tmp_path / "t.jsonl"
+        transcript.write_text(
+            '{"type":"assistant","message":{"model":"claude-sonnet-5"}}\n'
+            '{"type":"assistant","message":{"model":"claude-opus-5"}}\n'
+        )
+        records, _ = self._drive(tmp_path, {
+            "session_id": "s1",
+            "hook_event_name": "SessionStart",
+            "source": "clear",
+            "transcript_path": str(transcript),
+        }, monkeypatch)
+        assert records[-1]["model"] == "claude-opus-5"
+
+    def test_a_known_model_is_not_restated_on_every_event(self, tmp_path, monkeypatch):
+        """Re-stating it per tool call would bloat a size-capped log."""
+        state = tmp_path / "state"
+        sessions = state / "agent-sessions"
+        sessions.mkdir(parents=True, exist_ok=True)
+        (sessions / "s1.json").write_text(json.dumps({
+            "event": "PreToolUse", "tool": "Bash",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "harness": "claude", "model": "claude-opus-5",
+        }))
+        records, _ = self._drive(tmp_path, {
+            "session_id": "s1",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+        }, monkeypatch)
+        assert "model" not in records[-1]
+
+    def test_a_model_switch_mid_session_is_restated(self, tmp_path, monkeypatch):
+        state = tmp_path / "state"
+        sessions = state / "agent-sessions"
+        sessions.mkdir(parents=True, exist_ok=True)
+        (sessions / "s1.json").write_text(json.dumps({
+            "event": "PreToolUse", "tool": "Bash",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "harness": "claude", "model": "claude-opus-5",
+        }))
+        records, _ = self._drive(tmp_path, {
+            "session_id": "s1",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "model": "claude-sonnet-5",
+        }, monkeypatch)
+        assert records[-1]["model"] == "claude-sonnet-5"
+
+
+class TestModelFromTranscript:
+
+    def test_returns_the_last_model_named(self, tmp_path):
+        t = tmp_path / "t.jsonl"
+        t.write_text('{"model":"a"}\n{"model":"b"}\n{"model":"c"}\n')
+        assert agent_hook.model_from_transcript(str(t)) == "c"
+
+    def test_missing_or_empty_path_is_not_an_error(self, tmp_path):
+        assert agent_hook.model_from_transcript("") == ""
+        assert agent_hook.model_from_transcript(str(tmp_path / "nope.jsonl")) == ""
+
+    def test_transcript_without_a_model_yields_empty(self, tmp_path):
+        t = tmp_path / "t.jsonl"
+        t.write_text('{"type":"user","content":"hi"}\n')
+        assert agent_hook.model_from_transcript(str(t)) == ""
+
+    def test_only_the_tail_of_a_large_transcript_is_read(self, tmp_path):
+        """A model named only far from the end is out of the read window --
+        the bound is deliberate, since this runs on every tool call."""
+        t = tmp_path / "t.jsonl"
+        t.write_text('{"model":"stale"}\n' + ("x" * (agent_hook.MODEL_TAIL_BYTES + 4096)) + "\n")
+        assert agent_hook.model_from_transcript(str(t)) == ""
+
+    def test_a_model_within_the_tail_window_is_found(self, tmp_path):
+        t = tmp_path / "t.jsonl"
+        t.write_text(("x" * (agent_hook.MODEL_TAIL_BYTES + 4096)) + '\n{"model":"fresh"}\n')
+        assert agent_hook.model_from_transcript(str(t)) == "fresh"
+
+
+class TestCachedSession:
+
+    def test_reads_back_a_written_session_file(self, tmp_path):
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps({"harness": "codex", "model": "gpt-5.6-sol"}))
+        assert agent_hook.cached_session(str(p))["model"] == "gpt-5.6-sol"
+
+    def test_missing_or_corrupt_file_yields_empty(self, tmp_path):
+        assert agent_hook.cached_session(str(tmp_path / "nope.json")) == {}
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        assert agent_hook.cached_session(str(bad)) == {}
+
+    def test_non_object_json_yields_empty(self, tmp_path):
+        p = tmp_path / "arr.json"
+        p.write_text("[1,2,3]")
+        assert agent_hook.cached_session(str(p)) == {}


### PR DESCRIPTION
## Problem

Nothing in the event log said who was working.

`agent_hook.py` computed `harness = payload.get("harness") or "claude"` but only wrote it to the per-session file, never to the record. Claude Code sends no `harness` of its own, so every Claude event went out untagged and a reader could not tell "this is Claude" from "nobody said". Adapters for other harnesses set it explicitly, so they were fine.

Model was worse. Only a `SessionStart` with `source: startup` carries one, so a session begun with `/clear` had no model on any event, for its whole life. Three of six session starts in my log had none.

There was also no way to turn an id into a name. Nothing in the tree mapped `claude-opus-5[1m]` to anything a person would say.

## Plan

Write the defaulted harness into the record itself.

For the model, use `transcript_path`, which every payload already carries. Read the tail of it, cache the answer in the session file, and restate it in the log only when it changes, so a long session does not repeat it on every tool call.

Add `AgentRoles.modelDisplayName(raw, provider)`. Derive Claude names from the id's shape so new releases need no code change. Codenames need a lookup, since `sol` is styled SOL and `luna` is styled Luna, and neither is derivable. Keep tier suffixes distinct from codenames: `gpt-5.4-mini` reads "GPT-5.4 mini", never "Mini 5.4".

## Resolution

Every event now carries `harness`, and the model resolves for `/clear` sessions:

    {"event":"post_tool_use", ... ,"harness":"claude","model":"claude-opus-5"}

Naming, verified through the headless probe against the real ids in use:

| id | name |
|---|---|
| `claude-opus-5[1m]` | Opus 5 |
| `claude-sonnet-4-6` | Sonnet 4.6 |
| `claude-haiku-4-5-20251001` | Haiku 4.5 |
| `gpt-5.6-sol` | SOL 5.6 |
| `gpt-6-astra` | Astra 6 |
| `gpt-5.4-mini` | GPT-5.4 mini |
| `llama3.1:8b` via Ollama | ollama/llama3.1 |

The hook reads at most 64KB of a transcript and only while the model is still unknown.

14 new tests, 44 in that file, 85 in the suite. 11 of the new ones fail against the old code.

The display side of this is `T-Crypt/aphotic-plugins#fix/agent-graph-identity`.