### PR TITLE
Wallpaper picker is SUPER+W, not SUPER+SHIFT+W

### DIFF
--- a/Configs/quickshell/aphotic/modules/background/Wallpaper.qml
+++ b/Configs/quickshell/aphotic/modules/background/Wallpaper.qml
@@ -59,7 +59,7 @@ Item {
                     }
 
                     StyledText {
-                        text: qsTr("Pick one with SUPER+SHIFT+W")
+                        text: qsTr("Pick one with SUPER+W")
                         color: Colours.palette.m3onSurfaceVariant
                         font.pointSize: Tokens.fontSize.normal
                     }

--- a/Configs/quickshell/aphotic/modules/settings/panes/AppearancePane.qml
+++ b/Configs/quickshell/aphotic/modules/settings/panes/AppearancePane.qml
@@ -355,7 +355,7 @@ Item {
                 SettingsRow {
                     icon: "view_carousel"
                     label: qsTr("Launcher layout")
-                    description: qsTr("How SUPER+SHIFT+W presents your wallpapers")
+                    description: qsTr("How SUPER+W presents your wallpapers")
 
                     RowLayout {
                         spacing: Tokens.spacing.small

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -223,7 +223,7 @@ Singleton {
     // services/WallpaperCycle.qml) -- interval in minutes.
     property bool wallpaperAutoCycleEnabled: false
     property int wallpaperAutoCycleInterval: 15
-    // Which layout SUPER+SHIFT+W opens the full-screen picker in. Coverflow
+    // Which layout SUPER+W opens the full-screen picker in. Coverflow
     // is what the picker has always been, so it stays the default.
     readonly property var wallpaperPickerLayouts: ["coverflow", "grid", "dock"]
     property string wallpaperPickerLayout: "coverflow"


### PR DESCRIPTION
Three user-facing strings named the wrong keybind. `SUPER+W` opens the wallpaper picker (`keybinds.lua:14`). `SUPER+SHIFT+W` is the workspace plane, which no static bind owns because `WorkspaceKeybind.qml` binds and unbinds it at runtime as workspace plugins come and go.

- `modules/background/Wallpaper.qml` — the empty-desktop hint reads "Pick one with SUPER+SHIFT+W". Someone with no wallpaper set is told to press a key that does nothing on a stock install, since it stays unbound until a workspace plugin is installed. This one predates #186.
- `modules/settings/panes/AppearancePane.qml` — the layout picker's description, added in #186.
- `services/Settings.qml` — a comment, same source.

Caught while reconciling the wiki against `keybinds.lua`. The wiki's own `Super+W` row was stale in the other direction, still describing the pre-#119 random-pick behaviour; that is fixed on the wiki rather than here.

No test covers user-facing keybind strings, and I did not add one. Grepping the shell for `SUPER+SHIFT+W` now returns nothing.
