### PR TITLE
Workspace keybind, bound only while a plugin provides the plane

### DIFF
--- a/Configs/hypr/keybinds.lua
+++ b/Configs/hypr/keybinds.lua
@@ -13,6 +13,12 @@ hl.bind(mainMod .. " + space", hl.dsp.exec_cmd("qs -c aphotic ipc call launcher 
 hl.bind(mainMod .. " + S", hl.dsp.exec_cmd('grim -g "$(slurp)" - | swappy -f -'), { description = "Screenshot: select area" })
 hl.bind(mainMod .. " + W", hl.dsp.exec_cmd("qs -c aphotic ipc call wallpaperpicker toggle"), { description = "Wallpaper picker (current theme)" })
 hl.bind(mainMod .. " + CTRL + W", hl.dsp.exec_cmd("qs -c aphotic ipc call launcher openWallpapers"), { description = "Browse wallpapers (all themes)" })
+-- SUPER + SHIFT + W is the Workspace plane, and it is deliberately not
+-- bound here. That surface only exists while a plugin registers a
+-- `ui.workspace`, so the shell binds and unbinds the combo at runtime as
+-- plugins come and go (services/WorkspaceKeybind.qml). Leave it free, or
+-- your own bind will be replaced the next time a workspace plugin is
+-- enabled.
 hl.bind(mainMod .. " + comma", hl.dsp.exec_cmd("aphotic theme prev"), { description = "Previous theme" })
 hl.bind(mainMod .. " + period", hl.dsp.exec_cmd("aphotic theme next"), { description = "Next theme" })
 hl.bind(mainMod .. " + B", hl.dsp.exec_cmd("systemctl --user restart aphotic-shell.service"), { description = "Restart Aphotic shell" })

--- a/Configs/quickshell/aphotic/services/WorkspaceKeybind.qml
+++ b/Configs/quickshell/aphotic/services/WorkspaceKeybind.qml
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023-2026 Trevin Tindall (T-Crypt) and Aphotic-Hypr contributors
+
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+
+// The Workspace surface's keybind, bound only while something is there
+// to open.
+//
+// Every other bind this shell ships is a line in `Configs/hypr/
+// keybinds.lua`, because every other surface exists on every install.
+// The Workspace plane does not: `ui.workspace` is a plugin capability,
+// and with no enabled plugin registering one there is no window, no
+// action and nothing for a key to do. A static line would still be
+// listed in the SUPER+K cheatsheet and would still swallow the combo,
+// promising a surface the install does not have.
+//
+// So the bind is made at runtime and removed the moment the last
+// workspace plugin goes. `HyprKeybinds` reads `hyprctl binds -j` rather
+// than parsing keybinds.lua, so the cheatsheet picks this up and drops
+// it with no help from here.
+//
+// Nothing is written to the user's config. This is a live compositor
+// keyword and it dies with the Hyprland session, which is what makes it
+// safe to assert on every shell start.
+//
+// This singleton acts on its own rather than answering a reader, so it
+// needs a construction site in `shell.qml`'s `_residentSingletons` or
+// none of the below ever runs. See CLAUDE.md.
+Singleton {
+    id: root
+
+    // Free on a stock install: SUPER+W is the wallpaper picker and
+    // SUPER+CTRL+W browses every theme's wallpapers, so the third W is
+    // the one still going spare and keeps the surface openers together.
+    readonly property string combo: "SUPER + SHIFT + W"
+    readonly property string legacyCombo: "SUPER SHIFT, W"
+
+    // Read back by the cheatsheet, so it has to bucket into "Aphotic
+    // Shell" under HyprKeybinds' own `_categoryFor` heuristic. Anything
+    // starting "Open " lands in Apps & System instead.
+    readonly property string description: "Toggle plugin workspace"
+    readonly property string command: "qs -c aphotic ipc call workspace toggle"
+
+    readonly property bool wanted: PluginRegistry.surfacesFor("workspace").length > 0
+
+    // "", "lua" or "legacy". Which form the bind should be in right now,
+    // and the reason this is a property rather than a branch inside
+    // _sync(): `wanted` and `Hypr.usingLua` settle independently, one on
+    // the plugin registry loading and one on the Hyprland connection
+    // coming up. Reading the parser once, at whatever moment the
+    // registry happened to finish, silently emitted the refused form on
+    // a Lua install and left the combo unbound with nothing logged.
+    // Watching both means the wrong guess corrects itself.
+    readonly property string desiredForm: !root.wanted ? "" : (Hypr.usingLua ? "lua" : "legacy")
+    readonly property string appliedForm: root._applied
+    readonly property bool bound: root._applied.length > 0
+
+    property string _applied: ""
+
+    // The two config parsers take this differently, the same split
+    // `StateSnapshot.monitorCommand()` already documents: `hyprctl
+    // keyword` is refused outright under the Lua parser ("keyword can't
+    // work with non-legacy parsers"), where the runtime equivalent is
+    // `hl.bind` through `hyprctl eval`. Both forms verified live,
+    // including that `hyprctl binds -j` echoes the description back so
+    // the cheatsheet can read it.
+    function _bindArgs(form: string): var {
+        if (form === "lua")
+            return ["hyprctl", "eval", `hl.bind("${root.combo}", hl.dsp.exec_cmd("${root.command}"), { description = "${root.description}" })`];
+        return ["hyprctl", "keyword", "bindd", `${root.legacyCombo}, ${root.description}, exec, ${root.command}`];
+    }
+
+    function _unbindArgs(form: string): var {
+        if (form === "lua")
+            return ["hyprctl", "eval", `hl.unbind("${root.combo}")`];
+        return ["hyprctl", "keyword", "unbind", root.legacyCombo];
+    }
+
+    // Binding a combo replaces whatever held it, so switching form needs
+    // no unbind of its own. Only going back to nothing does.
+    function _sync(): void {
+        const want = root.desiredForm;
+        const had = root._applied;
+        if (want === had)
+            return;
+        root._applied = want;
+        binder.command = want.length > 0 ? root._bindArgs(want) : root._unbindArgs(had);
+        binder.running = false;
+        binder.running = true;
+    }
+
+    onDesiredFormChanged: root._sync()
+    Component.onCompleted: root._sync()
+
+    // A shell that exits leaves the bind pointing at an IPC target that
+    // has gone. Hyprland outlives the shell, so this is the one moment
+    // worth cleaning up at; a kill -9 skips it and the next start
+    // re-asserts the same combo over the stale one.
+    Component.onDestruction: {
+        if (root._applied.length > 0)
+            Quickshell.execDetached(root._unbindArgs(root._applied));
+    }
+
+    Process {
+        id: binder
+    }
+}

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -39,6 +39,7 @@ singleton Players 1.0 Players.qml
 singleton Time 1.0 Time.qml
 singleton Toaster 1.0 Toaster.qml
 singleton Wallpapers 1.0 Wallpapers.qml
+singleton WorkspaceKeybind 1.0 WorkspaceKeybind.qml
 CavaProvider 1.0 CavaProvider.qml
 BeatTracker 1.0 BeatTracker.qml
 CircularBuffer 1.0 CircularBuffer.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -494,7 +494,7 @@ ShellRoot {
     // services/ that runs on its own rather than answering a reader
     // belongs in this list, and tests/test_singleton_reachability.py
     // fails the build if it does not.
-    readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift, SafeMode]
+    readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift, SafeMode, WorkspaceKeybind]
 
     // The profile substrate's inspection/drive surface (Phase 0 --
     // docs/APHOTIC_UNIFIED_VISION.md section 3.5). Lives here rather than

--- a/README.md
+++ b/README.md
@@ -295,6 +295,20 @@ Plugins can be installed, enabled, disabled, and removed independently.
 
 The core desktop does not require optional plugins to function.
 
+A plugin can also claim the **Workspace plane**, a near-full-screen
+surface for a tool that needs room to work. The plane belongs to the
+shell and the content belongs to the plugin, so several plugins can
+register one and the plane lists them down its left edge.
+
+With no such plugin enabled there is no plane, no window, and no
+keybind: <kbd>Super</kbd> + <kbd>Shift</kbd> + <kbd>W</kbd> is bound
+when the first one arrives and released when the last one goes, so the
+combo stays yours on an install that has none.
+
+```sh
+qs -c aphotic ipc call workspace toggle
+```
+
 Repository: [T-Crypt/aphotic-plugins](https://github.com/T-Crypt/aphotic-plugins)
 
 ## Desktop Pets
@@ -544,7 +558,9 @@ treating system resources as static configuration.
 
 ## Keybindings
 
-All keybinds live in one place — [`Configs/hypr/keybinds.lua`](Configs/hypr/keybinds.lua) — grouped exactly as below. Every `qs -c aphotic ipc call ...` target the shell exposes has a keybind; anything below not bound to a key is intentionally IPC-only (scriptable, but not meant to be memorized).
+Keybinds live in one place, [`Configs/hypr/keybinds.lua`](Configs/hypr/keybinds.lua), grouped exactly as below. Every `qs -c aphotic ipc call ...` target the shell exposes has a keybind; anything below not bound to a key is intentionally IPC-only (scriptable, but not meant to be memorized).
+
+One exception: the Workspace plane is bound by the shell at runtime, because it only exists while a plugin provides one. See [Plugin System](#plugin-system).
 
 <details>
 <summary><strong>Launcher</strong></summary>
@@ -586,6 +602,7 @@ All keybinds live in one place — [`Configs/hypr/keybinds.lua`](Configs/hypr/ke
 | <kbd>Super</kbd> + <kbd>M</kbd> | `wlogout` (fallback power menu) |
 | <kbd>Super</kbd> + <kbd>B</kbd> | Restart Quickshell |
 | <kbd>Super</kbd> + <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd> | Cycle bar style (Full → Dock → Taskbar → Minimal → Capsule) |
+| <kbd>Super</kbd> + <kbd>Shift</kbd> + <kbd>W</kbd> | Workspace plane. Bound only while a plugin registers one, so on an install with none the combo stays free |
 
 </details>
 

--- a/tests/test_workspace_host.sh
+++ b/tests/test_workspace_host.sh
@@ -9,6 +9,9 @@ SHELL="$ROOT/Configs/quickshell/aphotic/shell.qml"
 ACTIONS="$ROOT/Configs/quickshell/aphotic/services/Actions.qml"
 CONTENT="$ROOT/Configs/quickshell/aphotic/modules/workspace/WorkspaceContent.qml"
 WINDOW="$ROOT/Configs/quickshell/aphotic/modules/workspace/WorkspaceWindow.qml"
+KEYBIND="$ROOT/Configs/quickshell/aphotic/services/WorkspaceKeybind.qml"
+QMLDIR="$ROOT/Configs/quickshell/aphotic/services/qmldir"
+LUA="$ROOT/Configs/hypr/keybinds.lua"
 
 [[ -f "$CONTENT" ]] || fail "Workspace content module is missing"
 [[ -f "$WINDOW" ]] || fail "Workspace window module is missing"
@@ -26,5 +29,43 @@ grep -qE 'target: "workspace"' "$SHELL" || fail "shell has no Workspace IPC targ
 grep -qE 'width: content.width' "$WINDOW" || fail "Workspace panel does not shield its backdrop from interior clicks"
 grep -qE 'id: "workspace\.open"' "$ACTIONS" || fail "Workspace action is missing"
 grep -qE 'PluginRegistry\.surfacesFor\("workspace"\)' "$ACTIONS" || fail "Workspace action is not availability-gated"
+
+# --- The keybind ------------------------------------------------------
+#
+# Bound at runtime rather than in keybinds.lua, because the surface only
+# exists while a plugin registers a ui.workspace.
+
+[[ -f "$KEYBIND" ]] || fail "Workspace keybind service is missing"
+grep -qE 'PluginRegistry\.surfacesFor\("workspace"\)\.length > 0' "$KEYBIND" || fail "Workspace keybind is not gated on a registered surface"
+grep -qE 'singleton WorkspaceKeybind 1\.0 WorkspaceKeybind\.qml' "$QMLDIR" || fail "Workspace keybind singleton is not exported"
+
+# A pragma Singleton nothing names is never constructed, and nothing
+# about that failure is visible. This one acts on its own, so it needs a
+# construction site. CLAUDE.md, and WallpaperCycle and DevDrift both
+# shipped broken this way.
+grep -qE '_residentSingletons:.*WorkspaceKeybind' "$SHELL" || fail "Workspace keybind singleton has no construction site"
+
+# hyprctl keyword is refused under the Lua parser, and hl.bind is not
+# available under the legacy one. Both paths have to exist.
+grep -qE 'hl\.bind\(' "$KEYBIND" || fail "Workspace keybind has no Lua-parser bind path"
+grep -qE 'hl\.unbind\(' "$KEYBIND" || fail "Workspace keybind has no Lua-parser unbind path"
+grep -qE 'keyword", "bindd' "$KEYBIND" || fail "Workspace keybind has no legacy-parser bind path"
+grep -qE 'keyword", "unbind' "$KEYBIND" || fail "Workspace keybind has no legacy-parser unbind path"
+
+# `wanted` and `Hypr.usingLua` settle independently. Reading the parser
+# once, whenever the registry happened to finish, emitted the refused
+# form on a Lua install and left the combo unbound with nothing logged.
+grep -qE 'Hypr\.usingLua' "$KEYBIND" || fail "Workspace keybind does not pick a parser form"
+grep -qE 'onDesiredFormChanged' "$KEYBIND" || fail "Workspace keybind does not re-sync when the parser resolves"
+
+# HyprKeybinds buckets the cheatsheet by matching this text. Anything
+# starting "Open " lands in Apps & System instead of Aphotic Shell.
+grep -qE 'description: "Toggle plugin workspace"' "$KEYBIND" || fail "Workspace keybind description changed without checking its cheatsheet category"
+
+# The combo has to stay free in the static file, or the two fight.
+grep -qE 'SUPER \+ SHIFT \+ W is the Workspace plane' "$LUA" || fail "keybinds.lua does not reserve the Workspace combo"
+if grep -E '^hl\.bind' "$LUA" | grep -qE 'SHIFT \+ W"'; then
+    fail "keybinds.lua statically binds the combo the shell manages at runtime"
+fi
 
 echo "PASS: tests/test_workspace_host.sh"


### PR DESCRIPTION
## Problem

The Workspace plane had no keybind. `qs -c aphotic ipc call workspace
toggle` worked, and `workspace.open` was already an availability-gated
action, but there was no key.

Adding a line to `Configs/hypr/keybinds.lua` would have been wrong.
Every other surface this shell binds exists on every install; the
Workspace plane only exists while a plugin registers a `ui.workspace`.
A static line would sit in the SUPER+K cheatsheet on every machine and
swallow the combo, promising a surface most installs do not have.

## Plan

Bind it at runtime instead, from the same registry check the plane, the
window and the action already gate on. Bound when the first workspace
plugin is enabled, released when the last one goes.

`HyprKeybinds` reads `hyprctl binds -j` rather than parsing
`keybinds.lua`, so the cheatsheet picks the bind up and drops it with no
help from this change.

Nothing is written to the user's config. A runtime keyword dies with the
Hyprland session, which is what makes it safe to assert on every shell
start and means an uninstall leaves nothing behind.

## Resolution

`services/WorkspaceKeybind.qml`, a resident singleton, plus its
construction site in `shell.qml`. A `pragma Singleton` nothing names is
never built and says nothing about it, and this one acts on its own, so
the test asserts the construction site as well as the file.

Two parser forms, the same split `StateSnapshot.monitorCommand()`
already documents for monitors: `hyprctl keyword` is refused outright
under the Lua parser, where `hl.bind` through `hyprctl eval` is the
runtime equivalent. Both verified live, including that `hyprctl binds
-j` echoes the description back so the cheatsheet can read it.

The form is a property rather than a branch inside the sync, because the
plugin registry and the Hyprland connection settle independently.
Reading the parser once, at whatever moment the registry happened to
finish, emitted the refused form on a Lua install and left the combo
unbound with nothing logged. Watching both corrects the wrong guess. A
probe caught this before it shipped.

SUPER+SHIFT+W is free on a stock install, and `keybinds.lua` carries a
comment reserving it so a later static bind does not fight this one. The
description is "Toggle plugin workspace" because `HyprKeybinds` buckets
the cheatsheet by matching that text, and anything starting "Open "
lands under Apps & System instead of Aphotic Shell.

Verified with a windowless probe on the live compositor: registry
resolves one surface, parser resolves to Lua, the bind lands with
modmask 65 on W under the `__lua` dispatcher, and the cheatsheet reads
it back with its description. The probe's bind was removed afterwards.
Full suite green, 46 tests.

README and the wiki's Keybindings and Plugin System pages carry it. The
wiki edit is written and not pushed.
