### PR TITLE
Alt+Tab switcher that does not move focus while you cycle

### DIFF
--- a/Configs/hypr/keybinds.lua
+++ b/Configs/hypr/keybinds.lua
@@ -84,9 +84,107 @@ hl.bind(mainMod .. " + CTRL + F", hl.dsp.window.pin(), { description = "Pin wind
 hl.bind(mainMod .. " + CTRL + H", hl.dsp.group.prev(), { description = "Previous window in group" })
 hl.bind(mainMod .. " + CTRL + L", hl.dsp.group.next(), { description = "Next window in group" })
 
--- Alt-tab window switcher
-hl.bind("ALT + Tab",         hl.dsp.window.cycle_next(), { description = "Cycle to next window" })
-hl.bind("ALT + SHIFT + Tab", hl.dsp.window.cycle_next({ next = false }), { description = "Cycle to previous window" })
+-- Alt-tab window switcher (Quickshell overlay, modules/switcher)
+--
+-- Hyprland's own `window.cycle_next` focuses on every press, so it
+-- rewrites the focus history it is walking: press ALT+Tab twice and you
+-- are back where you started. This binds a submap instead. ALT+Tab opens
+-- the overlay, which snapshots every window once, and every key below
+-- moves a selection inside that snapshot without touching the
+-- compositor. Focus moves once, on commit.
+--
+-- The submap is what makes releasing ALT mean something. Hyprland
+-- reports the release; nothing has to guess at it from key state.
+local switcher_cmd = "qs -c aphotic ipc call switcher"
+local switcher_release_watch = nil
+
+local function switcher_stop_watch()
+    if switcher_release_watch then
+        switcher_release_watch:set_enabled(false)
+        switcher_release_watch = nil
+    end
+end
+
+local function switcher_finish(action)
+    switcher_stop_watch()
+    hl.exec_cmd(switcher_cmd .. " " .. action)
+    hl.dispatch(hl.dsp.submap("reset"))
+end
+
+-- The release bind below is the fast path and handles every normal
+-- chord. This covers the one case it cannot see: ALT let go so quickly
+-- that it was already up before the submap existed, which leaves no
+-- release event for anything in the submap to catch. Four ticks of grace
+-- first, or the poll reads the key state from before the submap was
+-- entered and commits on the opening press.
+local function switcher_watch_release()
+    switcher_stop_watch()
+    local ticks = 0
+    switcher_release_watch = hl.timer(function()
+        if hl.get_current_submap() ~= "aphotic-switcher" then
+            switcher_stop_watch()
+            return
+        end
+        ticks = ticks + 1
+        if ticks < 4 then return end
+        if not hl.is_key_down("Alt_L") and not hl.is_key_down("Alt_R") then
+            switcher_finish("commit")
+        end
+    end, { timeout = 25, type = "repeat" })
+end
+
+hl.define_submap("aphotic-switcher", function()
+    -- Bound both bare and with ALT held, because the whole surface is
+    -- normally driven with a thumb still on ALT.
+    local function act(key, action)
+        local cmd = hl.dsp.exec_cmd(switcher_cmd .. " " .. action)
+        hl.bind(key, cmd)
+        hl.bind("ALT + " .. key, cmd)
+    end
+
+    act("Tab", "next")
+    act("SHIFT + Tab", "prev")
+
+    -- Left/right walk workspaces, up/down walk that workspace's windows.
+    for _, dir in ipairs({ "left", "right", "up", "down" }) do
+        act(dir, "move " .. dir)
+    end
+
+    -- Home row, one key per workspace: a s d f g h j k l ;
+    local ws_keys = { "a", "s", "d", "f", "g", "h", "j", "k", "l", "semicolon" }
+    local ws_names = { "a", "s", "d", "f", "g", "h", "j", "k", "l", ";" }
+    for i, key in ipairs(ws_keys) do
+        act(key, "workspace " .. ws_names[i])
+    end
+
+    -- The 1-9 badges on each window in the selected workspace.
+    for i = 1, 9 do
+        act(tostring(i), "window " .. i)
+    end
+
+    -- Releasing ALT commits. This is the path that runs almost always;
+    -- switcher_watch_release above only exists for the chord that ends
+    -- before the submap starts.
+    hl.bind("Alt_L", function() switcher_finish("commit") end, { release = true })
+    hl.bind("Alt_R", function() switcher_finish("commit") end, { release = true })
+
+    for _, key in ipairs({ "Return", "KP_Enter", "space" }) do
+        hl.bind(key, function() switcher_finish("commit") end)
+        hl.bind("ALT + " .. key, function() switcher_finish("commit") end)
+    end
+
+    hl.bind("Escape", function() switcher_finish("cancel") end)
+    hl.bind("ALT + Escape", function() switcher_finish("cancel") end)
+end)
+
+local function switcher_open(action)
+    hl.exec_cmd(switcher_cmd .. " " .. action)
+    hl.dispatch(hl.dsp.submap("aphotic-switcher"))
+    switcher_watch_release()
+end
+
+hl.bind("ALT + Tab",         function() switcher_open("next") end, { description = "Cycle to next window" })
+hl.bind("ALT + SHIFT + Tab", function() switcher_open("prev") end, { description = "Cycle to previous window" })
 
 -- Media keys (mpris — Quickshell's own player service, works with any
 -- MPRIS-capable player, not just one hardcoded to a specific app)

--- a/Configs/quickshell/aphotic/modules/switcher/SwitcherWindow.qml
+++ b/Configs/quickshell/aphotic/modules/switcher/SwitcherWindow.qml
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023-2026 Trevin Tindall (T-Crypt) and Aphotic-Hypr contributors
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Wayland
+import qs.config
+import qs.components
+import qs.services
+
+// The ALT+Tab surface. Reads Switcher and never writes to it except
+// through the same functions the keybinds call, so a click and a
+// keystroke go down one path.
+//
+// Deliberately takes no keyboard focus. Hyprland is in a submap for as
+// long as this is up (Configs/hypr/keybinds.lua), which means it, not
+// this window, sees the ALT release -- and a layer surface that grabbed
+// the keyboard mid-chord would have to guess at a key it never saw
+// pressed.
+PanelWindow {
+    id: root
+
+    required property var modelData
+    screen: modelData
+
+    // One monitor shows the switcher: the one that was focused when it
+    // opened. The others stay as they are rather than each drawing their
+    // own copy of the same snapshot.
+    visible: Switcher.open && Switcher.monitorName === (Hypr.monitorFor(root.modelData)?.name ?? "")
+
+    WlrLayershell.namespace: "aphotic-switcher"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+    WlrLayershell.exclusionMode: ExclusionMode.Ignore
+    color: "transparent"
+
+    anchors.top: true
+    anchors.bottom: true
+    anchors.left: true
+    anchors.right: true
+
+    implicitWidth: screen.width
+    implicitHeight: screen.height
+
+    // Cards are sized to fill the panel's width rather than to a fixed
+    // height, so two workspaces get big readable previews and eight
+    // still fit on one line without a scrollbar.
+    readonly property real panelWidth: Math.min(root.width - Tokens.padding.extraExtraLarge * 2, 1500)
+    readonly property real cardsWidth: root.panelWidth - Tokens.padding.extraLarge * 2
+    readonly property real aspectSum: Switcher.cards.reduce((sum, c) => sum + c.rect.width / c.rect.height, 0)
+    readonly property real cardHeight: {
+        const n = Switcher.cards.length;
+        if (n === 0 || root.aspectSum <= 0)
+            return 0;
+        const spacing = Tokens.spacing.medium * (n - 1);
+        return Math.min(240, (root.cardsWidth - spacing) / root.aspectSum);
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: Switcher.close()
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Qt.alpha(Colours.palette.m3shadow, 0.55)
+    }
+
+    StyledClippingRect {
+        id: panel
+
+        anchors.centerIn: parent
+        width: root.panelWidth
+        implicitHeight: content.implicitHeight + Tokens.padding.extraLarge * 2
+        radius: Tokens.rounding.extraLarge
+        color: Colours.tPalette.m3surfaceContainer
+        border.width: Config.border.thickness
+        border.color: Colours.palette.m3outlineVariant
+
+        // Swallow clicks on the panel so they don't reach the
+        // cancel-on-click-outside handler behind it.
+        MouseArea {
+            anchors.fill: parent
+        }
+
+        DepthGradient {
+            anchors.fill: parent
+            radius: panel.radius
+            baseColour: panel.color
+        }
+
+        ColumnLayout {
+            id: content
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Tokens.padding.extraLarge
+            spacing: Tokens.spacing.large
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.medium
+
+                MaterialIcon {
+                    text: "swap_horiz"
+                    fontStyle: Tokens.font.icon.large
+                    color: Colours.palette.m3primary
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Switch window")
+                    font: Tokens.font.title.large
+                }
+
+                StyledText {
+                    text: qsTr("%n window(s)", "", Switcher.windows.length)
+                    color: Colours.palette.m3onSurfaceVariant
+                    font: Tokens.font.label.medium
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                spacing: Tokens.spacing.medium
+
+                Repeater {
+                    model: Switcher.cards
+
+                    WorkspaceCard {
+                        required property var modelData
+
+                        card: modelData
+                        cardHeight: root.cardHeight
+                        active: Switcher.currentWorkspace === modelData.id
+                    }
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.medium
+
+                AppIcon {
+                    visible: !!Switcher.current
+                    appClass: Switcher.current?.appClass ?? ""
+                    size: 24
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    elide: Text.ElideRight
+                    font: Tokens.font.body.large
+                    text: Switcher.current ? Switcher.current.title : qsTr("Workspace %1").arg(Switcher.selectedWorkspace)
+                }
+
+                StyledText {
+                    text: Switcher.current ? Switcher.current.appClass : qsTr("empty desktop")
+                    color: Colours.palette.m3onSurfaceVariant
+                    font: Tokens.font.label.medium
+                }
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.label.small
+                text: qsTr("Tab cycle  ·  A-; workspace  ·  1-9 window  ·  arrows move  ·  release Alt to switch  ·  Esc cancel")
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/switcher/WindowTile.qml
+++ b/Configs/quickshell/aphotic/modules/switcher/WindowTile.qml
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023-2026 Trevin Tindall (T-Crypt) and Aphotic-Hypr contributors
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import qs.config
+import qs.components
+import qs.services
+
+// One window, drawn where it actually sits on its monitor. The parent
+// card hands over the scale factor; everything here is that scale
+// applied to the rectangle Hyprland reported at snapshot time, so the
+// preview is the desktop rather than a list pretending to be one.
+StyledRect {
+    id: root
+
+    required property var win
+    required property var rect
+    required property real scale
+    required property int badge
+    required property bool selected
+
+    x: (root.win.x - root.rect.x) * root.scale
+    y: (root.win.y - root.rect.y) * root.scale
+    width: Math.max(18, root.win.width * root.scale)
+    height: Math.max(14, root.win.height * root.scale)
+
+    radius: Tokens.rounding.small
+    color: root.selected ? Qt.alpha(Colours.palette.m3primary, 0.28) : Colours.layer(Colours.palette.m3surfaceContainer, 2)
+    border.width: root.selected ? 2 : 1
+    border.color: root.selected ? Colours.palette.m3primary : Colours.palette.m3outlineVariant
+
+    AppIcon {
+        anchors.centerIn: parent
+        appClass: root.win.appClass
+        size: Math.max(14, Math.min(28, Math.min(root.width, root.height) * 0.45))
+        colour: Colours.palette.m3onSurface
+    }
+
+    // Only nine badges exist, so a card with more windows than that
+    // stops numbering rather than showing keys that do nothing.
+    StyledRect {
+        visible: root.badge > 0 && root.badge <= 9
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.margins: 3
+        width: 15
+        height: 15
+        radius: Tokens.rounding.full
+        color: root.selected ? Colours.palette.m3primary : Colours.layer(Colours.palette.m3surfaceContainer, 3)
+
+        StyledText {
+            anchors.centerIn: parent
+            text: root.badge
+            color: root.selected ? Colours.palette.m3onPrimary : Colours.palette.m3onSurfaceVariant
+            font: Tokens.font.label.small
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        onEntered: Switcher.selectAddress(root.win.address)
+        onClicked: {
+            Switcher.selectAddress(root.win.address);
+            Switcher.commit();
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/switcher/WorkspaceCard.qml
+++ b/Configs/quickshell/aphotic/modules/switcher/WorkspaceCard.qml
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023-2026 Trevin Tindall (T-Crypt) and Aphotic-Hypr contributors
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import qs.config
+import qs.components
+import qs.services
+
+// One workspace as a miniature of its own monitor, at that monitor's
+// real aspect ratio -- an ultrawide reads as an ultrawide next to a
+// 16:9, which is the only way the window outlines inside mean anything.
+StyledClippingRect {
+    id: root
+
+    required property var card
+    required property real cardHeight
+    required property bool active
+
+    readonly property real scale: root.cardHeight / root.card.rect.height
+
+    implicitHeight: root.cardHeight
+    implicitWidth: Math.round(root.card.rect.width * root.scale)
+
+    radius: Tokens.rounding.large
+    color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
+    border.width: root.active ? 2 : Config.border.thickness
+    border.color: root.active ? Colours.palette.m3primary : Colours.palette.m3outlineVariant
+
+    Repeater {
+        model: root.card.windows
+
+        WindowTile {
+            required property var modelData
+            required property int index
+
+            win: modelData
+            rect: root.card.rect
+            scale: root.scale
+            badge: index + 1
+            selected: Switcher.current === modelData
+        }
+    }
+
+    // The home-row key, in the corner, on the card it lands on. Nothing
+    // else in the surface teaches which key goes where.
+    StyledRect {
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.margins: Tokens.padding.small
+        implicitWidth: keyLabel.implicitWidth + Tokens.padding.medium
+        implicitHeight: keyLabel.implicitHeight + Tokens.padding.extraSmall
+        radius: Tokens.rounding.small
+        visible: root.card.key.length > 0
+        color: root.active ? Colours.palette.m3primary : Colours.layer(Colours.tPalette.m3surfaceContainer, 3)
+
+        StyledText {
+            id: keyLabel
+
+            anchors.centerIn: parent
+            text: `${root.card.key.toUpperCase()}  ·  ${root.card.id}`
+            color: root.active ? Colours.palette.m3onPrimary : Colours.palette.m3onSurfaceVariant
+            font: Tokens.font.label.small
+        }
+    }
+
+    StyledText {
+        anchors.centerIn: parent
+        visible: root.card.windows.length === 0
+        text: qsTr("empty")
+        color: Colours.palette.m3onSurfaceVariant
+        font: Tokens.font.label.medium
+    }
+
+    // Selecting the card itself is what picks an empty desktop; on a
+    // populated one the tiles above take the click first.
+    MouseArea {
+        anchors.fill: parent
+        z: -1
+        onClicked: Switcher.selectWorkspace(root.card.id)
+        onDoubleClicked: {
+            Switcher.selectWorkspace(root.card.id);
+            Switcher.commit();
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/modules/switcher/qmldir
+++ b/Configs/quickshell/aphotic/modules/switcher/qmldir
@@ -1,0 +1,4 @@
+module qs.modules.switcher
+SwitcherWindow 1.0 SwitcherWindow.qml
+WorkspaceCard 1.0 WorkspaceCard.qml
+WindowTile 1.0 WindowTile.qml

--- a/Configs/quickshell/aphotic/services/Switcher.qml
+++ b/Configs/quickshell/aphotic/services/Switcher.qml
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023-2026 Trevin Tindall (T-Crypt) and Aphotic-Hypr contributors
+
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+
+// The ALT+Tab switcher's state, and the only thing that moves focus.
+//
+// The rule this file exists to keep: cycling never touches the
+// compositor. Every window, workspace and monitor rectangle is copied
+// into plain JS on open and nothing re-reads Hyprland until the overlay
+// closes, so walking the list cannot reorder the list being walked.
+// Hyprland's own `hl.dsp.window.cycle_next` focuses on every press,
+// which rewrites focus history under the cursor -- press Tab twice and
+// you are back where you started. One `WindowList.focus()` fires, from
+// commit(), and only if the selection actually moved.
+//
+// Nothing here reads the keyboard. `Configs/hypr/keybinds.lua` puts
+// Hyprland into an `aphotic-switcher` submap for as long as the overlay
+// is up and every key in it calls one of the IPC functions at the
+// bottom, which is what makes releasing ALT a commit rather than a
+// guess: Hyprland tells us, we don't poll for it.
+//
+// This singleton acts on its own rather than answering a reader, so it
+// needs a construction site in `shell.qml`'s `_residentSingletons` or
+// its IpcHandler never exists and every keybind below is a silent
+// no-op. See CLAUDE.md.
+Singleton {
+    id: root
+
+    // Home row, left index finger outwards. Ten keys, ten workspaces,
+    // in the order they sit under the hand.
+    readonly property var homeRow: ["a", "s", "d", "f", "g", "h", "j", "k", "l", ";"]
+
+    // Beyond this the cards are too narrow to read a window outline in,
+    // and the home row has run out of keys anyway.
+    readonly property int maxWorkspaces: 10
+
+    property bool open: false
+
+    // Which monitor the overlay draws on, captured at open. Not read
+    // live: the pointer moving across a monitor edge mid-cycle should
+    // not teleport the surface being cycled.
+    property string monitorName: ""
+
+    // The frozen snapshot. `windows` is in most-recently-used order,
+    // `cards` is one per workspace in id order with the windows that
+    // live on it. Both are plain arrays of plain objects, deliberately:
+    // a HyprlandToplevel is live and would defeat the whole point.
+    property var windows: []
+    property var cards: []
+
+    // Index into `windows`, or -1 when the selection is a workspace with
+    // nothing on it. Exactly one of these two is meaningful at a time.
+    property int selected: -1
+    property int selectedWorkspace: 0
+
+    readonly property var current: root.selected >= 0 ? root.windows[root.selected] ?? null : null
+
+    readonly property int currentWorkspace: root.current ? root.current.workspaceId : root.selectedWorkspace
+
+    // Hyprland numbers focus history 0-first, so ascending order is
+    // most-recent-first: index 0 is the window in front of you right
+    // now, index 1 is the one ALT+Tab is expected to land on. A window
+    // the compositor did not report an id for sorts to the back rather
+    // than to the front, where it would displace the real answer.
+    function _snapshotWindows(): var {
+        return WindowList.windows.filter(w => !w.workspaceName.startsWith("special:")).map(w => {
+            const ipc = w.toplevel?.lastIpcObject ?? {};
+            const at = ipc.at ?? [0, 0];
+            const size = ipc.size ?? [0, 0];
+            return {
+                address: w.address,
+                title: w.title,
+                appClass: w.appClass,
+                workspaceId: w.workspaceId,
+                floating: w.floating,
+                focused: w.focused,
+                x: at[0],
+                y: at[1],
+                width: size[0],
+                height: size[1],
+                order: ipc.focusHistoryID ?? 9999
+            };
+        }).sort((a, b) => a.order - b.order);
+    }
+
+    function _monitorRects(): var {
+        const rects = {};
+        for (const m of Hypr.monitors.values) {
+            const ipc = m.lastIpcObject ?? {};
+            rects[m.name] = {
+                x: ipc.x ?? m.x ?? 0,
+                y: ipc.y ?? m.y ?? 0,
+                width: ipc.width ?? m.width ?? 1920,
+                height: ipc.height ?? m.height ?? 1080
+            };
+        }
+        return rects;
+    }
+
+    // Cards run 1..N with no gaps, so an empty desktop between two busy
+    // ones is still somewhere the home row can land. N is one past the
+    // last workspace in use, which is how "jump to a fresh desktop and
+    // let go" works without the card list growing every time you do it.
+    function _snapshotCards(windows: var): var {
+        const rects = root._monitorRects();
+        const focusedWs = Hypr.focusedWorkspace?.id ?? 1;
+
+        let last = Math.max(focusedWs, 1);
+        for (const w of windows)
+            if (w.workspaceId > last)
+                last = w.workspaceId;
+        const count = Math.min(root.maxWorkspaces, last + 1);
+
+        const monitorOf = {};
+        for (const ws of Hypr.workspaces.values)
+            monitorOf[ws.id] = ws.monitor?.name ?? "";
+
+        const fallback = rects[root.monitorName] ?? Object.values(rects)[0] ?? {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080
+        };
+
+        const cards = [];
+        for (let id = 1; id <= count; id++) {
+            const rect = rects[monitorOf[id]] ?? fallback;
+            cards.push({
+                id,
+                key: root.homeRow[id - 1] ?? "",
+                rect,
+                windows: windows.filter(w => w.workspaceId === id)
+                    // Cards read spatially, so their windows are ordered
+                    // the way they sit on screen rather than by recency.
+                    // The 1-9 badges number this order.
+                    .sort((a, b) => (a.y - b.y) || (a.x - b.x))
+            });
+        }
+        return cards;
+    }
+
+    function _snapshot(): void {
+        root.monitorName = Hypr.focusedMonitor?.name ?? "";
+        const windows = root._snapshotWindows();
+        root.windows = windows;
+        root.cards = root._snapshotCards(windows);
+        root.selected = windows.length > 0 ? 0 : -1;
+        root.selectedWorkspace = Hypr.focusedWorkspace?.id ?? 1;
+    }
+
+    // First press opens on the snapshot and steps once, so ALT+Tab lands
+    // on the previous window the way it does everywhere else. Every
+    // press after that is one more step through the same frozen list.
+    function step(delta: int): void {
+        if (!root.open) {
+            root._snapshot();
+            root.open = true;
+        }
+        if (root.windows.length === 0)
+            return;
+        const from = root.selected >= 0 ? root.selected : -1;
+        root.selected = (from + delta + root.windows.length * 2) % root.windows.length;
+        root.selectedWorkspace = 0;
+    }
+
+    function _cardAt(id: int): var {
+        return root.cards.find(c => c.id === id) ?? null;
+    }
+
+    // Landing on a workspace selects its first window, or the workspace
+    // itself when there is none -- which is the whole reason an empty
+    // card is drawn at all.
+    function selectWorkspace(id: int): void {
+        if (!root.open)
+            return;
+        const card = root._cardAt(id);
+        if (!card)
+            return;
+        if (card.windows.length > 0) {
+            root.selected = root.windows.indexOf(card.windows[0]);
+            root.selectedWorkspace = 0;
+        } else {
+            root.selected = -1;
+            root.selectedWorkspace = id;
+        }
+    }
+
+    // The 1-9 badges, numbered within whichever card the selection is on.
+    function selectWindow(n: int): void {
+        if (!root.open)
+            return;
+        const card = root._cardAt(root.currentWorkspace);
+        const win = card?.windows[n - 1];
+        if (!win)
+            return;
+        root.selected = root.windows.indexOf(win);
+        root.selectedWorkspace = 0;
+    }
+
+    function selectAddress(address: string): void {
+        const at = root.windows.findIndex(w => w.address === address);
+        if (at < 0)
+            return;
+        root.selected = at;
+        root.selectedWorkspace = 0;
+    }
+
+    // Left/right walk the cards, up/down walk the windows inside the one
+    // the selection is on. Two axes, two meanings, so neither ever
+    // silently does the other's job.
+    function move(direction: string): void {
+        if (!root.open || root.cards.length === 0)
+            return;
+
+        if (direction === "left" || direction === "right") {
+            const at = root.cards.findIndex(c => c.id === root.currentWorkspace);
+            const delta = direction === "right" ? 1 : -1;
+            const next = (Math.max(at, 0) + delta + root.cards.length) % root.cards.length;
+            root.selectWorkspace(root.cards[next].id);
+            return;
+        }
+
+        const card = root._cardAt(root.currentWorkspace);
+        if (!card || card.windows.length === 0)
+            return;
+        const at = card.windows.indexOf(root.current);
+        const delta = direction === "down" ? 1 : -1;
+        const next = (Math.max(at, 0) + delta + card.windows.length) % card.windows.length;
+        root.selected = root.windows.indexOf(card.windows[next]);
+        root.selectedWorkspace = 0;
+    }
+
+    // The one place focus moves. A selection that never left the window
+    // already in front dispatches nothing at all, so tapping ALT+Tab and
+    // changing your mind costs the compositor nothing.
+    function commit(): void {
+        const win = root.current;
+        const workspace = root.selectedWorkspace;
+        root.close();
+
+        if (win) {
+            if (!win.focused)
+                WindowList.focus(win.address);
+            return;
+        }
+        if (workspace > 0)
+            Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ workspace = ${workspace} })` : `workspace ${workspace}`);
+    }
+
+    function close(): void {
+        root.open = false;
+        root.selected = -1;
+        root.selectedWorkspace = 0;
+        root.windows = [];
+        root.cards = [];
+    }
+
+    // A window closing while the overlay is up would leave the selection
+    // pointing at a dead address, and committing it dispatches a focus
+    // Hyprland answers with nothing. Cheaper to drop the surface than to
+    // re-derive a snapshot the user is halfway through reading.
+    Connections {
+        function onRawEvent(name: string): void {
+            if (root.open && name === "closewindow")
+                root.close();
+        }
+
+        target: Hypr
+    }
+
+    IpcHandler {
+        target: "switcher"
+
+        function next(): void {
+            root.step(1);
+        }
+
+        function prev(): void {
+            root.step(-1);
+        }
+
+        function move(direction: string): void {
+            root.move(direction);
+        }
+
+        function workspace(key: string): void {
+            const at = root.homeRow.indexOf(key);
+            if (at >= 0)
+                root.selectWorkspace(at + 1);
+        }
+
+        function window(n: string): void {
+            root.selectWindow(parseInt(n, 10));
+        }
+
+        function commit(): void {
+            root.commit();
+        }
+
+        function cancel(): void {
+            root.close();
+        }
+
+        function state(): string {
+            return JSON.stringify({
+                open: root.open,
+                monitor: root.monitorName,
+                selected: root.selected,
+                selectedWorkspace: root.selectedWorkspace,
+                windows: root.windows.length,
+                cards: root.cards.length
+            });
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -26,6 +26,7 @@ singleton ProcessUsage 1.0 ProcessUsage.qml
 singleton SafeMode 1.0 SafeMode.qml
 singleton SessionLockState 1.0 SessionLockState.qml
 singleton Settings 1.0 Settings.qml
+singleton Switcher 1.0 Switcher.qml
 singleton SystemUsage 1.0 SystemUsage.qml
 singleton Themes 1.0 Themes.qml
 singleton UiPickerState 1.0 UiPickerState.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -15,6 +15,7 @@ import qs.modules.session
 import qs.modules.dashboard
 import qs.modules.workspace
 import qs.modules.settings
+import qs.modules.switcher
 import qs.modules.background
 import qs.modules.areapicker
 import qs.modules.colorpicker
@@ -163,6 +164,15 @@ ShellRoot {
         SettingsWindow {
             screenState: root.screenStateFor(modelData)
         }
+    }
+
+    // The ALT+Tab surface. No ScreenState flag and no toggle entry:
+    // Switcher owns whether it is up, and only ever on the monitor that
+    // was focused when it opened (see SwitcherWindow's `visible`).
+    Variants {
+        model: Quickshell.screens
+
+        SwitcherWindow {}
     }
 
     Variants {
@@ -490,11 +500,12 @@ ShellRoot {
     // already ships a toggle and an interval picker for; DevDrift watches
     // DevProfile for a stale lockfile; SafeMode raises the toast that is
     // the only reason a user in safe mode knows why their plugins are
-    // gone. Listing them here is what makes them exist. Anything added to
+    // gone; Switcher holds the IpcHandler every ALT+Tab keybind
+    // calls, and no window names it until it is already open. Listing them here is what makes them exist. Anything added to
     // services/ that runs on its own rather than answering a reader
     // belongs in this list, and tests/test_singleton_reachability.py
     // fails the build if it does not.
-    readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift, SafeMode, WorkspaceKeybind]
+    readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift, SafeMode, WorkspaceKeybind, Switcher]
 
     // The profile substrate's inspection/drive surface (Phase 0 --
     // docs/APHOTIC_UNIFIED_VISION.md section 3.5). Lives here rather than

--- a/README.md
+++ b/README.md
@@ -662,12 +662,31 @@ One exception: the Workspace plane is bound by the shell at runtime, because it 
 | <kbd>Super</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd> | Toggle fullscreen |
 | <kbd>Super</kbd> + <kbd>&larr;</kbd>/<kbd>&rarr;</kbd>/<kbd>&uarr;</kbd>/<kbd>&darr;</kbd> | Move focus between windows |
 | <kbd>Super</kbd> + <kbd>Shift</kbd> + <kbd>&larr;</kbd>/<kbd>&rarr;</kbd>/<kbd>&uarr;</kbd>/<kbd>&darr;</kbd> | Move (swap) the focused window in a direction |
-| <kbd>Alt</kbd> + <kbd>Tab</kbd> | Cycle to the next window |
-| <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd> | Cycle to the previous window |
+| <kbd>Alt</kbd> + <kbd>Tab</kbd> | Open the window switcher, step forward |
+| <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd> | Open the window switcher, step back |
 | <kbd>Super</kbd> + <kbd>G</kbd> | Toggle group |
 | <kbd>Super</kbd> + <kbd>Ctrl</kbd> + <kbd>H</kbd> / <kbd>Super</kbd> + <kbd>Ctrl</kbd> + <kbd>L</kbd> | Cycle group tabs backward/forward |
 | <kbd>Super</kbd> + <kbd>LMB</kbd> drag | Move window |
 | <kbd>Super</kbd> + <kbd>RMB</kbd> drag | Resize window |
+
+While the switcher is up, Hyprland is in its own submap and these keys apply:
+
+| Keys | Action |
+| :-- | :-- |
+| <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd> | Step through windows, most recently used first |
+| <kbd>A</kbd>–<kbd>;</kbd> | Jump to workspace 1–10, home row, one key each |
+| <kbd>1</kbd>–<kbd>9</kbd> | Pick a numbered window on the selected workspace |
+| <kbd>&larr;</kbd> / <kbd>&rarr;</kbd> | Move between workspaces |
+| <kbd>&uarr;</kbd> / <kbd>&darr;</kbd> | Move between windows on the selected workspace |
+| Release <kbd>Alt</kbd>, or <kbd>Enter</kbd> / <kbd>Space</kbd> | Switch to the selection |
+| <kbd>Esc</kbd>, or click away | Close it, focus stays put |
+
+Every window is read once when the switcher opens and focus moves once,
+when you let go. Stepping through the list does not focus anything on the
+way, so the order you are walking cannot reorder itself under you, and
+backing out with <kbd>Esc</kbd> leaves the desktop exactly as it was. Each
+workspace draws as a miniature of the monitor it lives on, at that
+monitor's real aspect ratio, with every window where it actually sits.
 
 </details>
 


### PR DESCRIPTION
## Problem

`ALT+Tab` was bound to Hyprland's `window.cycle_next`, which focuses a
window on every press. Focusing rewrites the focus history that same
dispatcher walks, so the second press sends you back to the first
window and the third to the second. Cycling past two windows is not
possible with it, and every step leaves a real focus change behind, so
backing out means finding your way home by hand.

The shell had no switcher surface either. Nothing showed which window
was next, where it lived, or how many there were.

## Plan

Snapshot on open, commit on release.

`services/Switcher.qml` copies every window, workspace and monitor
rectangle into plain JS when the surface opens and reads Hyprland no
further. Tab, the home row, the number keys and the arrows move an index
inside that copy. `WindowList.focus()` fires once, from `commit()`, and
only when the selection moved off the window already in front.

Keys come from a Hyprland submap in `keybinds.lua`, not from a
layer-shell keyboard grab. That is what makes releasing ALT mean
something: the compositor sees the release and calls `commit`, where a
surface that grabbed the keyboard mid-chord would be guessing at a key
it never saw pressed. A polling fallback covers the one chord the
release bind cannot see, a tap so fast that ALT is up before the submap
exists.

Workspace cards run 1 to one past the last workspace in use, so a gap
between two busy desktops is somewhere the home row can land, and there
is always one empty desktop to jump to.

## Resolution

Seven files.

- `services/Switcher.qml` holds the snapshot, the selection and the IPC
  target every key calls. Listed in `shell.qml`'s `_residentSingletons`,
  without which its `IpcHandler` never exists and every bind is a silent
  no-op.
- `modules/switcher/` draws it: one card per workspace at its own
  monitor's aspect ratio, window outlines at their real positions, home
  row key on each card, `1`-`9` badges on each window.
- `Configs/hypr/keybinds.lua` replaces the two `cycle_next` binds with
  the `aphotic-switcher` submap, 60 binds inside it.
- README documents the switcher keys and what the snapshot buys.

Verified with two headless probes against this desktop's 8 windows over
workspaces 3, 4, 5 and 7. MRU order matches `focusHistoryID`, cards
carry the right per-monitor geometry (3440x1440 on DP-1, 1920x1080 on
DP-2), the home row maps to the cards it draws, and stepping never
dispatched. `keybinds.lua` was executed against a stub Lua host: 60
submap binds, both ALT release binds, both top-level binds keeping their
cheatsheet descriptions. Suite green at 85 passed, no new binding loops.

Needs a live look. The overlay itself has not been seen on a desktop.
