### PR TITLE
Bar icons focus and cycle an app's windows

### DIFF
--- a/Configs/quickshell/aphotic/modules/bar/DockAppIcon.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockAppIcon.qml
@@ -42,7 +42,7 @@ Item {
         stateOpacity: root.showHover && containsMouse ? 0.08 : 0
         onClicked: {
             if (root.item.windows.length > 0)
-                WindowList.focus(root.item.windows[0].address);
+                WindowList.cycleWindows(root.item.windows);
             else
                 root.item.entry?.execute();
         }

--- a/Configs/quickshell/aphotic/modules/bar/TaskbarBar.qml
+++ b/Configs/quickshell/aphotic/modules/bar/TaskbarBar.qml
@@ -237,9 +237,14 @@ Item {
         StateLayer {
             anchors.fill: parent
             radius: parent.radius
-            onClicked: {
-                if (item.group.windows.length === 1) {
-                    WindowList.focus(item.group.windows[0].address);
+            // StateLayer is a MouseArea and takes LeftButton only by
+            // default. Left-click walks the group's windows one at a
+            // time; the list of them all moved to right-click, since a
+            // popout on every click is in the way of the common case.
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: event => {
+                if (event.button === Qt.LeftButton || item.group.windows.length === 1) {
+                    WindowList.cycleWindows(item.group.windows);
                     return;
                 }
                 const popouts = item.taskbarRoot.popouts;

--- a/Configs/quickshell/aphotic/modules/bar/components/Media.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/Media.qml
@@ -46,7 +46,7 @@ StyledRect {
             return cls.length > 0 && (cls.includes(identity.toLowerCase()) || identity.toLowerCase().includes(cls));
         });
         if (win) {
-            Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ address = "${win.address}" })` : `focuswindow address:${win.address}`);
+            WindowList.focus(win.address);
             return;
         }
 

--- a/Configs/quickshell/aphotic/modules/launcher/WindowItem.qml
+++ b/Configs/quickshell/aphotic/modules/launcher/WindowItem.qml
@@ -18,8 +18,7 @@ Item {
     implicitHeight: Tokens.sizes.launcher.itemHeight
 
     function execute(): void {
-        const address = root.modelData.address;
-        Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ address = "${address}" })` : `focuswindow address:${address}`);
+        WindowList.focus(root.modelData.address);
     }
 
     StateLayer {

--- a/Configs/quickshell/aphotic/services/WindowList.qml
+++ b/Configs/quickshell/aphotic/services/WindowList.qml
@@ -51,7 +51,31 @@ Singleton {
         return seen;
     }
 
+    // Quickshell reports an address with no `0x`, Hyprland's `address:`
+    // selector requires one, and the Lua dispatcher takes a window
+    // selector string rather than an address key. Getting any of the
+    // three wrong fails silently: Hyprland.dispatch() reports nothing
+    // back. Every focus-a-window path goes through here for that reason.
     function focus(address: string): void {
-        Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ address = "${address}" })` : `focuswindow address:${address}`);
+        if (!address)
+            return;
+        const selector = `address:${address.startsWith("0x") ? address : "0x" + address}`;
+        Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ window = "${selector}" })` : `focuswindow ${selector}`);
+    }
+
+    // Walk one app's windows a click at a time, wherever they live. The
+    // focused window is the anchor, so a second click moves on rather
+    // than bouncing back to the first; with none of them focused the
+    // walk starts at the top. Order is `Hypr.toplevels`' own, which is
+    // stable while no window opens or closes.
+    function cycleWindows(windows: var): void {
+        if (!windows?.length)
+            return;
+        const at = windows.findIndex(w => w.focused);
+        root.focus(windows[(at + 1) % windows.length].address);
+    }
+
+    function cycle(appClass: string): void {
+        root.cycleWindows(root.windowsForClass(appClass));
     }
 }


### PR DESCRIPTION
## Problem

Clicking a window focused nothing, anywhere in the shell, on any Hyprland running a Lua config. Dock icons, taskbar items, the task-group popout, media click-to-focus, the launcher's window rows and `AgentWindowFocus` were all dead, and `Hyprland.dispatch()` reports nothing back to QML when the compositor rejects a request, so it failed in silence.

Two faults stacked, which is why reading either half alone looks fine.

1. `WindowList.focus()` sent `hl.dsp.focus({ address = "..." })`. Hyprland 0.56 answers `hl.focus: unrecognized arguments. Expected one of: direction, monitor, window, urgent_or_last, last`. The form that returns `ok` is `hl.dsp.focus({ window = "address:0x<addr>" })`.
2. Quickshell reports `Toplevel.address` without the `0x` prefix (`561474185fe0`), verified with a headless probe. Hyprland's `address:` selector requires it. The legacy branch, `focuswindow address:<addr>`, was unprefixed the same way.

`modules/bar/components/Media.qml` and `modules/launcher/WindowItem.qml` had each inlined their own copy of that dispatch rather than calling `WindowList.focus()`, so one bug lived in three places.

## Plan

Fix the selector and normalise the address in `WindowList.focus()`, then route the two inlined copies through it. Add `cycleWindows()` on top: clicking an app icon walks that app's windows a click at a time, anchored on whichever one holds focus, wrapping at the end. On the taskbar that takes the left button, and the group list moves to right-click, since a popout on every click sits in the way of the common case. The dock has no popout host at all, so it just cycles.

Workspace focus was checked at the same time and is healthy. `hl.dsp.focus({ workspace = ... })` returns `ok` for a quoted name, a bare id and a relative `r+1`, so none of those call sites changed.

## Resolution

Five files, one behavioural change.

- `services/WindowList.qml` builds a prefixed `address:` selector and picks the right dispatch form for both config styles. `cycleWindows()` and `cycle()` added.
- `DockAppIcon.qml` and `TaskbarBar.qml` cycle instead of taking the first window.
- `Media.qml` and `launcher/WindowItem.qml` call `WindowList.focus()`.

Proved end to end against five `kitty` windows spread over workspaces 4, 7, 3 and 5: each cycle landed on the next window in order and switched workspace to reach it. Every changed file compiles and instantiates under the headless probe, and the suite is green at 85 passed.

Needs a live look on a real desktop.