### PR TITLE
epiq: land project.json on main

### DIFF
--- a/.epiq/project.json
+++ b/.epiq/project.json
@@ -1,0 +1,5 @@
+{
+  "projectId": "01M1YMMJYNZ09GRZH6CZBBPZ5G",
+  "stateBranch": "__epiq_state__",
+  "createdAt": "2026-09-07T19:13:36.213Z"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ recordings/
 # zvec-grep's semantic index over docs/ + architectural prose.
 graphify-out/
 .zvec-grep/
+
+# [epiq]: local hydrated state is never committed
+.epiq/events/
+.epiq/log/


### PR DESCRIPTION
## Problem
epiq's project init committed `.epiq/project.json` (the pointer file every
checkout needs to find the shared state branch) onto `feature/wiki-refresh`
instead of `main`. That branch has no open PR and sits behind main, so
every other branch and checkout fails epiq's board tools with "no
project.json found".

## Plan
Cherry-pick the init commit onto a fresh branch off current `main` so the
pointer file (and its narrow `.gitignore` entries for `.epiq/events/` and
`.epiq/log/`) land where every branch actually inherits them.

## Resolution
Cherry-picked `7534b7f` onto `main`, resolving the `.gitignore` conflict by
keeping both blocks. `feature/wiki-refresh` is untouched.

Note: PR #179 ignores all of `.epiq/`, which would also hide
`project.json` from git once both land. Worth narrowing that PR to just
`.epiq/events/` and `.epiq/log/` instead.