### PR TITLE
reconcile, rollback: converge plugin state, undo it if needed

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_backup.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_backup.sh
@@ -13,10 +13,26 @@
 # concept). `restore` deploys Aphotic's own upstream defaults with
 # populate/overwrite semantics (HyDE's P/O flags).
 
+# "name|path": each snapshot stores a target at ${dest}/<name>, not
+# ${dest}/$(basename path) -- QUICKSHELL_CONFIG_DIR
+# (~/.config/quickshell/aphotic) and APHOTIC_CONFIG_HOME
+# (~/.config/aphotic) both basename to "aphotic", and a plain-path array
+# let the two silently collide in every snapshot ever taken: whichever
+# target this array listed later landed in the shared slot and quietly
+# overwrote whatever the earlier one had just copied there, so the
+# earlier target was never actually recoverable. Found while wiring
+# aphotic reconcile's rollback through this, which is exactly the kind
+# of silent failure the whole point of a reconciliation layer is to
+# rule out.
 _aphotic_backup_targets=(
-    "$HOME/.config/hypr"
-    "$QUICKSHELL_CONFIG_DIR"
-    "$APHOTIC_CONFIG_HOME"
+    "hypr|$HOME/.config/hypr"
+    "quickshell|$QUICKSHELL_CONFIG_DIR"
+    "aphotic|$APHOTIC_CONFIG_HOME"
+    # aphotic reconcile --apply's only mutation target: the enabled/
+    # disabled flags in the plugin registry. Without this here, a
+    # pre-reconcile snapshot wouldn't actually cover the one thing
+    # reconcile changes, and `aphotic rollback` couldn't undo it.
+    "plugins-state|$APHOTIC_PLUGINS_STATE_FILE"
 )
 
 _aphotic_backup_create() {
@@ -33,9 +49,12 @@ _aphotic_backup_create() {
     dest="${APHOTIC_BACKUP_DIR}/${id}"
     mkdir -p "$dest"
 
-    for target in "${_aphotic_backup_targets[@]}"; do
+    local entry name target
+    for entry in "${_aphotic_backup_targets[@]}"; do
+        name="${entry%%|*}"
+        target="${entry#*|}"
         if [[ -e "$target" ]]; then
-            cp -a "$target" "${dest}/$(basename "$target")"
+            cp -a "$target" "${dest}/${name}"
         else
             missing=$((missing + 1))
         fi
@@ -98,10 +117,17 @@ _aphotic_backup_revert() {
     # is itself always reversible.
     _aphotic_backup_create --label "pre-revert" >/dev/null
 
-    for target in "${_aphotic_backup_targets[@]}"; do
-        local rel="${src}/$(basename "$target")"
+    local entry name target rel
+    for entry in "${_aphotic_backup_targets[@]}"; do
+        name="${entry%%|*}"
+        target="${entry#*|}"
+        rel="${src}/${name}"
         if [[ -e "$rel" ]]; then
             rm -rf "$target"
+            # The target's parent may not exist yet -- a fresh machine,
+            # or a target that never got created before this snapshot
+            # was taken. cp -a does not create it.
+            mkdir -p "$(dirname "$target")"
             cp -a "$rel" "$target"
         fi
     done

--- a/Configs/.local/lib/aphotic/commands/cmd_diff.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_diff.sh
@@ -49,7 +49,7 @@ HELP
     local missing_count=0
     [[ -n "$missing_packages" ]] && missing_count="$(wc -l <<<"$missing_packages")"
 
-    local plugins_declared="false" plugin_missing=() plugin_extra=() plugin_ok=0
+    local plugins_declared="false" plugin_missing=() plugin_extra=() plugin_disabled=() plugin_ok=0
     if _aphotic_state_plugins_declared; then
         plugins_declared="true"
         local name state
@@ -58,6 +58,7 @@ HELP
             case "$state" in
                 missing) plugin_missing+=("$name") ;;
                 extra) plugin_extra+=("$name") ;;
+                disabled) plugin_disabled+=("$name") ;;
                 ok) plugin_ok=$((plugin_ok + 1)) ;;
             esac
         done < <(_aphotic_state_plugin_drift)
@@ -73,16 +74,17 @@ HELP
 
     local changes=0
     [[ "$missing_count" -gt 0 ]] && changes=$((changes + missing_count))
-    changes=$((changes + ${#plugin_missing[@]} + ${#plugin_extra[@]}))
+    changes=$((changes + ${#plugin_missing[@]} + ${#plugin_extra[@]} + ${#plugin_disabled[@]}))
     [[ "$daemon_state" != "running" ]] && changes=$((changes + 1))
     [[ "$dm_state" == "conflict" ]] && changes=$((changes + 1))
     [[ "$drift_status" == "behind" ]] && changes=$((changes + 1))
 
     if [[ "$as_json" -eq 1 ]]; then
-        local missing_json="[]" plugin_missing_json="[]" plugin_extra_json="[]"
+        local missing_json="[]" plugin_missing_json="[]" plugin_extra_json="[]" plugin_disabled_json="[]"
         [[ -n "$missing_packages" ]] && missing_json="$(printf '%s\n' "$missing_packages" | jq -R . | jq -sc .)"
         [[ "${#plugin_missing[@]}" -gt 0 ]] && plugin_missing_json="$(printf '%s\n' "${plugin_missing[@]}" | jq -R . | jq -sc .)"
         [[ "${#plugin_extra[@]}" -gt 0 ]] && plugin_extra_json="$(printf '%s\n' "${plugin_extra[@]}" | jq -R . | jq -sc .)"
+        [[ "${#plugin_disabled[@]}" -gt 0 ]] && plugin_disabled_json="$(printf '%s\n' "${plugin_disabled[@]}" | jq -R . | jq -sc .)"
 
         jq -nc \
             --argjson missingPackages "$missing_json" \
@@ -90,6 +92,7 @@ HELP
             --argjson pluginsOk "$plugin_ok" \
             --argjson pluginsMissing "$plugin_missing_json" \
             --argjson pluginsExtra "$plugin_extra_json" \
+            --argjson pluginsDisabled "$plugin_disabled_json" \
             --arg daemon "$daemon_state" \
             --arg displayManager "$dm_state" \
             --arg displayManagerDetail "${dm_detail:-}" \
@@ -97,7 +100,7 @@ HELP
             --argjson versionCommitsBehind "${drift_behind:-0}" \
             --argjson changesRequired "$changes" \
             '{missingPackages: $missingPackages,
-              plugins: {declared: $pluginsDeclared, ok: $pluginsOk, missing: $pluginsMissing, extra: $pluginsExtra},
+              plugins: {declared: $pluginsDeclared, ok: $pluginsOk, missing: $pluginsMissing, extra: $pluginsExtra, disabled: $pluginsDisabled},
               services: {daemon: $daemon, displayManager: $displayManager, displayManagerDetail: $displayManagerDetail},
               version: {status: $versionStatus, commitsBehind: $versionCommitsBehind},
               changesRequired: $changesRequired}'
@@ -115,12 +118,15 @@ HELP
 
     if [[ "$plugins_declared" == "false" ]]; then
         _aphotic_diff_line skip plugins "not declared in aphotic.toml, drift not tracked"
-    elif [[ "${#plugin_missing[@]}" -eq 0 && "${#plugin_extra[@]}" -eq 0 ]]; then
+    elif [[ "${#plugin_missing[@]}" -eq 0 && "${#plugin_extra[@]}" -eq 0 && "${#plugin_disabled[@]}" -eq 0 ]]; then
         _aphotic_diff_line ok plugins "in sync (${plugin_ok})"
     else
         local p
         for p in "${plugin_missing[@]}"; do
             _aphotic_diff_line miss plugins "${p} missing"
+        done
+        for p in "${plugin_disabled[@]}"; do
+            _aphotic_diff_line warn plugins "${p} installed but disabled"
         done
         for p in "${plugin_extra[@]}"; do
             _aphotic_diff_line warn plugins "${p} not desired (enabled, not declared)"

--- a/Configs/.local/lib/aphotic/commands/cmd_reconcile.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_reconcile.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# aphotic reconcile — converge installed plugins to match aphotic.toml's
+# [plugins] enabled list. Dry-run by default; --apply actually converges.
+#
+# Scope is deliberately narrow: plugins are the only domain with a real
+# user-declared desired state today (aphotic.toml's [plugins] section).
+# --apply only ever toggles enable/disable on plugins already installed
+# -- it never installs a plugin it doesn't have (that's a network fetch
+# with its own failure modes, not a flip of a flag) and never touches
+# packages (needs sudo and a resolved profile, install.sh's job, same
+# boundary `aphotic sync` already respects). A "missing" plugin is
+# reported with the command to install it, not run automatically.
+# Daemon/display-manager drift is informational only -- there's no
+# [services] section declaring a "should be" state to converge against.
+# @cmd: reconcile
+# @cmd.desc: Converge installed plugins to match aphotic.toml's [plugins] list
+# @cmd.group: LIFECYCLE
+# @cmd.opt: (no args) | Dry run: show what would change
+# @cmd.opt: --apply    | Enable/disable plugins to match aphotic.toml (auto-snapshots first)
+# @cmd.opt: --json     | Machine-readable report
+
+aphotic_cmd_reconcile() {
+    source "${LIB_DIR}/state.sh"
+
+    local apply=0 as_json=0
+    for arg in "$@"; do
+        case "$arg" in
+            --apply) apply=1 ;;
+            --json) as_json=1 ;;
+            -h|--help)
+                cat <<'HELP'
+Usage: aphotic reconcile [--apply] [--json]
+
+Compares the plugin registry against aphotic.toml's [plugins] enabled
+list. With no flags, prints what would change (a dry run) -- nothing is
+touched. --apply enables/disables plugins to match, snapshotting first
+(aphotic backup create --label pre-reconcile) so aphotic rollback can
+undo it. A plugin that isn't installed at all is reported, not
+installed -- run the printed 'aphotic plugin install' command yourself.
+Packages aren't touched here either; see 'aphotic diff'/'aphotic sync'.
+HELP
+                return 0
+                ;;
+        esac
+    done
+
+    if ! _aphotic_state_plugins_declared; then
+        if [[ "$as_json" -eq 1 ]]; then
+            jq -nc '{declared: false, missing: [], toEnable: [], toDisable: [], applied: false}'
+        else
+            aphotic_log "no [plugins] section in aphotic.toml -- nothing declared, nothing to reconcile"
+        fi
+        return 0
+    fi
+
+    local missing=() to_enable=() to_disable=() name state
+    while IFS=$'\t' read -r name state; do
+        [[ -z "$name" ]] && continue
+        case "$state" in
+            missing) missing+=("$name") ;;
+            disabled) to_enable+=("$name") ;;
+            extra) to_disable+=("$name") ;;
+        esac
+    done < <(_aphotic_state_plugin_drift)
+
+    local applicable=$((${#to_enable[@]} + ${#to_disable[@]}))
+    local total=$((applicable + ${#missing[@]}))
+
+    if [[ "$as_json" -eq 1 && "$apply" -eq 0 ]]; then
+        local missing_json="[]" enable_json="[]" disable_json="[]"
+        [[ "${#missing[@]}" -gt 0 ]] && missing_json="$(printf '%s\n' "${missing[@]}" | jq -R . | jq -sc .)"
+        [[ "${#to_enable[@]}" -gt 0 ]] && enable_json="$(printf '%s\n' "${to_enable[@]}" | jq -R . | jq -sc .)"
+        [[ "${#to_disable[@]}" -gt 0 ]] && disable_json="$(printf '%s\n' "${to_disable[@]}" | jq -R . | jq -sc .)"
+        jq -nc \
+            --argjson missing "$missing_json" \
+            --argjson toEnable "$enable_json" \
+            --argjson toDisable "$disable_json" \
+            '{declared: true, missing: $missing, toEnable: $toEnable, toDisable: $toDisable, applied: false}'
+        return 0
+    fi
+
+    if [[ "$total" -eq 0 ]]; then
+        [[ "$apply" -eq 0 && "$as_json" -eq 0 ]] && aphotic_ok "plugins already match aphotic.toml -- nothing to reconcile"
+        return 0
+    fi
+
+    if [[ "$apply" -eq 0 ]]; then
+        echo "Aphotic reconcile — dry run"
+        echo
+        local p
+        for p in "${to_enable[@]}"; do printf '  enable   %s\n' "$p"; done
+        for p in "${to_disable[@]}"; do printf '  disable  %s\n' "$p"; done
+        for p in "${missing[@]}"; do printf '  (manual) aphotic plugin install %s\n' "$p"; done
+        echo
+        if [[ "$applicable" -gt 0 ]]; then
+            printf '%s change(s) would be applied. Run with --apply to converge.\n' "$applicable"
+        else
+            echo "Nothing --apply can converge on its own -- install the missing plugin(s) above first."
+        fi
+        return 0
+    fi
+
+    # --apply from here down.
+    if [[ "$applicable" -eq 0 ]]; then
+        aphotic_log "nothing to enable or disable -- ${#missing[@]} plugin(s) still need 'aphotic plugin install' by hand"
+        return 0
+    fi
+
+    source "${COMMANDS_DIR}/cmd_backup.sh"
+    # >/dev/null, not captured: _aphotic_backup_create's own aphotic_ok
+    # call writes to the same stdout as its final `echo "$id"`, so
+    # capturing it here would fold that status line into the id itself.
+    # Same reason cmd_restore.sh's --overwrite path discards it too.
+    # aphotic_rollback finds the snapshot by label, not by id, so nothing
+    # downstream needs the id anyway.
+    _aphotic_backup_create --label "pre-reconcile" >/dev/null
+    aphotic_log "pre-reconcile snapshot saved (aphotic rollback undoes this)"
+
+    local failures=0 p
+    for p in "${to_enable[@]}"; do
+        aphotic_plugin_set_enabled "$p" true && aphotic_ok "enabled ${p}" || failures=$((failures + 1))
+    done
+    for p in "${to_disable[@]}"; do
+        aphotic_plugin_set_enabled "$p" false && aphotic_ok "disabled ${p}" || failures=$((failures + 1))
+    done
+
+    if [[ "$failures" -eq 0 ]]; then
+        aphotic_ok "reconcile complete -- ${applicable} change(s) applied"
+    else
+        aphotic_warn "reconcile finished with ${failures} failure(s) above -- 'aphotic rollback' restores ${snapshot} if needed"
+    fi
+    [[ "${#missing[@]}" -gt 0 ]] && aphotic_log "${#missing[@]} plugin(s) still need 'aphotic plugin install' by hand"
+}

--- a/Configs/.local/lib/aphotic/commands/cmd_rollback.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_rollback.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# aphotic rollback — undo the most recent `aphotic reconcile --apply`.
+# Thin wrapper around `aphotic backup`'s existing revert: no new revert
+# logic, just finds the latest snapshot reconcile labelled and calls it.
+# @cmd: rollback
+# @cmd.desc: Restore the most recent pre-reconcile snapshot
+# @cmd.group: LIFECYCLE
+# @cmd.opt: --yes | Skip the confirmation prompt
+
+# Most recent backup directory whose .label matches, or nothing (exit 1)
+# if there is none. Backup ids are timestamp-prefixed, but sorted by
+# mtime here (same as _aphotic_backup_clean) rather than trusting the
+# name to sort correctly forever.
+_aphotic_rollback_latest_snapshot() {
+    local label="$1" dir found=""
+    [[ -d "$APHOTIC_BACKUP_DIR" ]] || return 1
+    while IFS= read -r dir; do
+        [[ -f "${dir}/.label" ]] || continue
+        [[ "$(<"${dir}/.label")" == "$label" ]] || continue
+        found="$(basename "$dir")"
+    done < <(find "$APHOTIC_BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d -printf '%T@ %p\n' 2>/dev/null | sort -n | cut -d' ' -f2-)
+    [[ -n "$found" ]] || return 1
+    printf '%s\n' "$found"
+}
+
+aphotic_cmd_rollback() {
+    local assume_yes=0
+    for arg in "$@"; do
+        case "$arg" in
+            -y|--yes) assume_yes=1 ;;
+            -h|--help)
+                cat <<'HELP'
+Usage: aphotic rollback [--yes]
+
+Restores the most recent pre-reconcile snapshot -- the one `aphotic
+reconcile --apply` writes automatically before it changes anything.
+Thin wrapper around `aphotic backup revert`; use `aphotic backup list`
+and `aphotic backup revert <id>` directly to restore a different
+snapshot.
+HELP
+                return 0
+                ;;
+        esac
+    done
+
+    source "${COMMANDS_DIR}/cmd_backup.sh"
+    local id
+    id="$(_aphotic_rollback_latest_snapshot pre-reconcile)" || {
+        aphotic_err "no pre-reconcile snapshot found -- nothing for 'aphotic rollback' to undo (see 'aphotic backup list')"
+        return 1
+    }
+
+    if [[ "$assume_yes" -eq 1 ]]; then
+        _aphotic_backup_revert --yes "$id"
+    else
+        _aphotic_backup_revert "$id"
+    fi
+}

--- a/Configs/.local/lib/aphotic/commands/cmd_status.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_status.sh
@@ -9,16 +9,17 @@
 # @cmd.opt: --json | Machine-readable snapshot
 
 _aphotic_status_plugin_counts() {
-    local ok=0 missing=0 extra=0 state name
+    local ok=0 missing=0 extra=0 disabled=0 state name
     while IFS=$'\t' read -r name state; do
         [[ -z "$name" ]] && continue
         case "$state" in
             ok) ok=$((ok + 1)) ;;
             missing) missing=$((missing + 1)) ;;
             extra) extra=$((extra + 1)) ;;
+            disabled) disabled=$((disabled + 1)) ;;
         esac
     done < <(_aphotic_state_plugin_drift)
-    printf '%s\t%s\t%s\n' "$ok" "$missing" "$extra"
+    printf '%s\t%s\t%s\t%s\n' "$ok" "$missing" "$extra" "$disabled"
 }
 
 aphotic_cmd_status() {
@@ -55,10 +56,10 @@ HELP
     local drift_status drift_branch drift_head drift_behind
     IFS=$'\t' read -r drift_status drift_branch drift_head drift_behind < <(_aphotic_state_version_drift)
 
-    local declared="false" ok=0 missing=0 extra=0
+    local declared="false" ok=0 missing=0 extra=0 disabled=0
     if _aphotic_state_plugins_declared; then
         declared="true"
-        IFS=$'\t' read -r ok missing extra < <(_aphotic_status_plugin_counts)
+        IFS=$'\t' read -r ok missing extra disabled < <(_aphotic_status_plugin_counts)
     fi
 
     local services daemon_state dm_state
@@ -79,11 +80,12 @@ HELP
             --argjson pluginsOk "$ok" \
             --argjson pluginsMissing "$missing" \
             --argjson pluginsExtra "$extra" \
+            --argjson pluginsDisabled "$disabled" \
             --arg daemon "$daemon_state" \
             --arg displayManager "$dm_state" \
             '{version: $version, profile: $profile, layers: ($layers | split(",") | map(select(length > 0))),
               versionDrift: {status: $driftStatus, branch: $driftBranch, head: $driftHead, commitsBehind: $driftBehind},
-              plugins: {declared: $pluginsDeclared, ok: $pluginsOk, missing: $pluginsMissing, extra: $pluginsExtra},
+              plugins: {declared: $pluginsDeclared, ok: $pluginsOk, missing: $pluginsMissing, extra: $pluginsExtra, disabled: $pluginsDisabled},
               services: {daemon: $daemon, displayManager: $displayManager}}'
         return 0
     fi
@@ -107,7 +109,7 @@ HELP
     esac
     echo
     if [[ "$declared" == "true" ]]; then
-        printf 'Plugins:  %s ok, %s missing, %s extra (vs aphotic.toml)\n' "$ok" "$missing" "$extra"
+        printf 'Plugins:  %s ok, %s missing, %s extra, %s disabled (vs aphotic.toml)\n' "$ok" "$missing" "$extra" "$disabled"
     else
         echo "Plugins:  not declared in aphotic.toml, drift not tracked"
     fi

--- a/Configs/.local/lib/aphotic/state.sh
+++ b/Configs/.local/lib/aphotic/state.sh
@@ -38,21 +38,28 @@ _aphotic_state_plugins_declared() {
     grep -qE '^\[plugins\][[:space:]]*$' "$toml"
 }
 
-# name<TAB>state, one per line: state is "ok" (desired and actual agree),
-# "missing" (desired, not installed/enabled) or "extra" (installed and
-# enabled, not desired). Callers needing just one side can grep the tab
-# field rather than re-diffing.
+# name<TAB>state, one per line:
+#   ok       desired, installed, enabled -- nothing to do
+#   disabled desired, installed, but disabled -- `aphotic plugin enable`
+#   missing  desired, not installed at all -- `aphotic plugin install`
+#   extra    installed and enabled, not desired -- `aphotic plugin disable`
+# disabled and missing need different actions (install refuses on an
+# already-installed plugin), so callers converging state -- reconcile --
+# must not collapse them into one "absent" bucket.
 _aphotic_state_plugin_drift() {
     _aphotic_state_plugins_declared || return 0
 
-    local desired actual name
+    local desired installed actual name
     desired="$(_aphotic_state_desired_plugins)"
+    installed="$(aphotic_plugin_names)"
     actual="$(_aphotic_state_actual_plugins)"
 
     while IFS= read -r name; do
         [[ -z "$name" ]] && continue
         if grep -qxF "$name" <<<"$actual"; then
             printf '%s\tok\n' "$name"
+        elif grep -qxF "$name" <<<"$installed"; then
+            printf '%s\tdisabled\n' "$name"
         else
             printf '%s\tmissing\n' "$name"
         fi

--- a/tests/test_backup_targets.sh
+++ b/tests/test_backup_targets.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# tests/test_backup_targets.sh
+# aphotic backup create/revert used $(basename "$target") as each
+# snapshot's slot name. QUICKSHELL_CONFIG_DIR (~/.config/quickshell/
+# aphotic) and APHOTIC_CONFIG_HOME (~/.config/aphotic) both basename to
+# "aphotic", so every real backup silently overwrote one with the other
+# in the same slot -- found while wiring aphotic reconcile's rollback
+# through this. Targets are now "name|path" pairs. Also covers revert
+# creating a target's parent directory, which plain cp -a does not do.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB_DIR="$ROOT/Configs/.local/lib/aphotic"
+COMMANDS_DIR="$LIB_DIR/commands"
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+source "$LIB_DIR/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_backup.sh"
+
+# Two distinct, real targets that collide on basename ("aphotic"), each
+# with content that would prove which one survived.
+mkdir -p "$QUICKSHELL_CONFIG_DIR"
+echo "quickshell-content" > "$QUICKSHELL_CONFIG_DIR/shell.qml"
+mkdir -p "$APHOTIC_CONFIG_HOME"
+echo '{"marker": "shell.json-content"}' > "$APHOTIC_CONFIG_FILE"
+
+id="$(_aphotic_backup_create --label test 2>/dev/null | tail -1)"
+[[ -n "$id" ]] || fail "expected _aphotic_backup_create to print a snapshot id"
+
+snapshot="${APHOTIC_BACKUP_DIR}/${id}"
+[[ -f "${snapshot}/quickshell/shell.qml" ]] || fail "expected the quickshell target captured under its own name"
+[[ -f "${snapshot}/aphotic/shell.json" ]] || fail "expected the aphotic-config target captured under its own name, not overwritten by quickshell"
+[[ "$(<"${snapshot}/quickshell/shell.qml")" == "quickshell-content" ]] || fail "expected quickshell's own content, not clobbered"
+
+# --- mutate both, then revert: both must come back independently ---
+
+echo "mutated" > "$QUICKSHELL_CONFIG_DIR/shell.qml"
+echo '{"marker": "mutated"}' > "$APHOTIC_CONFIG_FILE"
+
+_aphotic_backup_revert --yes "$id" >/dev/null 2>&1
+
+[[ "$(<"$QUICKSHELL_CONFIG_DIR/shell.qml")" == "quickshell-content" ]] || fail "expected quickshell restored to its pre-mutation content"
+grep -q "shell.json-content" "$APHOTIC_CONFIG_FILE" || fail "expected aphotic config restored to its pre-mutation content"
+
+# --- revert into a target whose parent directory doesn't exist yet ---
+
+rm -rf "$QUICKSHELL_CONFIG_DIR" "$(dirname "$QUICKSHELL_CONFIG_DIR")"
+[[ -d "$(dirname "$QUICKSHELL_CONFIG_DIR")" ]] && fail "test setup: expected quickshell's parent dir gone"
+
+_aphotic_backup_revert --yes "$id" >/dev/null 2>&1
+
+[[ -f "$QUICKSHELL_CONFIG_DIR/shell.qml" ]] || fail "expected revert to create the missing parent directory and restore the file"
+
+echo "ok: test_backup_targets"

--- a/tests/test_reconcile_rollback.sh
+++ b/tests/test_reconcile_rollback.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# tests/test_reconcile_rollback.sh
+# aphotic reconcile converges the plugin registry to match aphotic.toml's
+# [plugins] enabled list: enable/disable only, never installs a missing
+# plugin (that stays a printed suggestion). --apply auto-snapshots first
+# so aphotic rollback (a thin wrapper over aphotic backup revert) can
+# undo it.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB_DIR="$ROOT/Configs/.local/lib/aphotic"
+COMMANDS_DIR="$LIB_DIR/commands"
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+
+DOTS="$TESTHOME/dots"
+mkdir -p "$DOTS"
+cat > "$DOTS/aphotic.toml" <<'EOF'
+[plugins]
+enabled = ["foo", "bar"]
+EOF
+export APHOTIC_DOTS_DIR="$DOTS"
+
+source "$LIB_DIR/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_reconcile.sh"
+source "$COMMANDS_DIR/cmd_rollback.sh"
+
+install_plugin() {
+    mkdir -p "$APHOTIC_PLUGINS_DIR/$1"
+    : > "$APHOTIC_PLUGINS_DIR/$1/plugin.toml"
+}
+
+# foo: desired, installed, enabled -- nothing to do.
+# bar: desired, installed, disabled -- reconcile should enable it.
+# baz: not desired, installed, enabled -- reconcile should disable it.
+# nope: desired, never installed -- reconcile must never try to install it.
+install_plugin foo
+install_plugin bar
+install_plugin baz
+echo '{"disabled": ["bar"]}' > "$APHOTIC_PLUGINS_STATE_FILE"
+cat > "$DOTS/aphotic.toml" <<'EOF'
+[plugins]
+enabled = ["foo", "bar", "nope"]
+EOF
+
+# --- dry run: reports the plan, touches nothing ---
+
+out="$(aphotic_cmd_reconcile)"
+[[ "$out" == *"enable   bar"* ]] || fail "expected dry run to plan enabling bar, got: $out"
+[[ "$out" == *"disable  baz"* ]] || fail "expected dry run to plan disabling baz, got: $out"
+[[ "$out" == *"aphotic plugin install nope"* ]] || fail "expected dry run to suggest installing nope manually, got: $out"
+aphotic_plugin_is_enabled bar && fail "expected dry run not to have touched bar"
+
+json="$(aphotic_cmd_reconcile --json)"
+[[ "$(jq -c '.toEnable' <<<"$json")" == '["bar"]' ]] || fail "expected --json toEnable=[bar], got: $json"
+[[ "$(jq -c '.toDisable' <<<"$json")" == '["baz"]' ]] || fail "expected --json toDisable=[baz], got: $json"
+[[ "$(jq -c '.missing' <<<"$json")" == '["nope"]' ]] || fail "expected --json missing=[nope], got: $json"
+
+# --- --apply: converges enable/disable, snapshots first, never installs nope ---
+
+aphotic_cmd_reconcile --apply >/dev/null
+
+aphotic_plugin_is_enabled bar || fail "expected --apply to enable bar"
+aphotic_plugin_is_enabled baz && fail "expected --apply to disable baz"
+[[ -d "${APHOTIC_PLUGINS_DIR}/nope" ]] && fail "expected --apply to never install nope"
+
+[[ -f "${APHOTIC_PLUGINS_STATE_FILE}" ]] || fail "expected a plugins state file to exist after apply"
+snapshot_count="$(find "$APHOTIC_BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d -name '*-pre-reconcile' 2>/dev/null | wc -l)"
+[[ "$snapshot_count" -eq 1 ]] || fail "expected exactly one pre-reconcile snapshot, found $snapshot_count"
+
+# --- rollback restores the pre-apply state ---
+
+aphotic_cmd_rollback --yes >/dev/null
+
+aphotic_plugin_is_enabled bar && fail "expected rollback to restore bar to disabled"
+aphotic_plugin_is_enabled baz || fail "expected rollback to restore baz to enabled"
+
+# --- no [plugins] section: reconcile has nothing to do, doesn't error ---
+
+rm "$DOTS/aphotic.toml"
+out="$(aphotic_cmd_reconcile)"
+[[ "$out" == *"nothing declared"* ]] || fail "expected reconcile to report nothing declared with no [plugins] section, got: $out"
+
+echo "ok: test_reconcile_rollback"

--- a/tests/test_state_plugin_drift.sh
+++ b/tests/test_state_plugin_drift.sh
@@ -39,16 +39,19 @@ _aphotic_state_plugins_declared && fail "expected _aphotic_state_plugins_declare
 
 # --- [plugins] declared: foo desired+installed (ok), bar desired but
 #     missing, baz installed+enabled but not desired (extra), qux
-#     installed but disabled and not desired (silent -- neither side) ---
+#     installed but disabled and not desired (silent -- neither side),
+#     quux desired, installed, but disabled (needs `enable`, not
+#     `install` -- install refuses on an already-installed plugin) ---
 
 cat > "$DOTS/aphotic.toml" <<'EOF'
 [plugins]
-enabled = ["foo", "bar"]
+enabled = ["foo", "bar", "quux"]
 EOF
 
 install_plugin "foo"
 install_plugin "qux"
-echo '{"disabled": ["qux"]}' > "$APHOTIC_PLUGINS_STATE_FILE"
+install_plugin "quux"
+echo '{"disabled": ["qux", "quux"]}' > "$APHOTIC_PLUGINS_STATE_FILE"
 
 _aphotic_state_plugins_declared || fail "expected _aphotic_state_plugins_declared to be true once [plugins] exists"
 
@@ -56,6 +59,7 @@ drift="$(_aphotic_state_plugin_drift)"
 grep -qxF $'foo\tok' <<<"$drift" || fail "expected foo to report ok, got: $drift"
 grep -qxF $'bar\tmissing' <<<"$drift" || fail "expected bar to report missing, got: $drift"
 grep -qxF $'baz\textra' <<<"$drift" || fail "expected baz to report extra, got: $drift"
+grep -qxF $'quux\tdisabled' <<<"$drift" || fail "expected desired+installed+disabled quux to report disabled, got: $drift"
 grep -q "^qux" <<<"$drift" && fail "expected disabled+undesired qux to be silent, got: $drift"
 
 echo "ok: test_state_plugin_drift"


### PR DESCRIPTION
## Problem
#171/#172 gave aphotic.toml a declared desired state for plugins and a
way to see the drift (aphotic diff), but nothing to act on it, and no
undo. The original plan sketch also included folding this into aphotic
update -- that name is already a real, different, documented command
(pull + restore + reload, referenced in RELEASE_NOTES.md and tests), so
this PR does not touch it; a composed "one boring update command" stays
open for later, separate from redefining an existing one.

## Plan
aphotic reconcile, deliberately narrow: it only ever enables/disables
plugins already installed, to match aphotic.toml's [plugins] list.
Never installs a plugin it doesn't have (network fetch, its own failure
modes) and never touches packages (sudo, install.sh's job, same
boundary aphotic sync already respects). Dry run by default; --apply
snapshots first via aphotic backup, so aphotic rollback (a thin wrapper
over aphotic backup revert) can undo it.

Building this meant refining lib/aphotic/state.sh's plugin-drift
classification (installed-but-disabled and never-installed both used to
report as "missing," but need different fixes) and wiring the
pre-reconcile snapshot through cmd_backup.sh's existing targets list --
which surfaced a real, pre-existing bug in that list, fixed here too.

## Resolution
- aphotic reconcile [--apply] [--json]: enable/disable plugins to
  converge on aphotic.toml, snapshotting first on --apply. A plugin
  that isn't installed at all is reported with the install command, not
  run automatically.
- aphotic rollback [--yes]: finds the latest pre-reconcile snapshot and
  reverts to it. No new revert logic.
- lib/aphotic/state.sh's plugin drift now distinguishes disabled
  (desired, installed, disabled -- needs enable) from missing (desired,
  never installed -- needs install); status/diff updated to show both.
- cmd_backup.sh bug fix: QUICKSHELL_CONFIG_DIR
  (~/.config/quickshell/aphotic) and APHOTIC_CONFIG_HOME
  (~/.config/aphotic) both basename to "aphotic", so the snapshot
  target list -- unchanged since before this session -- silently
  overwrote one with the other in every backup ever taken. The
  quickshell config was never actually recoverable via aphotic backup
  revert. Targets are now explicit "name|path" pairs instead of
  $(basename path); revert also now creates a target's parent directory
  if it's missing, which cp -a never did.
- New tests: test_reconcile_rollback.sh (dry run, --apply, rollback,
  never-installs-missing), test_backup_targets.sh (proves the collision
  fix and the parent-directory fix -- cmd_backup.sh had no test
  coverage before this).

Verify: bash tests/test_reconcile_rollback.sh, bash
tests/test_backup_targets.sh, full suite green. This closes out REL-02's
MVP (status/diff/reconcile/rollback) once #171 and #172 also merge.