### PR TITLE
Color GTK4 and libadwaita apps with the active theme

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_scheme.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_scheme.sh
@@ -66,6 +66,11 @@ aphotic_cmd_scheme() {
                 else
                     aphotic_warn "wallust not found, skipping palette regeneration"
                 fi
+
+                # Deploy the GTK4/libadwaita stylesheet the engine above
+                # staged. cmd_theme.sh is already sourced for
+                # _aphotic_toml_get, so the function is in scope.
+                _aphotic_theme_refresh_gtk
             else
                 aphotic_log "no active theme/wallpaper found in ${APHOTIC_THEME_STATE_FILE}, skipping palette regeneration"
             fi

--- a/Configs/.local/lib/aphotic/commands/cmd_theme.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_theme.sh
@@ -9,6 +9,7 @@
 # @cmd.opt: download <name>           | Download a theme from APHOTIC_THEMES_REPO
 # @cmd.opt: update <name>|--all       | Refresh a downloaded theme's files from the repo
 # @cmd.opt: remove <name>             | Delete a downloaded (non-core) theme
+# @cmd.opt: refresh-gtk               | Re-deploy the GTK4/libadwaita stylesheet and restart idle GTK4 apps
 # @cmd.opt: ensure-default            | Apply the install-time theme if none is set yet (startup.lua only)
 #
 # Themes live as directories under APHOTIC_AWWW_DIR, each with a
@@ -341,6 +342,104 @@ _aphotic_theme_clamp_palette() {
 # pins from theme.toml, then persist state. wallpaper_file may be
 # empty to fall back to the theme's declared default (or its first
 # wallpaper alphabetically).
+# ---------------------------------------------------------------------
+# GTK4 / libadwaita
+#
+# GTK3 apps follow gtk-theme-name, so adw-gtk3 plus the generated
+# gtk-3.0/gtk.css already themes them. GTK4 ones do not: libadwaita
+# compiles its palette in and ignores the theme name outright, which is
+# why Files, Text Editor, Calculator and the rest of the stock GNOME set
+# sit at Adwaita's grey next to a themed desktop. The one thing it does
+# read is ~/.config/gtk-4.0/gtk.css.
+#
+# Both color engines render that stylesheet to a staging file. Two things
+# still have to happen to it, and neither is something a color engine can
+# do: the live UI font has to be stamped in, and the apps already running
+# have to be told, because libadwaita reads the file once at process
+# start and never again.
+# ---------------------------------------------------------------------
+
+APHOTIC_GTK4_STAGED="${APHOTIC_STATE_HOME}/gtk4.css"
+APHOTIC_GTK4_CSS="${XDG_CONFIG_HOME:-$HOME/.config}/gtk-4.0/gtk.css"
+
+# GTK4 apps that outlive their last window as a D-Bus service, so closing
+# the window is not enough to make them re-read the stylesheet. Each row
+# is `window class|process name|quit command`. Add a row to theme another
+# one; anything not listed still picks the new colors up the next time it
+# is launched, which is all a non-resident app needs.
+APHOTIC_GTK4_DAEMONS=(
+    "org.gnome.Nautilus|nautilus|nautilus -q"
+)
+
+_aphotic_theme_ui_font() {
+    local font=""
+    if command -v gsettings >/dev/null 2>&1; then
+        font="$(gsettings get org.gnome.desktop.interface font-name 2>/dev/null | sed -e "s/^'//" -e "s/'$//" -e 's/ [0-9.]*$//')"
+    fi
+    printf '%s' "${font:-Inter}"
+}
+
+# How many windows of a given class are on screen right now. Used to
+# leave an app alone rather than quitting it out from under someone --
+# see the call site.
+_aphotic_theme_window_count() {
+    local class="$1"
+    command -v hyprctl >/dev/null 2>&1 || { printf '0'; return; }
+    command -v jq >/dev/null 2>&1 || { printf '0'; return; }
+    hyprctl -j clients 2>/dev/null | jq --arg c "$class" '[.[] | select(.class == $c)] | length' 2>/dev/null || printf '0'
+}
+
+# Restarting a daemon that has a window open would close that window, and
+# the stylesheet is not worth someone's in-progress file copy. An app
+# with nothing on screen is only a background service, so quitting it
+# costs nothing: it respawns on the next launch and reads the new file
+# then. One with a window open is skipped and picks the colors up when it
+# is next started.
+_aphotic_theme_restart_gtk4_daemons() {
+    local row class proc quit open
+    for row in "${APHOTIC_GTK4_DAEMONS[@]}"; do
+        IFS='|' read -r class proc quit <<<"$row"
+        pgrep -x "$proc" >/dev/null 2>&1 || continue
+
+        open="$(_aphotic_theme_window_count "$class")"
+        if [[ "$open" -gt 0 ]]; then
+            aphotic_warn "${proc} has ${open} window(s) open, leaving it alone -- new colors apply next launch"
+            continue
+        fi
+
+        local -a quit_cmd
+        read -ra quit_cmd <<<"$quit"
+        "${quit_cmd[@]}" >/dev/null 2>&1 || true
+    done
+}
+
+# Deploys the staged stylesheet with the live font stamped in.
+#
+# Renders to a temp file and copies it over the destination rather than
+# editing in place. ~/.config/gtk-4.0/gtk.css is a symlink on some setups
+# and both `sed -i` and `install` unlink the destination first, which
+# turns the link into a plain file; every later theme switch then keeps
+# writing a path nothing reads. `cp` writes through the link instead.
+_aphotic_theme_refresh_gtk() {
+    if [[ ! -f "$APHOTIC_GTK4_STAGED" ]]; then
+        aphotic_warn "no GTK4 stylesheet at ${APHOTIC_GTK4_STAGED} yet -- apply a theme first"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$APHOTIC_GTK4_CSS")"
+
+    local font tmp
+    font="$(_aphotic_theme_ui_font)"
+    tmp="$(mktemp)"
+    sed -E "s/font-family:[^;]+;/font-family: \"${font}\", sans-serif;/" "$APHOTIC_GTK4_STAGED" > "$tmp"
+    cp "$tmp" "$APHOTIC_GTK4_CSS"
+    chmod 644 "$APHOTIC_GTK4_CSS"
+    rm -f "$tmp"
+
+    _aphotic_theme_restart_gtk4_daemons
+    return 0
+}
+
 _aphotic_theme_apply() {
     local theme_name="$1" wallpaper_file="${2:-}"
     local dir; dir="$(_aphotic_theme_dir "$theme_name")"
@@ -418,6 +517,9 @@ _aphotic_theme_apply() {
     fi
 
     cp "$image_path" "${APHOTIC_AWWW_DIR}/current-wallpaper" 2>/dev/null || true
+
+    # Deploy the GTK4/libadwaita stylesheet the engine above just staged.
+    _aphotic_theme_refresh_gtk
 
     # Plugin theme-hooks (see docs/PLUGIN_SYSTEM.md) -- fire-and-forget,
     # the shared implementation (cmd_plugin.sh) already backgrounds each
@@ -569,6 +671,7 @@ aphotic_cmd_theme() {
         update) _aphotic_theme_update "${1:-}" ;;
         remove) _aphotic_theme_remove "${1:-}" ;;
         ensure-default) _aphotic_theme_ensure_default ;;
+        refresh-gtk) _aphotic_theme_refresh_gtk ;;
         set)
             local name="${1:-}"
             [[ -z "$name" ]] && { aphotic_err "usage: aphotic theme set <name>"; return 1; }
@@ -627,7 +730,7 @@ aphotic_cmd_theme() {
             ;;
         ""|-h|--help)
             cat <<HELP
-Usage: aphotic theme <list|set|next|prev|download|update|remove|ensure-default> [args]
+Usage: aphotic theme <list|set|next|prev|download|update|remove|refresh-gtk|ensure-default> [args]
 
   list [--remote] [--json]  List theme folders (${APHOTIC_AWWW_DIR}), or
                              --remote: what's available from
@@ -642,6 +745,12 @@ Usage: aphotic theme <list|set|next|prev|download|update|remove|ensure-default> 
                              theme (skips the ones that ship with Aphotic)
   remove <name>              Delete a downloaded theme; refuses to take out
                              one of the themes that ships with Aphotic
+  refresh-gtk                Re-deploy ~/.config/gtk-4.0/gtk.css from the
+                             current theme with the live UI font stamped
+                             in, and restart the GTK4 apps sitting idle in
+                             the background so they read it. Runs as part
+                             of `theme set`; call it by hand after
+                             changing your interface font
   ensure-default             Apply the install-time theme if none is set
                              yet (no-op once a theme has ever been
                              applied); called once from Hyprland's

--- a/Configs/hypr/scripts/thunar_wall.py
+++ b/Configs/hypr/scripts/thunar_wall.py
@@ -16,6 +16,9 @@ subprocess.run(["wallust", "run", image_path])
 # generate current-wallpaper -- the shared "current wallpaper" marker, see
 # services/Wallpapers.qml
 subprocess.run(["cp", image_path, os.path.join(awww_dir, "current-wallpaper")])
+# Deploy the GTK4/libadwaita stylesheet wallust just staged, with the live
+# UI font stamped in -- see cmd_theme.sh's _aphotic_theme_refresh_gtk
+subprocess.run(["aphotic", "theme", "refresh-gtk"])
 # firefox
 subprocess.run(["pywalfox", "update"])
 # Reload the shell to apply colorscheme

--- a/Configs/hypr/scripts/wallswitcher.py
+++ b/Configs/hypr/scripts/wallswitcher.py
@@ -404,6 +404,12 @@ def apply_wallpaper(theme, wallpaper):
     # wallust finished" comment actually needed.
     run_detached(["aphotic", "plugin", "run-theme-hooks"])
 
+    # Deploy the GTK4/libadwaita stylesheet the engine above just staged.
+    # Same reason the hooks line sits here: the engine call is blocking,
+    # so its templates are on disk by now. See cmd_theme.sh's
+    # _aphotic_theme_refresh_gtk.
+    run_detached(["aphotic", "theme", "refresh-gtk"])
+
     # Handle papirus-folders with no sudo prompt if possible
     if papirus_color:
         run_detached(["sudo", "-n", "papirus-folders", "-C", papirus_color, "--theme", "Papirus-Dark", "-u"])

--- a/Configs/matugen/config.toml
+++ b/Configs/matugen/config.toml
@@ -44,9 +44,11 @@ output_path = "~/.config/hypr/colors.lua"
 input_path = "~/.config/matugen/templates/gtk.css"
 output_path = "~/.config/gtk-3.0/gtk.css"
 
+# GTK4 gets its own template and its own staging path, for the reasons
+# Configs/wallust/wallust.toml's matching entry spells out.
 [templates.gtk4]
-input_path = "~/.config/matugen/templates/gtk.css"
-output_path = "~/.config/gtk-4.0/gtk.css"
+input_path = "~/.config/matugen/templates/gtk4.css"
+output_path = "~/.local/state/aphotic/gtk4.css"
 
 [templates.wal_colors]
 input_path = "~/.config/matugen/templates/colors-wal-plain"

--- a/Configs/matugen/templates/gtk4.css
+++ b/Configs/matugen/templates/gtk4.css
@@ -1,0 +1,172 @@
+/* Aphotic's GTK4/libadwaita stylesheet, rendered by matugen on every
+   theme switch.
+
+   GTK4 apps do not read a GTK theme the way GTK3 ones do. libadwaita
+   compiles its own palette in and ignores gtk-theme-name outright, so
+   Files, Calculator, Text Editor and the rest of the stock GNOME set sit
+   at Adwaita's own grey next to a themed desktop. What libadwaita does
+   read is this file, and the named colors below are the ones it builds
+   every widget out of.
+
+   Two limits worth knowing. libadwaita reads this once, at process
+   start, so a running app keeps the old colors until it is restarted
+   (`aphotic theme refresh-gtk` restarts the resident ones it can do
+   safely). And the font-family line further down is a placeholder: the
+   same command stamps the live UI font over it, because a color engine
+   has no idea what font you are using.
+
+   matugen only substitutes on a double-brace pair, so this file's own
+   CSS rule blocks pass through untouched. */
+
+/* libadwaita named colors. */
+@define-color window_bg_color {{colors.surface.default.hex}};
+@define-color window_fg_color {{colors.on_surface.default.hex}};
+
+@define-color view_bg_color {{colors.surface.default.hex}};
+@define-color view_fg_color {{colors.on_surface.default.hex}};
+
+@define-color headerbar_bg_color {{colors.surface_container_low.default.hex}};
+@define-color headerbar_fg_color {{colors.on_surface.default.hex}};
+@define-color headerbar_border_color {{colors.outline_variant.default.hex}};
+@define-color headerbar_backdrop_color {{colors.surface_container_low.default.hex}};
+
+@define-color sidebar_bg_color {{colors.surface_container.default.hex}};
+@define-color sidebar_fg_color {{colors.on_surface.default.hex}};
+@define-color sidebar_backdrop_color {{colors.surface_container.default.hex}};
+@define-color sidebar_border_color {{colors.outline_variant.default.hex}};
+@define-color secondary_sidebar_bg_color {{colors.surface_container.default.hex}};
+@define-color secondary_sidebar_fg_color {{colors.on_surface.default.hex}};
+@define-color secondary_sidebar_backdrop_color {{colors.surface_container.default.hex}};
+@define-color secondary_sidebar_border_color {{colors.outline_variant.default.hex}};
+
+@define-color card_bg_color {{colors.surface_container_high.default.hex}};
+@define-color card_fg_color {{colors.on_surface.default.hex}};
+
+@define-color dialog_bg_color {{colors.surface_container_high.default.hex}};
+@define-color dialog_fg_color {{colors.on_surface.default.hex}};
+
+@define-color popover_bg_color {{colors.surface_container_high.default.hex}};
+@define-color popover_fg_color {{colors.on_surface.default.hex}};
+
+@define-color thumbnail_bg_color {{colors.surface_container_high.default.hex}};
+@define-color thumbnail_fg_color {{colors.on_surface.default.hex}};
+
+@define-color accent_bg_color {{colors.primary.default.hex}};
+@define-color accent_fg_color {{colors.on_primary.default.hex}};
+@define-color accent_color {{colors.primary.default.hex}};
+
+@define-color destructive_bg_color {{colors.error.default.hex}};
+@define-color destructive_fg_color {{colors.on_error.default.hex}};
+@define-color destructive_color {{colors.error.default.hex}};
+
+@define-color success_bg_color {{colors.tertiary.default.hex}};
+@define-color success_fg_color {{colors.surface.default.hex}};
+@define-color success_color {{colors.tertiary.default.hex}};
+
+@define-color warning_bg_color {{colors.secondary.default.hex}};
+@define-color warning_fg_color {{colors.surface.default.hex}};
+@define-color warning_color {{colors.secondary.default.hex}};
+
+@define-color error_bg_color {{colors.error.default.hex}};
+@define-color error_fg_color {{colors.on_error.default.hex}};
+@define-color error_color {{colors.error.default.hex}};
+
+@define-color borders {{colors.outline_variant.default.hex}};
+
+/* GTK4's own names, for anything that predates libadwaita's set. */
+@define-color theme_bg_color {{colors.surface.default.hex}};
+@define-color theme_fg_color {{colors.on_surface.default.hex}};
+@define-color theme_base_color {{colors.surface.default.hex}};
+@define-color theme_text_color {{colors.on_surface.default.hex}};
+@define-color theme_selected_bg_color {{colors.primary.default.hex}};
+@define-color theme_selected_fg_color {{colors.on_primary.default.hex}};
+@define-color insensitive_bg_color {{colors.surface_container_low.default.hex}};
+@define-color insensitive_fg_color {{colors.on_surface_variant.default.hex}};
+@define-color insensitive_base_color {{colors.surface.default.hex}};
+
+/* The shade colors libadwaita paints over headerbars, sidebars and cards
+   are opaque near-blacks chosen for Adwaita's own grey. On any other
+   background they read as a dirty band along every edge, which is most
+   of why a stock GNOME app looks wrong on a themed desktop even after
+   the colors above are set. Alpha over the real background instead. */
+@define-color shade_color alpha({{colors.on_surface.default.hex}}, 0.09);
+@define-color headerbar_shade_color alpha({{colors.on_surface.default.hex}}, 0.07);
+@define-color headerbar_darker_shade_color alpha({{colors.on_surface.default.hex}}, 0.12);
+@define-color sidebar_shade_color alpha({{colors.on_surface.default.hex}}, 0.07);
+@define-color card_shade_color alpha({{colors.on_surface.default.hex}}, 0.07);
+@define-color popover_shade_color alpha({{colors.on_surface.default.hex}}, 0.07);
+@define-color dialog_shade_color alpha({{colors.on_surface.default.hex}}, 0.07);
+@define-color scrollbar_outline_color alpha({{colors.on_surface.default.hex}}, 0.12);
+
+/* `aphotic theme refresh-gtk` rewrites the font-family below with
+   whatever gsettings reports as the interface font. Size is left alone:
+   scaling GTK apps against the rest of the desktop is the user's call,
+   not the theme's. */
+window, popover, dialog, .background {
+  font-family: "Inter", sans-serif;
+}
+
+/* Sidebar and content share one background in stock Adwaita, so the
+   split reads only as a shadow, which the alpha shades above just
+   softened. Give it a real line. */
+window separator.sidebar,
+window paned > separator {
+  background-color: {{colors.outline_variant.default.hex}};
+  min-width: 1px;
+  min-height: 1px;
+}
+
+/* Scroll edges paint a gradient sampled from Adwaita's background, which
+   stays grey however the named colors are set. */
+undershoot.top, undershoot.bottom,
+undershoot.left, undershoot.right {
+  background: none;
+}
+
+/* Row selection is drawn from the accent, at an alpha that keeps the
+   label legible rather than inverting it. */
+row:selected,
+gridview child:selected,
+columnview row:selected,
+listview row:selected,
+flowboxchild:selected {
+  background-color: alpha({{colors.primary.default.hex}}, 0.18);
+  color: {{colors.on_surface.default.hex}};
+}
+
+row:selected:focus-within,
+gridview child:selected:focus-within,
+columnview row:selected:focus-within,
+listview row:selected:focus-within {
+  background-color: alpha({{colors.primary.default.hex}}, 0.28);
+}
+
+row:hover:not(:selected),
+gridview child:hover:not(:selected),
+columnview row:hover:not(:selected),
+listview row:hover:not(:selected),
+flowboxchild:hover:not(:selected) {
+  background-color: alpha({{colors.on_surface.default.hex}}, 0.06);
+}
+
+/* Drag-select in a file view. */
+rubberband, .rubberband {
+  background-color: alpha({{colors.primary.default.hex}}, 0.20);
+  border: 1px solid {{colors.primary.default.hex}};
+}
+
+entry:focus-within, spinbutton:focus-within {
+  outline-color: {{colors.primary.default.hex}};
+}
+
+scrollbar slider {
+  background-color: alpha({{colors.on_surface.default.hex}}, 0.35);
+}
+
+scrollbar slider:hover {
+  background-color: alpha({{colors.on_surface.default.hex}}, 0.55);
+}
+
+scrollbar slider:active {
+  background-color: {{colors.primary.default.hex}};
+}

--- a/Configs/quickshell/aphotic/services/Wallpapers.qml
+++ b/Configs/quickshell/aphotic/services/Wallpapers.qml
@@ -147,6 +147,20 @@ Singleton {
         Quickshell.execDetached(["aphotic", "greeter", "sync"]);
     }
 
+    // Everything that has to wait for the colour engine to finish writing
+    // its templates, in one place. Three code paths below reach this
+    // point (no clamp, a clamp that failed, a clamp that ran), and each
+    // used to fire the theme hooks on its own, so anything added here had
+    // to be added three times or it silently covered two paths out of
+    // three. The GTK4 deploy is exactly that kind of thing: the engine
+    // stages ~/.local/state/aphotic/gtk4.css and this is what installs it
+    // with the live font stamped in (see cmd_theme.sh's
+    // _aphotic_theme_refresh_gtk).
+    function _afterEngine(): void {
+        Quickshell.execDetached(["aphotic", "theme", "refresh-gtk"]);
+        Quickshell.execDetached(["aphotic", "plugin", "run-theme-hooks"]);
+    }
+
     Process {
         id: awwwProc
     }
@@ -179,7 +193,7 @@ Singleton {
             if (root._pendingClamp)
                 root._startClamp(root._pendingClamp);
             else
-                Quickshell.execDetached(["aphotic", "plugin", "run-theme-hooks"]);
+                root._afterEngine();
         }
     }
 
@@ -231,7 +245,7 @@ Singleton {
             if (clampProc.taggedGeneration !== root._generation)
                 return;
             if (exitCode !== 0) {
-                Quickshell.execDetached(["aphotic", "plugin", "run-theme-hooks"]);
+                root._afterEngine();
                 return;
             }
             csProc.taggedGeneration = root._generation;
@@ -247,7 +261,7 @@ Singleton {
         onExited: {
             if (csProc.taggedGeneration !== root._generation)
                 return;
-            Quickshell.execDetached(["aphotic", "plugin", "run-theme-hooks"]);
+            root._afterEngine();
         }
     }
 }

--- a/Configs/wallust/templates/gtk4.css
+++ b/Configs/wallust/templates/gtk4.css
@@ -1,0 +1,173 @@
+/* Aphotic's GTK4/libadwaita stylesheet, rendered by wallust on every
+   theme switch.
+
+   GTK4 apps do not read a GTK theme the way GTK3 ones do. libadwaita
+   compiles its own palette in and ignores gtk-theme-name outright, so
+   Files, Calculator, Text Editor and the rest of the stock GNOME set sit
+   at Adwaita's own grey next to a themed desktop. What libadwaita does
+   read is this file, and the named colors below are the ones it builds
+   every widget out of.
+
+   Two limits worth knowing. libadwaita reads this once, at process
+   start, so a running app keeps the old colors until it is restarted
+   (`aphotic theme refresh-gtk` restarts the resident ones it can do
+   safely). And the font-family line further down is a placeholder: the
+   same command stamps the live UI font over it, because a color engine
+   has no idea what font you are using.
+
+   Native templating mode, not pywal-compat: this file's own CSS rule
+   blocks would be misread as substitution tokens under pywal-compat,
+   which treats every single opening brace as a variable start. */
+
+/* libadwaita named colors. */
+@define-color window_bg_color {{ background }};
+@define-color window_fg_color {{ foreground }};
+
+@define-color view_bg_color {{ background }};
+@define-color view_fg_color {{ foreground }};
+
+@define-color headerbar_bg_color {{ background | darken(0.05) }};
+@define-color headerbar_fg_color {{ foreground }};
+@define-color headerbar_border_color {{ color8 }};
+@define-color headerbar_backdrop_color {{ background | darken(0.05) }};
+
+@define-color sidebar_bg_color {{ background | darken(0.08) }};
+@define-color sidebar_fg_color {{ foreground }};
+@define-color sidebar_backdrop_color {{ background | darken(0.08) }};
+@define-color sidebar_border_color {{ color8 }};
+@define-color secondary_sidebar_bg_color {{ background | darken(0.08) }};
+@define-color secondary_sidebar_fg_color {{ foreground }};
+@define-color secondary_sidebar_backdrop_color {{ background | darken(0.08) }};
+@define-color secondary_sidebar_border_color {{ color8 }};
+
+@define-color card_bg_color {{ background | lighten(0.06) }};
+@define-color card_fg_color {{ foreground }};
+
+@define-color dialog_bg_color {{ background | lighten(0.06) }};
+@define-color dialog_fg_color {{ foreground }};
+
+@define-color popover_bg_color {{ background | lighten(0.06) }};
+@define-color popover_fg_color {{ foreground }};
+
+@define-color thumbnail_bg_color {{ background | lighten(0.06) }};
+@define-color thumbnail_fg_color {{ foreground }};
+
+@define-color accent_bg_color {{ color4 }};
+@define-color accent_fg_color {{ background }};
+@define-color accent_color {{ color4 }};
+
+@define-color destructive_bg_color {{ color1 }};
+@define-color destructive_fg_color {{ background }};
+@define-color destructive_color {{ color1 }};
+
+@define-color success_bg_color {{ color2 }};
+@define-color success_fg_color {{ background }};
+@define-color success_color {{ color2 }};
+
+@define-color warning_bg_color {{ color3 }};
+@define-color warning_fg_color {{ background }};
+@define-color warning_color {{ color3 }};
+
+@define-color error_bg_color {{ color1 }};
+@define-color error_fg_color {{ background }};
+@define-color error_color {{ color1 }};
+
+@define-color borders {{ color8 }};
+
+/* GTK4's own names, for anything that predates libadwaita's set. */
+@define-color theme_bg_color {{ background }};
+@define-color theme_fg_color {{ foreground }};
+@define-color theme_base_color {{ background }};
+@define-color theme_text_color {{ foreground }};
+@define-color theme_selected_bg_color {{ color4 }};
+@define-color theme_selected_fg_color {{ background }};
+@define-color insensitive_bg_color {{ background | darken(0.05) }};
+@define-color insensitive_fg_color {{ color7 }};
+@define-color insensitive_base_color {{ background }};
+
+/* The shade colors libadwaita paints over headerbars, sidebars and cards
+   are opaque near-blacks chosen for Adwaita's own grey. On any other
+   background they read as a dirty band along every edge, which is most
+   of why a stock GNOME app looks wrong on a themed desktop even after
+   the colors above are set. Alpha over the real background instead. */
+@define-color shade_color alpha({{ foreground }}, 0.09);
+@define-color headerbar_shade_color alpha({{ foreground }}, 0.07);
+@define-color headerbar_darker_shade_color alpha({{ foreground }}, 0.12);
+@define-color sidebar_shade_color alpha({{ foreground }}, 0.07);
+@define-color card_shade_color alpha({{ foreground }}, 0.07);
+@define-color popover_shade_color alpha({{ foreground }}, 0.07);
+@define-color dialog_shade_color alpha({{ foreground }}, 0.07);
+@define-color scrollbar_outline_color alpha({{ foreground }}, 0.12);
+
+/* `aphotic theme refresh-gtk` rewrites the font-family below with
+   whatever gsettings reports as the interface font. Size is left alone:
+   scaling GTK apps against the rest of the desktop is the user's call,
+   not the theme's. */
+window, popover, dialog, .background {
+  font-family: "Inter", sans-serif;
+}
+
+/* Sidebar and content share one background in stock Adwaita, so the
+   split reads only as a shadow, which the alpha shades above just
+   softened. Give it a real line. */
+window separator.sidebar,
+window paned > separator {
+  background-color: {{ color8 }};
+  min-width: 1px;
+  min-height: 1px;
+}
+
+/* Scroll edges paint a gradient sampled from Adwaita's background, which
+   stays grey however the named colors are set. */
+undershoot.top, undershoot.bottom,
+undershoot.left, undershoot.right {
+  background: none;
+}
+
+/* Row selection is drawn from the accent, at an alpha that keeps the
+   label legible rather than inverting it. */
+row:selected,
+gridview child:selected,
+columnview row:selected,
+listview row:selected,
+flowboxchild:selected {
+  background-color: alpha({{ color4 }}, 0.18);
+  color: {{ foreground }};
+}
+
+row:selected:focus-within,
+gridview child:selected:focus-within,
+columnview row:selected:focus-within,
+listview row:selected:focus-within {
+  background-color: alpha({{ color4 }}, 0.28);
+}
+
+row:hover:not(:selected),
+gridview child:hover:not(:selected),
+columnview row:hover:not(:selected),
+listview row:hover:not(:selected),
+flowboxchild:hover:not(:selected) {
+  background-color: alpha({{ foreground }}, 0.06);
+}
+
+/* Drag-select in a file view. */
+rubberband, .rubberband {
+  background-color: alpha({{ color4 }}, 0.20);
+  border: 1px solid {{ color4 }};
+}
+
+entry:focus-within, spinbutton:focus-within {
+  outline-color: {{ color4 }};
+}
+
+scrollbar slider {
+  background-color: alpha({{ foreground }}, 0.35);
+}
+
+scrollbar slider:hover {
+  background-color: alpha({{ foreground }}, 0.55);
+}
+
+scrollbar slider:active {
+  background-color: {{ color4 }};
+}

--- a/Configs/wallust/wallust.toml
+++ b/Configs/wallust/wallust.toml
@@ -46,5 +46,12 @@ plugin_palette = { template = "colors-plugin-palette.json", target = "~/.local/s
 # Jinja2 only triggers on double braces, so those pass through untouched.
 hyprland = { template = "colors-hyprland.lua", target = "~/.config/hypr/colors.lua" }
 gtk = { template = "gtk.css", target = "~/.config/gtk-3.0/gtk.css" }
-gtk4 = { template = "gtk.css", target = "~/.config/gtk-4.0/gtk.css" }
+# GTK4 gets its own template and its own staging path. Its own template
+# because libadwaita ignores gtk-theme-name and builds every widget out
+# of a set of named colors GTK3 has never heard of, so the two files
+# have almost nothing in common. Its own staging path because the file
+# GTK reads still needs the live UI font stamped into it, which no color
+# engine knows -- `_aphotic_theme_refresh_gtk` in cmd_theme.sh does that
+# and installs the result over ~/.config/gtk-4.0/gtk.css.
+gtk4 = { template = "gtk4.css", target = "~/.local/state/aphotic/gtk4.css" }
 wal_colors_json = { template = "colors-wal.json", target = "~/.cache/wal/colors.json" }

--- a/README.md
+++ b/README.md
@@ -414,8 +414,41 @@ aphotic theme list
 aphotic theme set <theme>
 aphotic theme next
 aphotic theme prev
+aphotic theme refresh-gtk
 aphotic wallpaper --random
 ```
+
+### GTK4 and libadwaita apps
+
+GTK3 apps follow `gtk-theme-name`, so `adw-gtk3` plus the generated
+`gtk-3.0/gtk.css` already covers them. GTK4 is a different problem.
+libadwaita compiles its palette in and ignores the theme name, which is
+why Files, Text Editor, Calculator and the rest of the stock GNOME set
+sit at Adwaita's grey next to a themed desktop.
+
+The one thing libadwaita does read is `~/.config/gtk-4.0/gtk.css`, so
+that is what `aphotic theme set` writes: the full set of libadwaita
+named colors off your active palette, plus the handful of rules that
+fix what the named colors alone cannot. Chief among them the shade
+colors libadwaita paints along every headerbar, sidebar and card edge,
+which are opaque near-blacks picked for Adwaita's own grey and read as
+a dirty band over anything else.
+
+Two things follow from how libadwaita loads that file:
+
+-   It reads it once, at process start. A running app keeps the old
+    colors until it restarts. `aphotic theme set` restarts the GTK4
+    apps that stay resident with no window on screen, and leaves alone
+    any with a window open, which pick the colors up next launch.
+-   A color engine has no idea what font you use, so the stylesheet
+    ships a placeholder and the deploy step stamps in whatever
+    `gsettings` reports as your interface font. Run
+    `aphotic theme refresh-gtk` after changing that font.
+
+Both color engines render the stylesheet, so this works whichever one a
+theme pins. To theme another resident GTK4 app, add a row to
+`APHOTIC_GTK4_DAEMONS` in
+[`cmd_theme.sh`](Configs/.local/lib/aphotic/commands/cmd_theme.sh).
 
 > [!TIP]
 > Thunar has a right-click **Set as Theme** action for building a theme

--- a/README.md
+++ b/README.md
@@ -427,9 +427,11 @@ why Files, Text Editor, Calculator and the rest of the stock GNOME set
 sit at Adwaita's grey next to a themed desktop.
 
 The one thing libadwaita does read is `~/.config/gtk-4.0/gtk.css`, so
-that is what `aphotic theme set` writes: the full set of libadwaita
-named colors off your active palette, plus the handful of rules that
-fix what the named colors alone cannot. Chief among them the shade
+that is what Aphotic writes on every palette change, whichever way you
+made it: the CLI, the wallpaper picker, `Super` + `W`, thunar's Set as
+Theme. It carries the full set of libadwaita named colors off your
+active palette, plus the handful of rules that fix what the named
+colors alone cannot. Chief among them the shade
 colors libadwaita paints along every headerbar, sidebar and card edge,
 which are opaque near-blacks picked for Adwaita's own grey and read as
 a dirty band over anything else.
@@ -437,9 +439,9 @@ a dirty band over anything else.
 Two things follow from how libadwaita loads that file:
 
 -   It reads it once, at process start. A running app keeps the old
-    colors until it restarts. `aphotic theme set` restarts the GTK4
-    apps that stay resident with no window on screen, and leaves alone
-    any with a window open, which pick the colors up next launch.
+    colors until it restarts. Aphotic restarts the GTK4 apps that stay
+    resident with no window on screen, and leaves alone any with a
+    window open, which pick the colors up next launch.
 -   A color engine has no idea what font you use, so the stylesheet
     ships a placeholder and the deploy step stamps in whatever
     `gsettings` reports as your interface font. Run

--- a/tests/test_gtk4_theme_coverage.py
+++ b/tests/test_gtk4_theme_coverage.py
@@ -1,0 +1,109 @@
+"""Every path that regenerates the palette must also deploy the GTK4 stylesheet.
+
+The colour engines write ~/.local/state/aphotic/gtk4.css. Nothing reads
+it until `aphotic theme refresh-gtk` stamps the live UI font in and
+installs it over ~/.config/gtk-4.0/gtk.css, which is the only file
+libadwaita looks at. A path that runs an engine and skips that step
+leaves every GTK4 app on the previous theme's colours, and says nothing.
+
+That is not one call site. Five separate places run an engine: the CLI's
+theme apply and scheme set, Hyprland's two wallpaper scripts, and the
+shell's own picker. The first cut of this feature covered one of them.
+
+So this test has two halves. It pins the five known paths, and it fails
+on a sixth appearing anywhere in the tree, which is the half that
+actually catches the next one.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# The deploy, named as each language spells it.
+DEPLOY = re.compile(r"_aphotic_theme_refresh_gtk|refresh-gtk")
+
+# An engine in command position, which is narrower than the engine being
+# named. `wallust run`, `matugen image` and the list-head form
+# ["wallust", "cs", ...] all launch one. Colours.qml's
+# `engine === "matugen"` reads which one already ran and must not match,
+# nor must a wallust.toml path or a `wallust_cmd` variable name.
+ENGINE = re.compile(
+    r"""wallust\s+(?:run|cs|pywal|theme)\b"""
+    r"""|matugen\s+image\b"""
+    r"""|["'](?:wallust|matugen)["']\s*,"""
+    r"""|aphotic_matugen_run"""
+)
+
+# Files that name an engine without being a path a user can take to a new
+# palette. Each is exempt for a stated reason, not because the pattern was
+# inconvenient.
+EXEMPT = {
+    "Configs/.local/lib/aphotic/globalcontrol.sh":
+        "defines aphotic_matugen_run; every caller is itself covered below",
+    "scripts/generate-theme-anchors.sh":
+        "runs wallust against a throwaway config dir, never the real targets",
+    "Configs/.local/lib/aphotic/palette_clamp.py":
+        "rewrites a cached palette file, runs no engine",
+}
+
+# The paths that must deploy. Listed rather than discovered, so deleting a
+# call site fails here instead of quietly shrinking the covered set.
+REQUIRED = [
+    "Configs/.local/lib/aphotic/commands/cmd_theme.sh",
+    "Configs/.local/lib/aphotic/commands/cmd_scheme.sh",
+    "Configs/hypr/scripts/wallswitcher.py",
+    "Configs/hypr/scripts/thunar_wall.py",
+    "Configs/quickshell/aphotic/services/Wallpapers.qml",
+]
+
+SCANNED = (".sh", ".py", ".qml", ".lua")
+
+
+def strip_comments(text, suffix):
+    """A grep-shaped test fails on its own explanatory prose otherwise.
+
+    Both halves below would match the comments this feature is documented
+    in, so the comments come out first. Same reason
+    test_singleton_reachability.py strips `//`.
+    """
+    marker = {".qml": "//", ".lua": "--"}.get(suffix, "#")
+    return "\n".join(line.split(marker)[0] for line in text.splitlines())
+
+
+def source_files():
+    for path in ROOT.rglob("*"):
+        if path.suffix not in SCANNED or not path.is_file():
+            continue
+        rel = path.relative_to(ROOT).as_posix()
+        if rel.startswith(("tests/", "docs/", ".git/")):
+            continue
+        yield rel, path
+
+
+@pytest.mark.parametrize("rel", REQUIRED)
+def test_known_palette_path_deploys_gtk4_stylesheet(rel):
+    path = ROOT / rel
+    body = strip_comments(path.read_text(), path.suffix)
+    assert ENGINE.search(body), f"{rel} no longer runs a colour engine; drop it from REQUIRED"
+    assert DEPLOY.search(body), (
+        f"{rel} regenerates the palette without deploying the GTK4 stylesheet, "
+        "so every GTK4 app keeps the previous theme's colours"
+    )
+
+
+def test_no_unlisted_path_runs_a_colour_engine():
+    missed = []
+    for rel, path in source_files():
+        if rel in REQUIRED or rel in EXEMPT:
+            continue
+        body = strip_comments(path.read_text(), path.suffix)
+        if ENGINE.search(body):
+            missed.append(rel)
+    assert not missed, (
+        "these run a colour engine and are neither a known deploy path nor "
+        f"exempt: {missed}. Add the GTK4 deploy and list it in REQUIRED, or "
+        "add it to EXEMPT with the reason it cannot reach a new palette"
+    )

--- a/tests/test_theme_refresh_gtk.sh
+++ b/tests/test_theme_refresh_gtk.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# tests/test_theme_refresh_gtk.sh
+# `aphotic theme refresh-gtk` deploys the GTK4/libadwaita stylesheet the
+# color engine staged, with the live UI font stamped in, and restarts the
+# GTK4 apps that are sitting idle in the background so libadwaita reads
+# it (it reads the file once, at process start, and never again).
+#
+# The three things worth pinning down here: the font actually lands, the
+# destination is written by replacement rather than edited in place (it
+# can be a symlink, and `sed -i` would break the link), and an app with a
+# window open is left alone instead of being quit out from under someone.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TESTHOME=$(mktemp -d)
+export TESTHOME
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+export APHOTIC_SDDM_THEME_DIR="$TESTHOME/no-such-sddm-theme"
+
+FAKEBIN="$TESTHOME/fakebin"
+mkdir -p "$FAKEBIN"
+
+cat > "$FAKEBIN/gsettings" <<'EOF'
+#!/usr/bin/env bash
+[[ "$*" == "get org.gnome.desktop.interface font-name" ]] && echo "'Cantarell Test 11'"
+exit 0
+EOF
+
+# Records that it was asked to quit, so the assertions below can tell a
+# restart that happened from one that was skipped.
+cat > "$FAKEBIN/nautilus" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-q" ]] && echo quit >> "$TESTHOME/nautilus-quit.log"
+exit 0
+EOF
+
+# The daemon is "running" for every case below; what changes between them
+# is whether hyprctl reports a window for it.
+cat > "$FAKEBIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+[[ "$*" == *nautilus* ]] && exit 0
+exit 1
+EOF
+
+cat > "$FAKEBIN/hyprctl" <<'EOF'
+#!/usr/bin/env bash
+cat "$TESTHOME/clients.json"
+EOF
+
+chmod +x "$FAKEBIN"/*
+export PATH="$FAKEBIN:$PATH"
+
+LIB_DIR="$ROOT/Configs/.local/lib/aphotic"
+COMMANDS_DIR="$LIB_DIR/commands"
+source "$LIB_DIR/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_theme.sh"
+
+STAGED="$APHOTIC_STATE_HOME/gtk4.css"
+DEST="$XDG_CONFIG_HOME/gtk-4.0/gtk.css"
+
+# --- nothing staged yet: warn, do not fail, do not write ---
+echo '[]' > "$TESTHOME/clients.json"
+_aphotic_theme_refresh_gtk >/dev/null 2>&1 || fail "refresh-gtk should not fail with nothing staged"
+[[ -e "$DEST" ]] && fail "refresh-gtk wrote a stylesheet with nothing staged"
+
+# --- staged: font stamped, destination written ---
+mkdir -p "$APHOTIC_STATE_HOME"
+cat > "$STAGED" <<'EOF'
+@define-color window_bg_color #101010;
+window, popover, dialog, .background {
+  font-family: "Inter", sans-serif;
+}
+EOF
+
+_aphotic_theme_refresh_gtk >/dev/null 2>&1 || fail "refresh-gtk failed with a staged stylesheet"
+[[ -f "$DEST" ]] || fail "refresh-gtk did not write $DEST"
+grep -q 'font-family: "Cantarell Test", sans-serif;' "$DEST" \
+    || fail "the live UI font was not stamped in: $(grep font-family "$DEST")"
+grep -q '#101010' "$DEST" || fail "the staged colors did not survive the stamp"
+grep -q '"Inter"' "$DEST" && fail "the placeholder font was left in place"
+
+# --- idle daemon gets restarted ---
+[[ -f "$TESTHOME/nautilus-quit.log" ]] || fail "an idle GTK4 daemon was not restarted"
+
+# --- a symlinked destination stays a symlink's target, not the link ---
+rm -f "$DEST"
+REAL="$TESTHOME/real-gtk4.css"
+: > "$REAL"
+ln -s "$REAL" "$DEST"
+_aphotic_theme_refresh_gtk >/dev/null 2>&1 || fail "refresh-gtk failed against a symlinked destination"
+[[ -L "$DEST" ]] || fail "refresh-gtk replaced the symlink with a regular file"
+grep -q '#101010' "$REAL" || fail "refresh-gtk did not write through the symlink"
+
+# --- a daemon with a window open is left alone ---
+rm -f "$TESTHOME/nautilus-quit.log"
+cat > "$TESTHOME/clients.json" <<'EOF'
+[{"class": "org.gnome.Nautilus", "title": "Home"}]
+EOF
+out="$(_aphotic_theme_refresh_gtk 2>&1)" || fail "refresh-gtk failed with a window open"
+[[ -f "$TESTHOME/nautilus-quit.log" ]] && fail "a GTK4 app with a window open was quit"
+grep -q "leaving it alone" <<<"$out" || fail "no warning explained why the app was skipped: $out"
+grep -q '#101010' "$REAL" || fail "the stylesheet was not deployed when the restart was skipped"
+
+echo "PASS: theme refresh-gtk"


### PR DESCRIPTION
## Problem

Open Files, Text Editor or Calculator on a themed Aphotic desktop and
they sit at Adwaita's grey, headerbar shadows and all.

GTK3 apps follow `gtk-theme-name`, which `adw-gtk3` plus the generated
`gtk-3.0/gtk.css` already handles. GTK4 does not work that way.
libadwaita compiles its palette in and ignores the theme name outright.
The one file it does read is `~/.config/gtk-4.0/gtk.css`, and what both
color engines wrote there was the GTK3 template, twenty `@define-color`
lines that libadwaita only partly uses.

Two more things stood in the way even with the right colors. libadwaita
paints shade colors along every headerbar, sidebar and card edge, opaque
near-blacks chosen for its own grey, which read as a dirty band over any
other background. And it reads the stylesheet once, at process start, so
a resident app keeps the old colors however many times you switch theme.

## Plan

Give GTK4 its own template, its own staging path, and a deploy step.

`Configs/{wallust,matugen}/templates/gtk4.css` render the full set of
libadwaita named colors off the active palette, plus the rules the named
colors cannot reach: the shade colors as alpha over the real foreground,
the undershoot gradients, sidebar separators, and accent-tinted row
selection. Both files are generated from one body, so the two engines
cannot drift.

They render to `~/.local/state/aphotic/gtk4.css` rather than straight
into GTK's directory, because the file still needs the live UI font
stamped in and no color engine knows what font you use.

`_aphotic_theme_refresh_gtk` does the stamp, deploys the result, and
restarts the GTK4 apps that stay resident with nothing on screen. One
with a window open is skipped with a warning and picks the colors up
next launch: a stylesheet is not worth closing someone's file copy.
Exposed as `aphotic theme refresh-gtk` for use after a font change.

**It runs from every path that regenerates the palette, which is five
places, not one.** `_aphotic_theme_apply` covers `theme set/next/prev`
and `aphotic wallpaper`. The other four run an engine themselves and
each needed the call: the shell's own wallpaper picker
(`services/Wallpapers.qml`), `wallswitcher.py`, thunar's Set as Theme
(`thunar_wall.py`), and `aphotic scheme set`. Miss one and the staging
file updates while the file GTK reads goes stale, with nothing said.

`Wallpapers.qml` carried the same post-engine call three times over,
once per engine outcome, so anything added there covered two branches
out of three. Collapsed into `_afterEngine()`.

## Resolution

Eleven files.

- `Configs/wallust/templates/gtk4.css` and
  `Configs/matugen/templates/gtk4.css`, new.
- `wallust.toml` and `matugen/config.toml` point the `gtk4` target at the
  staging path. The `gtk` (GTK3) target is untouched.
- `cmd_theme.sh` gains the deploy, the font read, the daemon table and
  the `refresh-gtk` subcommand.
- `cmd_scheme.sh`, `wallswitcher.py`, `thunar_wall.py` and
  `Wallpapers.qml` call it after their own engine run.
- `tests/test_theme_refresh_gtk.sh` covers the font landing, the staged
  colors surviving, an idle daemon being restarted, one with a window
  open being left alone, and a symlinked destination staying a symlink
  (GNU `install` unlinks it the same way `sed -i` does; `cp` writes
  through).
- `tests/test_gtk4_theme_coverage.py` pins the five paths and fails on a
  sixth appearing anywhere in the tree.

Both templates were rendered against this desktop's wallpaper in a
sandbox config dir, one per engine, and GTK4's own CSS parser read each
result with no errors. `Wallpapers.qml` compiles and instantiates under
the headless probe with no binding errors; it was not driven, since
`setWallpaper()` would change the wallpaper for real. The coverage guard
was checked in both directions: dropping a listed deploy fails it, and
so does adding an unlisted engine call. Suite green, 91 python tests and
every bash test.

`Configs/wallust` and `Configs/matugen` are symlinked into `~/.config`
by the installer, so existing installs pick the templates up on the next
theme switch with no reinstall.

Needs a live look at a GTK4 app.
