### PR TITLE
Fix shell service unit bug and missing profile backfill

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
@@ -113,10 +113,11 @@ aphotic_cmd_doctor() {
     _aphotic_doctor_layer_plugins
 
     source "${LIB_DIR}/state.sh"
-    local services daemon_state dm_state dm_detail
+    local services daemon_state dm_state dm_detail shellunit_state shellunit_detail
     services="$(_aphotic_state_service_drift)"
     IFS=$'\t' read -r _ daemon_state _ <<<"$(grep '^daemon' <<<"$services")"
     IFS=$'\t' read -r _ dm_state dm_detail <<<"$(grep '^displaymanager' <<<"$services")"
+    IFS=$'\t' read -r _ shellunit_state shellunit_detail <<<"$(grep '^shellunit' <<<"$services")"
 
     echo
     echo "Display manager:"
@@ -144,6 +145,9 @@ aphotic_cmd_doctor() {
         echo "Daemon: running"
     else
         echo "Daemon: not running (aphotic shell -d)"
+    fi
+    if [[ "$shellunit_state" != "enabled" ]]; then
+        printf '  [warn] aphotic-shell.service: %s -- %s\n' "$shellunit_state" "$shellunit_detail"
     fi
 
     echo

--- a/Configs/.local/lib/aphotic/state.sh
+++ b/Configs/.local/lib/aphotic/state.sh
@@ -114,6 +114,7 @@ _aphotic_state_version_drift() {
 # Structured service facts, one tab-separated record per line:
 # <check>\t<state>\t<detail>
 #   daemon: running | stopped
+#   shellunit: enabled | disabled | missing (detail on disabled/missing)
 #   displaymanager: ok | conflict (detail: which two)
 # Not a new desired-state format -- just what `aphotic doctor` already
 # knew how to check, exposed so `aphotic status`/`aphotic diff` can ask
@@ -123,6 +124,20 @@ _aphotic_state_service_drift() {
         printf 'daemon\trunning\t\n'
     else
         printf 'daemon\tstopped\t\n'
+    fi
+
+    # `daemon` above only asks "is a qs process running right now" --
+    # true for a manually-launched or fallback-relaunched shell just the
+    # same as a systemd-supervised one, so it can't tell the two apart.
+    # A qs process that isn't aphotic-shell.service won't auto-restart on
+    # crash and won't come back on next login without a manual `aphotic
+    # reload`/relaunch, which is exactly the gap this closes.
+    if ! systemctl --user list-unit-files aphotic-shell.service &>/dev/null; then
+        printf 'shellunit\tmissing\tnot deployed -- the shell won'"'"'t auto-start or auto-restart on crash; run install.sh --config-only to deploy it\n'
+    elif ! systemctl --user is-enabled aphotic-shell.service &>/dev/null; then
+        printf 'shellunit\tdisabled\tdeployed but not enabled -- run: systemctl --user enable --now aphotic-shell.service\n'
+    else
+        printf 'shellunit\tenabled\t\n'
     fi
 
     local sddm_enabled greetd_enabled

--- a/Configs/systemd/user/aphotic-shell.service
+++ b/Configs/systemd/user/aphotic-shell.service
@@ -4,6 +4,16 @@ After=graphical-session.target
 PartOf=graphical-session.target
 StartLimitIntervalSec=60
 StartLimitBurst=5
+# Fires only once systemd gives up, i.e. StartLimitBurst above is
+# exceeded and the unit enters `failed` -- a single crash that restarts
+# cleanly never reaches it. That is the whole trigger for the recovery
+# surface: no polling, no watchdog, no second supervisor.
+#
+# This belongs in [Unit], not [Service] -- systemd silently ignores an
+# OnFailure= under [Service] ("Unknown key 'OnFailure' in section
+# [Service], ignoring"), so the recovery surface never fired on any
+# install until this moved.
+OnFailure=aphotic-recovery.service
 
 [Service]
 Type=simple
@@ -25,12 +35,6 @@ RestartSec=2
 # survive a machine that is rebooting to try again. Leading `-` because a
 # recorder that fails must not itself put the unit into a failed state.
 ExecStopPost=-/bin/sh -c 'exec %h/.local/bin/aphotic recovery record "$SERVICE_RESULT" "$EXIT_STATUS"'
-
-# Fires only once systemd gives up, i.e. StartLimitBurst above is
-# exceeded and the unit enters `failed` -- a single crash that restarts
-# cleanly never reaches it. That is the whole trigger for the recovery
-# surface: no polling, no watchdog, no second supervisor.
-OnFailure=aphotic-recovery.service
 
 [Install]
 WantedBy=graphical-session.target

--- a/lib/install/config_deploy.sh
+++ b/lib/install/config_deploy.sh
@@ -416,6 +416,18 @@ restart_shell_if_enabled() {
 }
 
 config_sync() {
+  if [[ ! -f "$APHOTIC_TOML" ]]; then
+    echo -e "$CWR - No aphotic.toml found -- inferring the installed profile from packages so the System pane isn't stuck on \"unknown\"."
+    local _inferred _inferred_profile _inferred_layers
+    _inferred="$(infer_profile_from_packages)"
+    _inferred_profile="$(sed -n '1p' <<< "$_inferred")"
+    _inferred_layers="$(sed -n '2p' <<< "$_inferred")"
+    write_aphotic_toml "$APHOTIC_TOML" "$_inferred_profile" "$_inferred_layers" "${THEME:-tokyonight}" "${ISNVIDIA:-false}" "${AUR_HELPER:-}" "$(date -Iseconds)" "${ISAMD:-false}"
+    [[ -z "$PROFILE" ]] && PROFILE="$_inferred_profile"
+    [[ -z "$LAYERS" ]] && LAYERS="$_inferred_layers"
+    echo -e "$COK - Wrote $APHOTIC_TOML (profile=$_inferred_profile, layers=${_inferred_layers:-none}, inferred from installed packages)"
+  fi
+
   TOTAL_STAGES=3
   print_stage 1 "Backup"
   if [[ "$NO_BACKUP" != "1" ]]; then
@@ -439,7 +451,7 @@ config_sync() {
   echo -e "  Layers:        ${LAYERS:-none}"
   echo -e "  Configs:       copied from $ROOT_DIR/Configs"
   echo -e "  Packages:      untouched"
-  echo -e "  aphotic.toml:  left as-is"
+  echo -e "  aphotic.toml:  $([[ -n "${_inferred_profile:-}" ]] && echo "backfilled (inferred profile=$_inferred_profile)" || echo "left as-is")"
   echo -e "$COK - Config sync complete."
 
   "$HOME/.local/bin/aphotic" whatsnew &>> "$INSTLOG" || true

--- a/lib/install/detect.sh
+++ b/lib/install/detect.sh
@@ -46,6 +46,50 @@ detect_dotfile_manager() {
   fi
 }
 
+# Backfills a missing aphotic.toml on a --config-only run whose original
+# install predates write_aphotic_toml (install.sh's call to it at the end
+# of a full run) or whose aphotic.toml was otherwise lost. Without this,
+# InstallProfile.qml's `known` never becomes true and the System settings
+# pane is stuck on "unknown" forever, since config-only never installs or
+# writes anything by design (config_sync's own "aphotic.toml: left as-is"
+# summary line). Inferred, not remembered: base profile comes from
+# whether any full-only package is present, layers from which layer's own
+# packages are actually installed. Best-effort -- a package the user
+# removed by hand won't be un-inferred, and one installed independently
+# of Aphotic could be mistaken for a layer -- but a one-time best guess
+# beats a permanent "unknown".
+infer_profile_from_packages() {
+  "$PYTHON_BIN" - "$ROOT_DIR" <<'PYEOF'
+import sys, tomllib, subprocess, pathlib
+
+root = pathlib.Path(sys.argv[1])
+installed = set(subprocess.run(["pacman", "-Qq"], capture_output=True, text=True).stdout.split())
+
+def pkgs(path):
+    try:
+        return set(tomllib.load(open(path, "rb")).get("packages", {}).get("main", []))
+    except Exception:
+        return set()
+
+full = pkgs(root / "profiles/base/full.toml")
+minimal = pkgs(root / "profiles/base/minimal.toml")
+full_only = full - minimal
+profile = "full" if installed & full_only else "minimal"
+
+layers = []
+for f in sorted((root / "profiles/layers").glob("*.toml")):
+    name = f.stem
+    if name == "exploit":
+        continue  # bundle alias for exploit-recon/-web/-network, never installed under its own name
+    p = pkgs(f)
+    if p and installed & p:
+        layers.append(name)
+
+print(profile)
+print(",".join(layers))
+PYEOF
+}
+
 detect_environment() {
   echo -e "$CNT - Checking what's already on this machine..."
 


### PR DESCRIPTION
## Problem

Three things surfaced together after a login this morning:

- The shell didn't start on its own; had to run `aphotic reload` manually.
- Settings → System kept showing "unknown" for the installed profile.
- SUPER+SHIFT+W wasn't opening the Workspace pane.

## Plan

Trace each to its actual cause instead of patching symptoms.

## Resolution

- `aphotic-shell.service` had `OnFailure=` under `[Service]` instead of
  `[Unit]`. systemd silently ignores a directive in the wrong section, so
  the crash-recovery surface has never actually fired on any install.
  Moved it.
- Added a doctor/state check for a missing or disabled shell unit. Before
  this, a manually-running `qs` process looked identical to a
  systemd-supervised one, so the exact failure mode from this morning had
  no diagnostic signal at all.
- `--config-only` never writes `aphotic.toml` (only a full install does),
  so a machine that's only ever had config-only syncs had no profile
  info on disk, ever. `config_sync()` now backfills it by inferring
  profile and layers from installed packages when the file is missing.
  That was also why SUPER+SHIFT+W stayed unbound: the Workspace surface
  needs its plugin's required layer recorded there, and there was
  nothing to read.
- Added an FAQ entry for what to do when the shell doesn't start
  (SUPER+T, `aphotic reload`, `aphotic doctor`), plus two keybinds that
  were missing from the wiki's Keybindings page.

Left alone: SDDM is still the active display manager. Switching to
greetd is a deliberate, manual, one-at-a-time operation
(`aphotic displaymanager switch greetd --confirm-tested`) gated behind
testing the greeter on a spare VT first, because a bad switch locks out
login. Nothing here changes that.