### PR TITLE
gitignore: exclude local agent-tooling indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ Thumbs.db
 *.qsb
 
 recordings/
+
+# Local agent-tooling state: retrieval/graph indexes over this checkout,
+# not shipped output and not portable between machines. graphify-out/
+# holds a knowledge-graph snapshot (graphify skill); .zvec-grep/ holds
+# zvec-grep's semantic index over docs/ + architectural prose.
+graphify-out/
+.zvec-grep/


### PR DESCRIPTION
## Problem
Two local retrieval tools got wired up for working on this project
(graphify for knowledge-graph snapshots, zvec-grep for semantic search
over docs/architectural prose). Both write per-machine index state
directly into the repo root (graphify-out/, .zvec-grep/) that isn't
portable between machines and isn't meant to be committed.

## Plan
Add both to .gitignore before either accumulates in a real commit.

## Resolution
Two lines added, with a short comment explaining what each directory
is. Nothing else changed.