### PR TITLE
doctor: report checkout drift, lay the groundwork for desired-state plugins

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
@@ -66,7 +66,10 @@ _aphotic_doctor_layer_plugins() {
 _aphotic_doctor_version_drift() {
     local dots="$APHOTIC_DOTS_DIR" branch head behind
 
-    [[ -d "${dots}/.git" ]] || {
+    # -d "$dots/.git" would miss a git worktree checkout -- .git there is
+    # a file (a "gitdir:" pointer back at the real repo), not a
+    # directory. rev-parse is the check that's actually true for both.
+    git -C "$dots" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
         echo "  [skip] ${dots} is not a git checkout"
         return 0
     }

--- a/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
@@ -57,6 +57,42 @@ _aphotic_doctor_layer_plugins() {
     [[ "$found" == "1" ]] || echo "  [ok]   no layer-gated plugins in the catalogue"
 }
 
+# APHOTIC_VERSION already comes straight off APHOTIC_DOTS_DIR/VERSION, so
+# it never itself drifts from the checkout -- what it can't say is whether
+# that checkout is behind origin/main. Compared against the cached
+# remote-tracking ref only; no network call here, since doctor is meant to
+# be fast and safe to run anytime. Same trap CONTRIBUTING.md warns about:
+# local main can sit behind origin/main with nothing surfacing it.
+_aphotic_doctor_version_drift() {
+    local dots="$APHOTIC_DOTS_DIR" branch head behind
+
+    [[ -d "${dots}/.git" ]] || {
+        echo "  [skip] ${dots} is not a git checkout"
+        return 0
+    }
+
+    branch="$(git -C "$dots" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    head="$(git -C "$dots" rev-parse --short HEAD 2>/dev/null)"
+    printf '  checked out: %s @ %s (v%s)\n' "${branch:-?}" "${head:-?}" "$APHOTIC_VERSION"
+
+    [[ "$branch" == "main" ]] || {
+        echo "  [skip] not on main -- drift check only compares main against origin/main"
+        return 0
+    }
+
+    git -C "$dots" rev-parse --verify -q origin/main >/dev/null 2>&1 || {
+        echo "  [skip] no origin/main ref cached -- run 'git fetch' to enable this check"
+        return 0
+    }
+
+    behind="$(git -C "$dots" rev-list --count HEAD..origin/main 2>/dev/null)"
+    if [[ -n "$behind" && "$behind" -gt 0 ]]; then
+        printf '  [warn] %s commit(s) behind origin/main (cached as of last fetch) -- aphotic sync to catch up\n' "$behind"
+    else
+        echo "  [ok]   up to date with origin/main (as of last fetch)"
+    fi
+}
+
 aphotic_cmd_doctor() {
     echo "Aphotic doctor — aphotic ${APHOTIC_VERSION}"
     echo
@@ -100,7 +136,7 @@ aphotic_cmd_doctor() {
         echo "Daemon: not running (aphotic shell -d)"
     fi
 
-    # TODO: compare APHOTIC_VERSION against APHOTIC_DOTS_DIR git HEAD /
-    # a version marker file, the way HyDE's `hyde-shell version` does,
-    # to surface "your dots are N commits behind" drift.
+    echo
+    echo "Version:"
+    _aphotic_doctor_version_drift
 }

--- a/Configs/.local/lib/aphotic/state.sh
+++ b/Configs/.local/lib/aphotic/state.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# lib/aphotic/state.sh — desired vs. actual plugin state.
+#
+# `aphotic.toml`'s optional `[plugins] enabled = [...]` is desired state;
+# the plugin registry on disk (APHOTIC_PLUGINS_DIR + APHOTIC_PLUGINS_STATE_FILE,
+# read through aphotic_plugin_names()/aphotic_plugin_is_enabled() in
+# globalcontrol.sh) is actual state. Nothing here writes either side --
+# it only reads both, so `aphotic diff`/`aphotic status`/`aphotic reconcile`
+# share one comparison instead of each re-deriving it.
+#
+# Not a cmd_*.sh: this is a library sourced by other commands, same as
+# globalcontrol.sh itself, and stays out of the dispatcher's command
+# discovery by living directly in lib/aphotic/ rather than commands/.
+
+# One desired plugin name per line, empty if the section is absent —
+# absence means "nothing declared", not "nothing should be enabled", so
+# callers must not treat an empty result as "disable everything".
+_aphotic_state_desired_plugins() {
+    aphotic_toml_get_array "${APHOTIC_DOTS_DIR}/aphotic.toml" plugins enabled
+}
+
+# One installed-and-enabled plugin name per line.
+_aphotic_state_actual_plugins() {
+    local name
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        aphotic_plugin_is_enabled "$name" && printf '%s\n' "$name"
+    done < <(aphotic_plugin_names)
+}
+
+# True (exit 0) only when aphotic.toml actually declares a [plugins]
+# section -- distinguishes "nothing desired" from "desired: nothing",
+# since an empty array is a real, meaningful desired state (uninstall
+# everything) and an absent section means drift tracking is opted out.
+_aphotic_state_plugins_declared() {
+    local toml="${APHOTIC_DOTS_DIR}/aphotic.toml"
+    [[ -f "$toml" ]] || return 1
+    grep -qE '^\[plugins\][[:space:]]*$' "$toml"
+}
+
+# name<TAB>state, one per line: state is "ok" (desired and actual agree),
+# "missing" (desired, not installed/enabled) or "extra" (installed and
+# enabled, not desired). Callers needing just one side can grep the tab
+# field rather than re-diffing.
+_aphotic_state_plugin_drift() {
+    _aphotic_state_plugins_declared || return 0
+
+    local desired actual name
+    desired="$(_aphotic_state_desired_plugins)"
+    actual="$(_aphotic_state_actual_plugins)"
+
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        if grep -qxF "$name" <<<"$actual"; then
+            printf '%s\tok\n' "$name"
+        else
+            printf '%s\tmissing\n' "$name"
+        fi
+    done <<<"$desired"
+
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        grep -qxF "$name" <<<"$desired" || printf '%s\textra\n' "$name"
+    done <<<"$actual"
+}

--- a/aphotic.toml.example
+++ b/aphotic.toml.example
@@ -17,6 +17,14 @@ position = "top"          # top | left
 nvidia = false
 aur_helper = "yay"
 
+# Declares which plugins should be installed and enabled -- the desired
+# state `aphotic diff`/`aphotic reconcile` compare the plugin registry
+# against. Omit the section entirely to opt out of plugin drift tracking;
+# an install with plugins already in place keeps working exactly as
+# before, nothing here is required.
+# [plugins]
+# enabled = ["resource-monitor", "agent-dashboard"]
+
 # Optional overrides for the Bar agent-status popout / Agent Graph's
 # built-in harness/provider table (Configs/quickshell/aphotic/services/
 # ai/AgentRoles.qml). Omit entirely to use the built-in defaults -- known

--- a/tests/test_doctor_version_drift.sh
+++ b/tests/test_doctor_version_drift.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# tests/test_doctor_version_drift.sh
+# `aphotic doctor`'s version section reports whether the dots checkout is
+# behind origin/main -- the trap noted in this repo's session docs: local
+# main can sit behind origin/main with nothing surfacing it. Exercises
+# _aphotic_doctor_version_drift directly against fabricated git state
+# rather than the real checkout, so the test doesn't depend on this
+# machine's actual fetch history.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/Configs/.local/lib/aphotic/commands/cmd_doctor.sh"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkrepo() {
+    local dir="$1"
+    mkdir -p "$dir"
+    git -C "$dir" init -q -b main
+    git -C "$dir" config user.email test@test.local
+    git -C "$dir" config user.name test
+    echo "9.9.9" > "$dir/VERSION"
+    git -C "$dir" add VERSION
+    git -C "$dir" commit -q -m init
+}
+
+# --- not a git checkout at all ---
+NOTGIT="$WORKDIR/notgit"
+mkdir -p "$NOTGIT"
+out="$(APHOTIC_DOTS_DIR="$NOTGIT" APHOTIC_VERSION="9.9.9" _aphotic_doctor_version_drift)"
+[[ "$out" == *"is not a git checkout"* ]] || fail "expected a non-git dots dir to be reported, got: $out"
+
+# --- on main, no origin/main ref cached ---
+NOFETCH="$WORKDIR/nofetch"
+mkrepo "$NOFETCH"
+out="$(APHOTIC_DOTS_DIR="$NOFETCH" APHOTIC_VERSION="9.9.9" _aphotic_doctor_version_drift)"
+[[ "$out" == *"no origin/main ref cached"* ]] || fail "expected a missing origin/main ref to be reported, got: $out"
+
+# --- on main, up to date with origin/main ---
+UPTODATE="$WORKDIR/uptodate"
+mkrepo "$UPTODATE"
+head="$(git -C "$UPTODATE" rev-parse HEAD)"
+git -C "$UPTODATE" update-ref refs/remotes/origin/main "$head"
+out="$(APHOTIC_DOTS_DIR="$UPTODATE" APHOTIC_VERSION="9.9.9" _aphotic_doctor_version_drift)"
+[[ "$out" == *"[ok]   up to date with origin/main"* ]] || fail "expected up-to-date main to report ok, got: $out"
+
+# --- on main, behind origin/main ---
+BEHIND="$WORKDIR/behind"
+mkrepo "$BEHIND"
+c1="$(git -C "$BEHIND" rev-parse HEAD)"
+echo "9.9.9-next" > "$BEHIND/VERSION"
+git -C "$BEHIND" commit -q -am next
+c2="$(git -C "$BEHIND" rev-parse HEAD)"
+git -C "$BEHIND" reset -q --hard "$c1"
+git -C "$BEHIND" update-ref refs/remotes/origin/main "$c2"
+out="$(APHOTIC_DOTS_DIR="$BEHIND" APHOTIC_VERSION="9.9.9" _aphotic_doctor_version_drift)"
+[[ "$out" == *"[warn] 1 commit(s) behind origin/main"* ]] || fail "expected 1 commit behind to be reported, got: $out"
+
+# --- not on main ---
+OTHERBRANCH="$WORKDIR/otherbranch"
+mkrepo "$OTHERBRANCH"
+git -C "$OTHERBRANCH" checkout -q -b feature/whatever
+out="$(APHOTIC_DOTS_DIR="$OTHERBRANCH" APHOTIC_VERSION="9.9.9" _aphotic_doctor_version_drift)"
+[[ "$out" == *"not on main"* ]] || fail "expected a non-main branch to be reported, got: $out"
+
+echo "ok: test_doctor_version_drift"

--- a/tests/test_doctor_version_drift.sh
+++ b/tests/test_doctor_version_drift.sh
@@ -66,4 +66,16 @@ git -C "$OTHERBRANCH" checkout -q -b feature/whatever
 out="$(APHOTIC_DOTS_DIR="$OTHERBRANCH" APHOTIC_VERSION="9.9.9" _aphotic_doctor_version_drift)"
 [[ "$out" == *"not on main"* ]] || fail "expected a non-main branch to be reported, got: $out"
 
+# --- a git worktree checkout, not a plain clone: .git is a file (a
+#     "gitdir:" pointer), not a directory, and must still count as a
+#     real checkout ---
+SOURCE="$WORKDIR/source"
+mkrepo "$SOURCE"
+WORKTREE="$WORKDIR/as-worktree"
+git -C "$SOURCE" worktree add -q -b feature/via-worktree "$WORKTREE" >/dev/null 2>&1
+[[ -f "$WORKTREE/.git" ]] || fail "test setup: expected .git to be a file under a worktree checkout"
+out="$(APHOTIC_DOTS_DIR="$WORKTREE" APHOTIC_VERSION="9.9.9" _aphotic_doctor_version_drift)"
+[[ "$out" == *"is not a git checkout"* ]] && fail "expected a worktree checkout to be recognized as git, got: $out"
+[[ "$out" == *"checked out: feature/via-worktree"* ]] || fail "expected the worktree's own branch to be reported, got: $out"
+
 echo "ok: test_doctor_version_drift"

--- a/tests/test_state_plugin_drift.sh
+++ b/tests/test_state_plugin_drift.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# tests/test_state_plugin_drift.sh
+# lib/aphotic/state.sh compares aphotic.toml's optional [plugins] enabled
+# list (desired) against the plugin registry (actual) for `aphotic diff`/
+# `status`/`reconcile` to share. An absent [plugins] section must mean
+# "drift tracking opted out", never "desired: nothing" -- an install that
+# has never declared the section should report no drift at all, not flag
+# every installed plugin as unwanted.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+
+DOTS="$TESTHOME/dots"
+mkdir -p "$DOTS"
+export APHOTIC_DOTS_DIR="$DOTS"
+
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$ROOT/Configs/.local/lib/aphotic/state.sh"
+
+install_plugin() {
+    mkdir -p "$APHOTIC_PLUGINS_DIR/$1"
+    : > "$APHOTIC_PLUGINS_DIR/$1/plugin.toml"
+}
+
+# --- no [plugins] section: opted out, no drift reported ---
+
+install_plugin "baz"
+[[ -z "$(_aphotic_state_plugin_drift)" ]] || fail "expected no drift with no [plugins] section declared"
+_aphotic_state_plugins_declared && fail "expected _aphotic_state_plugins_declared to be false with no section"
+
+# --- [plugins] declared: foo desired+installed (ok), bar desired but
+#     missing, baz installed+enabled but not desired (extra), qux
+#     installed but disabled and not desired (silent -- neither side) ---
+
+cat > "$DOTS/aphotic.toml" <<'EOF'
+[plugins]
+enabled = ["foo", "bar"]
+EOF
+
+install_plugin "foo"
+install_plugin "qux"
+echo '{"disabled": ["qux"]}' > "$APHOTIC_PLUGINS_STATE_FILE"
+
+_aphotic_state_plugins_declared || fail "expected _aphotic_state_plugins_declared to be true once [plugins] exists"
+
+drift="$(_aphotic_state_plugin_drift)"
+grep -qxF $'foo\tok' <<<"$drift" || fail "expected foo to report ok, got: $drift"
+grep -qxF $'bar\tmissing' <<<"$drift" || fail "expected bar to report missing, got: $drift"
+grep -qxF $'baz\textra' <<<"$drift" || fail "expected baz to report extra, got: $drift"
+grep -q "^qux" <<<"$drift" && fail "expected disabled+undesired qux to be silent, got: $drift"
+
+echo "ok: test_state_plugin_drift"


### PR DESCRIPTION
## Problem
Aphotic doctor checks dependencies, paths, layer/plugin coherence and
the display manager, but never says whether the dots checkout itself is
stale. Local main silently drifting behind origin/main has already bit
this project, and CONTRIBUTING.md documents the trap, but nothing
surfaces it automatically.

There's also no way today to declare which plugins should be installed
and enabled. Plugin state only ever changes imperatively
(aphotic plugin install/enable/disable), so there's nothing to diff a
machine against or reconverge to after a reinstall.

## Plan
Fill in doctor's existing TODO for version drift, comparing the checked-
out HEAD against the cached origin/main ref (no network call, so doctor
stays fast and safe to run anytime). Separately, give aphotic.toml one
new optional section, [plugins] enabled = [...], and a small shared
helper (lib/aphotic/state.sh) that diffs it against the plugin registry.
This is the foundation for aphotic status/diff/reconcile, which land as
their own PRs on top of this.

## Resolution
- aphotic doctor gains a "Version" section: checked-out branch/commit,
  and a warning with a commit count when main is behind origin/main
  (cached ref only, skips cleanly if nothing's been fetched yet or the
  checkout isn't on main).
- aphotic.toml.example documents the new [plugins] section. Omitting it
  keeps every existing install working exactly as before.
- lib/aphotic/state.sh: _aphotic_state_plugin_drift and its building
  blocks, reading desired state from aphotic.toml and actual state from
  the existing plugin registry helpers. Not wired into any command yet.
- Two new test files cover the version-drift function against
  fabricated git state and the plugin-drift helpers against a
  fabricated registry.

Nothing here changes behavior for an install that doesn't touch
[plugins]. Verify: bash tests/test_doctor_version_drift.sh, bash
tests/test_state_plugin_drift.sh, full suite green.