### PR TITLE
gitignore: exclude epiq's local event/log tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ recordings/
 # zvec-grep's semantic index over docs/ + architectural prose.
 graphify-out/
 .zvec-grep/
+
+# epiq's per-checkout event/log tracking. epiq's own state lives in its
+# own worktree/branch elsewhere, not this repo's history.
+.epiq/


### PR DESCRIPTION
## Problem
epiq (personal local progress tracking) drops an `.epiq/` (`events/`,
`log/`) directory into the working tree per checkout. It showed up as
untracked and would otherwise get swept into a commit by accident.

## Plan
Same treatment as `graphify-out/` and `.zvec-grep/`: it's machine-local
tooling state, not shipped output, and epiq keeps its actual state in
its own separate worktree/branch already.

## Resolution
Added `.epiq/` to `.gitignore`.