### PR TITLE
status, diff: read-only drift reporting on top of state.sh

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_diff.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_diff.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# aphotic diff — full drift report: what aphotic.toml (and the profile's
+# own package lists) declare versus what's actually true on this
+# machine. Read-only, same boundary `aphotic sync --check` already
+# respects: nothing here is applied. `aphotic reconcile` acts on this.
+# @cmd: diff
+# @cmd.desc: Report drift between aphotic.toml and what's actually installed/running
+# @cmd.group: CORE
+# @cmd.opt: --json | Machine-readable drift report
+
+# One line per row, prefixed with the mark that also decides whether it
+# counts toward "N changes required": ok never counts, warn and missing
+# always do, skip never does (nothing to reconcile, just not tracked).
+_aphotic_diff_line() {
+    local mark="$1" label="$2" detail="$3"
+    case "$mark" in
+        ok)   printf '\xe2\x9c\x93 %-10s %s\n' "$label" "$detail" ;;
+        warn) printf '! %-10s %s\n' "$label" "$detail" ;;
+        miss) printf -- '- %-10s %s\n' "$label" "$detail" ;;
+        skip) printf '  %-10s %s\n' "$label" "$detail" ;;
+    esac
+}
+
+aphotic_cmd_diff() {
+    source "${LIB_DIR}/state.sh"
+    source "${COMMANDS_DIR}/cmd_sync.sh"
+
+    local as_json=0
+    for arg in "$@"; do
+        case "$arg" in
+            --json) as_json=1 ;;
+            -h|--help)
+                cat <<'HELP'
+Usage: aphotic diff [--json]
+
+Full drift report: packages the current profile/layers ask for but
+aren't installed, plugins declared in aphotic.toml's [plugins] section
+that aren't installed/enabled (or the reverse), and the daemon/display-
+manager checks `aphotic doctor` also runs. Read-only. `aphotic reconcile`
+converges what it safely can.
+HELP
+                return 0
+                ;;
+        esac
+    done
+
+    local missing_packages
+    missing_packages="$(_aphotic_sync_missing_packages "$APHOTIC_DOTS_DIR")"
+    local missing_count=0
+    [[ -n "$missing_packages" ]] && missing_count="$(wc -l <<<"$missing_packages")"
+
+    local plugins_declared="false" plugin_missing=() plugin_extra=() plugin_ok=0
+    if _aphotic_state_plugins_declared; then
+        plugins_declared="true"
+        local name state
+        while IFS=$'\t' read -r name state; do
+            [[ -z "$name" ]] && continue
+            case "$state" in
+                missing) plugin_missing+=("$name") ;;
+                extra) plugin_extra+=("$name") ;;
+                ok) plugin_ok=$((plugin_ok + 1)) ;;
+            esac
+        done < <(_aphotic_state_plugin_drift)
+    fi
+
+    local services daemon_state dm_state dm_detail
+    services="$(_aphotic_state_service_drift)"
+    IFS=$'\t' read -r _ daemon_state _ <<<"$(grep '^daemon' <<<"$services")"
+    IFS=$'\t' read -r _ dm_state dm_detail <<<"$(grep '^displaymanager' <<<"$services")"
+
+    local drift_status drift_branch drift_head drift_behind
+    IFS=$'\t' read -r drift_status drift_branch drift_head drift_behind < <(_aphotic_state_version_drift)
+
+    local changes=0
+    [[ "$missing_count" -gt 0 ]] && changes=$((changes + missing_count))
+    changes=$((changes + ${#plugin_missing[@]} + ${#plugin_extra[@]}))
+    [[ "$daemon_state" != "running" ]] && changes=$((changes + 1))
+    [[ "$dm_state" == "conflict" ]] && changes=$((changes + 1))
+    [[ "$drift_status" == "behind" ]] && changes=$((changes + 1))
+
+    if [[ "$as_json" -eq 1 ]]; then
+        local missing_json="[]" plugin_missing_json="[]" plugin_extra_json="[]"
+        [[ -n "$missing_packages" ]] && missing_json="$(printf '%s\n' "$missing_packages" | jq -R . | jq -sc .)"
+        [[ "${#plugin_missing[@]}" -gt 0 ]] && plugin_missing_json="$(printf '%s\n' "${plugin_missing[@]}" | jq -R . | jq -sc .)"
+        [[ "${#plugin_extra[@]}" -gt 0 ]] && plugin_extra_json="$(printf '%s\n' "${plugin_extra[@]}" | jq -R . | jq -sc .)"
+
+        jq -nc \
+            --argjson missingPackages "$missing_json" \
+            --argjson pluginsDeclared "$plugins_declared" \
+            --argjson pluginsOk "$plugin_ok" \
+            --argjson pluginsMissing "$plugin_missing_json" \
+            --argjson pluginsExtra "$plugin_extra_json" \
+            --arg daemon "$daemon_state" \
+            --arg displayManager "$dm_state" \
+            --arg displayManagerDetail "${dm_detail:-}" \
+            --arg versionStatus "$drift_status" \
+            --argjson versionCommitsBehind "${drift_behind:-0}" \
+            --argjson changesRequired "$changes" \
+            '{missingPackages: $missingPackages,
+              plugins: {declared: $pluginsDeclared, ok: $pluginsOk, missing: $pluginsMissing, extra: $pluginsExtra},
+              services: {daemon: $daemon, displayManager: $displayManager, displayManagerDetail: $displayManagerDetail},
+              version: {status: $versionStatus, commitsBehind: $versionCommitsBehind},
+              changesRequired: $changesRequired}'
+        return 0
+    fi
+
+    echo "Aphotic system drift"
+    echo
+
+    if [[ "$missing_count" -eq 0 ]]; then
+        _aphotic_diff_line ok packages "all present"
+    else
+        _aphotic_diff_line miss packages "${missing_count} missing: $(printf '%s' "$missing_packages" | tr '\n' ' ')"
+    fi
+
+    if [[ "$plugins_declared" == "false" ]]; then
+        _aphotic_diff_line skip plugins "not declared in aphotic.toml, drift not tracked"
+    elif [[ "${#plugin_missing[@]}" -eq 0 && "${#plugin_extra[@]}" -eq 0 ]]; then
+        _aphotic_diff_line ok plugins "in sync (${plugin_ok})"
+    else
+        local p
+        for p in "${plugin_missing[@]}"; do
+            _aphotic_diff_line miss plugins "${p} missing"
+        done
+        for p in "${plugin_extra[@]}"; do
+            _aphotic_diff_line warn plugins "${p} not desired (enabled, not declared)"
+        done
+    fi
+
+    if [[ "$daemon_state" == "running" ]]; then
+        _aphotic_diff_line ok services "daemon running"
+    else
+        _aphotic_diff_line miss services "daemon not running (aphotic shell -d)"
+    fi
+    if [[ "$dm_state" == "conflict" ]]; then
+        _aphotic_diff_line warn services "$dm_detail"
+    fi
+
+    case "$drift_status" in
+        notgit) _aphotic_diff_line skip version "not a git checkout" ;;
+        not-main) _aphotic_diff_line skip version "not on main, drift not tracked" ;;
+        no-origin-ref) _aphotic_diff_line skip version "no origin/main ref cached, run git fetch" ;;
+        behind) _aphotic_diff_line warn version "${drift_behind} commit(s) behind origin/main" ;;
+        ok) _aphotic_diff_line ok version "up to date with origin/main" ;;
+    esac
+
+    echo
+    if [[ "$changes" -eq 0 ]]; then
+        echo "no changes required"
+    else
+        printf '%s change(s) required\n' "$changes"
+    fi
+}

--- a/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
@@ -59,41 +59,35 @@ _aphotic_doctor_layer_plugins() {
 
 # APHOTIC_VERSION already comes straight off APHOTIC_DOTS_DIR/VERSION, so
 # it never itself drifts from the checkout -- what it can't say is whether
-# that checkout is behind origin/main. Compared against the cached
-# remote-tracking ref only; no network call here, since doctor is meant to
-# be fast and safe to run anytime. Same trap CONTRIBUTING.md warns about:
-# local main can sit behind origin/main with nothing surfacing it.
+# that checkout is behind origin/main. Formats _aphotic_state_version_drift
+# (lib/aphotic/state.sh), shared with `aphotic status`/`aphotic diff` so
+# all three agree on what "behind" means.
 _aphotic_doctor_version_drift() {
-    local dots="$APHOTIC_DOTS_DIR" branch head behind
+    source "${LIB_DIR}/state.sh"
 
-    # -d "$dots/.git" would miss a git worktree checkout -- .git there is
-    # a file (a "gitdir:" pointer back at the real repo), not a
-    # directory. rev-parse is the check that's actually true for both.
-    git -C "$dots" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
-        echo "  [skip] ${dots} is not a git checkout"
+    local status branch head behind
+    IFS=$'\t' read -r status branch head behind < <(_aphotic_state_version_drift)
+
+    if [[ "$status" == "notgit" ]]; then
+        echo "  [skip] ${APHOTIC_DOTS_DIR} is not a git checkout"
         return 0
-    }
-
-    branch="$(git -C "$dots" rev-parse --abbrev-ref HEAD 2>/dev/null)"
-    head="$(git -C "$dots" rev-parse --short HEAD 2>/dev/null)"
-    printf '  checked out: %s @ %s (v%s)\n' "${branch:-?}" "${head:-?}" "$APHOTIC_VERSION"
-
-    [[ "$branch" == "main" ]] || {
-        echo "  [skip] not on main -- drift check only compares main against origin/main"
-        return 0
-    }
-
-    git -C "$dots" rev-parse --verify -q origin/main >/dev/null 2>&1 || {
-        echo "  [skip] no origin/main ref cached -- run 'git fetch' to enable this check"
-        return 0
-    }
-
-    behind="$(git -C "$dots" rev-list --count HEAD..origin/main 2>/dev/null)"
-    if [[ -n "$behind" && "$behind" -gt 0 ]]; then
-        printf '  [warn] %s commit(s) behind origin/main (cached as of last fetch) -- aphotic sync to catch up\n' "$behind"
-    else
-        echo "  [ok]   up to date with origin/main (as of last fetch)"
     fi
+
+    printf '  checked out: %s @ %s (v%s)\n' "$branch" "$head" "$APHOTIC_VERSION"
+    case "$status" in
+        not-main)
+            echo "  [skip] not on main -- drift check only compares main against origin/main"
+            ;;
+        no-origin-ref)
+            echo "  [skip] no origin/main ref cached -- run 'git fetch' to enable this check"
+            ;;
+        behind)
+            printf '  [warn] %s commit(s) behind origin/main (cached as of last fetch) -- aphotic sync to catch up\n' "$behind"
+            ;;
+        ok)
+            echo "  [ok]   up to date with origin/main (as of last fetch)"
+            ;;
+    esac
 }
 
 aphotic_cmd_doctor() {
@@ -118,22 +112,35 @@ aphotic_cmd_doctor() {
     echo "Layer plugins:"
     _aphotic_doctor_layer_plugins
 
+    source "${LIB_DIR}/state.sh"
+    local services daemon_state dm_state dm_detail
+    services="$(_aphotic_state_service_drift)"
+    IFS=$'\t' read -r _ daemon_state _ <<<"$(grep '^daemon' <<<"$services")"
+    IFS=$'\t' read -r _ dm_state dm_detail <<<"$(grep '^displaymanager' <<<"$services")"
+
     echo
     echo "Display manager:"
+    # A unit systemd has never heard of still writes "not-found" to
+    # stdout before exiting non-zero -- `|| echo disabled` inside the
+    # same command substitution let both land in the variable at once
+    # ("not-found\ndisabled" on one line). The fallback only applies when
+    # nothing came back at all.
     local sddm_enabled greetd_enabled
-    sddm_enabled="$(systemctl is-enabled sddm.service 2>/dev/null || echo disabled)"
-    greetd_enabled="$(systemctl is-enabled greetd.service 2>/dev/null || echo not-installed)"
+    sddm_enabled="$(systemctl is-enabled sddm.service 2>/dev/null)" || true
+    [[ -n "$sddm_enabled" ]] || sddm_enabled="disabled"
+    greetd_enabled="$(systemctl is-enabled greetd.service 2>/dev/null)" || true
+    [[ -n "$greetd_enabled" ]] || greetd_enabled="not-installed"
     printf '  sddm:   %s\n' "$sddm_enabled"
     printf '  greetd: %s\n' "$greetd_enabled"
     if [[ -f /etc/xdg/quickshell/aphotic-greeter/shell.qml ]]; then
         printf '  [ok]   greetd greeter scaffold deployed (aphotic displaymanager status for detail)\n'
     fi
-    if [[ "$sddm_enabled" == "enabled" && "$greetd_enabled" == "enabled" ]]; then
-        printf '  [warn] both sddm and greetd are enabled -- only one owns display-manager.service; run '\''aphotic displaymanager status'\'' to see which actually wins\n'
+    if [[ "$dm_state" == "conflict" ]]; then
+        printf '  [warn] %s; run '\''aphotic displaymanager status'\'' to see which actually wins\n' "$dm_detail"
     fi
 
     echo
-    if pgrep -f "qs -c aphotic" >/dev/null 2>&1; then
+    if [[ "$daemon_state" == "running" ]]; then
         echo "Daemon: running"
     else
         echo "Daemon: not running (aphotic shell -d)"

--- a/Configs/.local/lib/aphotic/commands/cmd_status.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_status.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# aphotic status — one-screen snapshot of what Aphotic is actually
+# running, versus `aphotic doctor` (dependency/path/coherence checks) and
+# `aphotic diff` (the full drift report). Reads lib/aphotic/state.sh's
+# shared helpers rather than re-deriving any of this.
+# @cmd: status
+# @cmd.desc: One-screen snapshot of profile, layers, plugins, services and version drift
+# @cmd.group: CORE
+# @cmd.opt: --json | Machine-readable snapshot
+
+_aphotic_status_plugin_counts() {
+    local ok=0 missing=0 extra=0 state name
+    while IFS=$'\t' read -r name state; do
+        [[ -z "$name" ]] && continue
+        case "$state" in
+            ok) ok=$((ok + 1)) ;;
+            missing) missing=$((missing + 1)) ;;
+            extra) extra=$((extra + 1)) ;;
+        esac
+    done < <(_aphotic_state_plugin_drift)
+    printf '%s\t%s\t%s\n' "$ok" "$missing" "$extra"
+}
+
+aphotic_cmd_status() {
+    source "${LIB_DIR}/state.sh"
+
+    local as_json=0
+    for arg in "$@"; do
+        case "$arg" in
+            --json) as_json=1 ;;
+            -h|--help)
+                cat <<'HELP'
+Usage: aphotic status [--json]
+
+One-screen snapshot: version/checkout drift, install profile and layers,
+plugin state versus aphotic.toml's declared [plugins] (if any), and the
+same daemon/display-manager checks `aphotic doctor` runs. Read-only --
+see `aphotic diff` for the full drift report and `aphotic reconcile` to
+act on it.
+HELP
+                return 0
+                ;;
+        esac
+    done
+
+    local toml="${APHOTIC_DOTS_DIR}/aphotic.toml"
+    local profile layers
+    # aphotic_toml_get/_get_array return 1 when aphotic.toml itself is
+    # missing (a bare checkout with no install.sh run yet) -- || true
+    # keeps that a graceful "unknown" below rather than an abort under
+    # set -e.
+    profile="$(aphotic_toml_get "$toml" install profile)" || true
+    layers="$(aphotic_toml_get_array "$toml" install layers | paste -sd, -)" || true
+
+    local drift_status drift_branch drift_head drift_behind
+    IFS=$'\t' read -r drift_status drift_branch drift_head drift_behind < <(_aphotic_state_version_drift)
+
+    local declared="false" ok=0 missing=0 extra=0
+    if _aphotic_state_plugins_declared; then
+        declared="true"
+        IFS=$'\t' read -r ok missing extra < <(_aphotic_status_plugin_counts)
+    fi
+
+    local services daemon_state dm_state
+    services="$(_aphotic_state_service_drift)"
+    IFS=$'\t' read -r _ daemon_state _ <<<"$(grep '^daemon' <<<"$services")"
+    IFS=$'\t' read -r _ dm_state _ <<<"$(grep '^displaymanager' <<<"$services")"
+
+    if [[ "$as_json" -eq 1 ]]; then
+        jq -nc \
+            --arg version "$APHOTIC_VERSION" \
+            --arg profile "${profile:-}" \
+            --arg layers "${layers:-}" \
+            --arg driftStatus "$drift_status" \
+            --arg driftBranch "${drift_branch:-}" \
+            --arg driftHead "${drift_head:-}" \
+            --argjson driftBehind "${drift_behind:-0}" \
+            --argjson pluginsDeclared "$declared" \
+            --argjson pluginsOk "$ok" \
+            --argjson pluginsMissing "$missing" \
+            --argjson pluginsExtra "$extra" \
+            --arg daemon "$daemon_state" \
+            --arg displayManager "$dm_state" \
+            '{version: $version, profile: $profile, layers: ($layers | split(",") | map(select(length > 0))),
+              versionDrift: {status: $driftStatus, branch: $driftBranch, head: $driftHead, commitsBehind: $driftBehind},
+              plugins: {declared: $pluginsDeclared, ok: $pluginsOk, missing: $pluginsMissing, extra: $pluginsExtra},
+              services: {daemon: $daemon, displayManager: $displayManager}}'
+        return 0
+    fi
+
+    echo "Aphotic status — aphotic ${APHOTIC_VERSION}"
+    echo
+    printf 'Profile: %s\n' "${profile:-unknown}"
+    printf 'Layers:  %s\n' "${layers:-none}"
+    echo
+    case "$drift_status" in
+        notgit) echo "Checkout: not a git checkout" ;;
+        *)
+            printf 'Checkout: %s @ %s\n' "$drift_branch" "$drift_head"
+            case "$drift_status" in
+                behind) printf '          %s commit(s) behind origin/main\n' "$drift_behind" ;;
+                ok) echo "          up to date with origin/main" ;;
+                not-main) echo "          not on main, drift not tracked" ;;
+                no-origin-ref) echo "          no origin/main ref cached, run git fetch" ;;
+            esac
+            ;;
+    esac
+    echo
+    if [[ "$declared" == "true" ]]; then
+        printf 'Plugins:  %s ok, %s missing, %s extra (vs aphotic.toml)\n' "$ok" "$missing" "$extra"
+    else
+        echo "Plugins:  not declared in aphotic.toml, drift not tracked"
+    fi
+    printf 'Daemon:   %s\n' "$daemon_state"
+    printf 'Display manager: %s\n' "$dm_state"
+}

--- a/Configs/.local/lib/aphotic/state.sh
+++ b/Configs/.local/lib/aphotic/state.sh
@@ -63,3 +63,67 @@ _aphotic_state_plugin_drift() {
         grep -qxF "$name" <<<"$desired" || printf '%s\textra\n' "$name"
     done <<<"$actual"
 }
+
+# Structured git-drift facts for the dots checkout, one tab-separated
+# record: <status>\t<branch>\t<head>\t<behind>
+#   status: notgit | not-main | no-origin-ref | ok | behind
+#   behind: commit count when status=behind, empty otherwise
+# No network call -- compares against whatever origin/main was cached by
+# the last `git fetch`, so this stays fast and safe to run anytime.
+# Shared by `aphotic doctor`, `aphotic status` and `aphotic diff` so the
+# three surfaces can't drift from each other on what "behind" means.
+_aphotic_state_version_drift() {
+    local dots="$APHOTIC_DOTS_DIR" branch head behind
+
+    # -d "$dots/.git" would miss a git worktree checkout -- .git there is
+    # a file (a "gitdir:" pointer back at the real repo), not a
+    # directory. rev-parse is the check that's actually true for both.
+    git -C "$dots" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+        printf 'notgit\t\t\t\n'
+        return 0
+    }
+
+    branch="$(git -C "$dots" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    head="$(git -C "$dots" rev-parse --short HEAD 2>/dev/null)"
+
+    [[ "$branch" == "main" ]] || {
+        printf 'not-main\t%s\t%s\t\n' "${branch:-?}" "${head:-?}"
+        return 0
+    }
+
+    git -C "$dots" rev-parse --verify -q origin/main >/dev/null 2>&1 || {
+        printf 'no-origin-ref\t%s\t%s\t\n' "$branch" "$head"
+        return 0
+    }
+
+    behind="$(git -C "$dots" rev-list --count HEAD..origin/main 2>/dev/null)"
+    if [[ -n "$behind" && "$behind" -gt 0 ]]; then
+        printf 'behind\t%s\t%s\t%s\n' "$branch" "$head" "$behind"
+    else
+        printf 'ok\t%s\t%s\t0\n' "$branch" "$head"
+    fi
+}
+
+# Structured service facts, one tab-separated record per line:
+# <check>\t<state>\t<detail>
+#   daemon: running | stopped
+#   displaymanager: ok | conflict (detail: which two)
+# Not a new desired-state format -- just what `aphotic doctor` already
+# knew how to check, exposed so `aphotic status`/`aphotic diff` can ask
+# the same question instead of re-deriving it.
+_aphotic_state_service_drift() {
+    if pgrep -f "qs -c aphotic" >/dev/null 2>&1; then
+        printf 'daemon\trunning\t\n'
+    else
+        printf 'daemon\tstopped\t\n'
+    fi
+
+    local sddm_enabled greetd_enabled
+    sddm_enabled="$(systemctl is-enabled sddm.service 2>/dev/null)" || true
+    greetd_enabled="$(systemctl is-enabled greetd.service 2>/dev/null)" || true
+    if [[ "$sddm_enabled" == "enabled" && "$greetd_enabled" == "enabled" ]]; then
+        printf 'displaymanager\tconflict\tboth sddm and greetd enabled -- only one owns display-manager.service\n'
+    else
+        printf 'displaymanager\tok\t\n'
+    fi
+}

--- a/tests/test_diff_cli.sh
+++ b/tests/test_diff_cli.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# tests/test_diff_cli.sh
+# `aphotic diff` aggregates lib/aphotic/state.sh's plugin/service/version
+# drift plus cmd_sync.sh's existing missing-packages check into one
+# report, both human and --json. Exercises the aggregation and the
+# "N changes required" count against fabricated plugin/git/service state
+# -- not `_aphotic_sync_missing_packages` itself, which this reuses as-is.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB_DIR="$ROOT/Configs/.local/lib/aphotic"
+COMMANDS_DIR="$LIB_DIR/commands"
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+
+DOTS="$TESTHOME/dots"
+mkdir -p "$DOTS"
+git -C "$DOTS" init -q -b main
+git -C "$DOTS" config user.email test@test.local
+git -C "$DOTS" config user.name test
+echo "9.9.9" > "$DOTS/VERSION"
+git -C "$DOTS" add VERSION
+git -C "$DOTS" commit -q -m init
+export APHOTIC_DOTS_DIR="$DOTS"
+
+# Stub systemctl/pgrep so daemon+display-manager read as clean and
+# deterministic, same shape as test_config_sync_orphan_kill.sh's stubs.
+mkdir -p "$TESTHOME/bin"
+export PATH="$TESTHOME/bin:$PATH"
+cat > "$TESTHOME/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+echo disabled
+exit 1
+EOF
+chmod +x "$TESTHOME/bin/systemctl"
+cat > "$TESTHOME/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$TESTHOME/bin/pgrep"
+
+source "$LIB_DIR/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_diff.sh"
+
+# --- nothing declared, daemon not running: exactly one required change ---
+
+out="$(aphotic_cmd_diff)"
+[[ "$out" == *"1 change(s) required"* ]] || fail "expected exactly 1 change with nothing else drifted, got: $out"
+[[ "$out" == *"not declared in aphotic.toml"* ]] || fail "expected plugins to report undeclared, got: $out"
+
+json="$(aphotic_cmd_diff --json)"
+[[ "$(jq -r '.changesRequired' <<<"$json")" == "1" ]] || fail "expected --json changesRequired=1, got: $json"
+[[ "$(jq -r '.plugins.declared' <<<"$json")" == "false" ]] || fail "expected --json plugins.declared=false, got: $json"
+
+# --- [plugins] declared: one ok, one missing, one extra ---
+
+cat > "$DOTS/aphotic.toml" <<'EOF'
+[plugins]
+enabled = ["foo", "bar"]
+EOF
+mkdir -p "$APHOTIC_PLUGINS_DIR/foo" "$APHOTIC_PLUGINS_DIR/baz"
+: > "$APHOTIC_PLUGINS_DIR/foo/plugin.toml"
+: > "$APHOTIC_PLUGINS_DIR/baz/plugin.toml"
+
+out="$(aphotic_cmd_diff)"
+[[ "$out" == *"bar missing"* ]] || fail "expected bar to report missing, got: $out"
+[[ "$out" == *"baz not desired"* ]] || fail "expected baz to report not desired, got: $out"
+[[ "$out" == *"3 change(s) required"* ]] || fail "expected 3 changes (bar missing, baz extra, daemon stopped), got: $out"
+
+json="$(aphotic_cmd_diff --json)"
+[[ "$(jq -r '.plugins.missing[0]' <<<"$json")" == "bar" ]] || fail "expected --json plugins.missing to include bar, got: $json"
+[[ "$(jq -r '.plugins.extra[0]' <<<"$json")" == "baz" ]] || fail "expected --json plugins.extra to include baz, got: $json"
+
+echo "ok: test_diff_cli"

--- a/tests/test_doctor_version_drift.sh
+++ b/tests/test_doctor_version_drift.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 fail() { echo "FAIL: $1"; exit 1; }
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-source "$ROOT/Configs/.local/lib/aphotic/commands/cmd_doctor.sh"
+LIB_DIR="$ROOT/Configs/.local/lib/aphotic"
+source "$LIB_DIR/commands/cmd_doctor.sh"
 
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT

--- a/tests/test_status_cli.sh
+++ b/tests/test_status_cli.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# tests/test_status_cli.sh
+# `aphotic status` is the one-screen read of profile/layers, plugin
+# counts against aphotic.toml's [plugins], and version/service state --
+# same lib/aphotic/state.sh helpers `aphotic diff` uses, summarized
+# rather than itemized.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB_DIR="$ROOT/Configs/.local/lib/aphotic"
+COMMANDS_DIR="$LIB_DIR/commands"
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+
+DOTS="$TESTHOME/dots"
+mkdir -p "$DOTS"
+git -C "$DOTS" init -q -b main
+git -C "$DOTS" config user.email test@test.local
+git -C "$DOTS" config user.name test
+echo "9.9.9" > "$DOTS/VERSION"
+git -C "$DOTS" add VERSION
+git -C "$DOTS" commit -q -m init
+git -C "$DOTS" update-ref refs/remotes/origin/main "$(git -C "$DOTS" rev-parse HEAD)"
+cat > "$DOTS/aphotic.toml" <<'EOF'
+[install]
+profile = "full"
+layers = ["gaming", "ai"]
+
+[plugins]
+enabled = ["foo"]
+EOF
+export APHOTIC_DOTS_DIR="$DOTS"
+
+source "$LIB_DIR/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_status.sh"
+
+mkdir -p "$APHOTIC_PLUGINS_DIR/foo"
+: > "$APHOTIC_PLUGINS_DIR/foo/plugin.toml"
+
+mkdir -p "$TESTHOME/bin"
+export PATH="$TESTHOME/bin:$PATH"
+cat > "$TESTHOME/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+echo disabled
+exit 1
+EOF
+chmod +x "$TESTHOME/bin/systemctl"
+cat > "$TESTHOME/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$TESTHOME/bin/pgrep"
+
+out="$(aphotic_cmd_status)"
+[[ "$out" == *"Profile: full"* ]] || fail "expected profile full, got: $out"
+[[ "$out" == *"Layers:  gaming,ai"* ]] || fail "expected layers gaming,ai, got: $out"
+[[ "$out" == *"1 ok, 0 missing, 0 extra"* ]] || fail "expected plugin counts 1/0/0, got: $out"
+[[ "$out" == *"up to date with origin/main"* ]] || fail "expected up-to-date version drift, got: $out"
+
+json="$(aphotic_cmd_status --json)"
+[[ "$(jq -r '.profile' <<<"$json")" == "full" ]] || fail "expected --json profile=full, got: $json"
+[[ "$(jq -c '.layers' <<<"$json")" == '["gaming","ai"]' ]] || fail "expected --json layers array, got: $json"
+[[ "$(jq -r '.plugins.ok' <<<"$json")" == "1" ]] || fail "expected --json plugins.ok=1, got: $json"
+[[ "$(jq -r '.versionDrift.status' <<<"$json")" == "ok" ]] || fail "expected --json versionDrift.status=ok, got: $json"
+
+echo "ok: test_status_cli"


### PR DESCRIPTION
## Problem
aphotic doctor checks dependencies and paths but there's nowhere to ask
"what does aphotic.toml want, and is it true right now" in one place --
profile/layers, plugin drift against the new [plugins] section (#171),
daemon/display-manager state, checkout drift. aphotic sync --check
covers packages/plugin-version drift but nothing else.

## Plan
Two new read-only commands, aphotic status (one-screen summary) and
aphotic diff (the full report, plus a "N changes required" count), both
built on lib/aphotic/state.sh. Rather than each re-deriving doctor's
daemon/display-manager and version-drift logic, pulled those into
state.sh as structured (tab-separated) helpers and had doctor delegate
to them too, so all three commands agree on what "drifted" means.

Stacked on #171 (this branch was cut from it before its own fix commit
landed, so this PR's diff includes a worktree-checkout-detection fix
that overlaps with one already pushed to #171 -- rebasing onto main
once #171 merges will resolve that; nothing to review twice, just a
mechanical step).

## Resolution
- aphotic status [--json]: profile, layers, plugin ok/missing/extra
  counts (only when aphotic.toml declares [plugins]), checkout drift,
  daemon/display-manager state.
- aphotic diff [--json]: the same facts as a full report -- missing
  packages (reuses _aphotic_sync_missing_packages as-is), per-plugin
  missing/extra, daemon/display-manager, checkout drift -- with a
  changes-required count. Nothing here writes anything.
- lib/aphotic/state.sh gains _aphotic_state_version_drift and
  _aphotic_state_service_drift, both structured (tab-separated)
  versions of what doctor already checked; doctor now delegates to
  both, output unchanged.
- Two bugs found and fixed while doing that pull: a failed systemctl
  is-enabled call landing two lines in one captured variable, and a
  missing aphotic.toml aborting a plain toml read under set -e instead
  of degrading to "unknown".
- New tests: test_status_cli.sh, test_diff_cli.sh, plus a worktree-
  checkout case added to test_doctor_version_drift.sh.

Verify: bash tests/test_status_cli.sh, bash tests/test_diff_cli.sh,
full suite green. aphotic reconcile/rollback/update (the apply path)
land as their own PR on top of this.