### PR TITLE
Fix dock picker navigation, and make the picker snappier

### DIFF
--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperDock.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperDock.qml
@@ -18,32 +18,72 @@ Item {
     readonly property int cellHeight: Math.max(96, Math.round(root.height * 0.13))
     readonly property int cellWidth: Math.round(cellHeight * 16 / 9)
     readonly property int cellGap: Tokens.spacing.small
+    readonly property int slotPitch: cellWidth + cellGap
 
     readonly property string backdropSource: root.model.fullSizeFor(strip.currentIndex)
 
     // Proximity magnification, the same quadratic falloff DockBar uses for
     // app icons so the two docks in this shell feel like one idea.
-    readonly property real magnifyRadius: root.cellWidth * 1.2
-    readonly property real magnifyExtra: 0.34
+    readonly property real magnifyRadius: root.cellWidth * 1.3
+    readonly property real magnifyExtra: 0.3
+
+    // Hover fades in and out rather than snapping, so the deck settles when
+    // the pointer leaves instead of every card dropping at once. The
+    // falloff below tracks the pointer live; this only scales how much of
+    // it applies.
+    property real hoverStrength: hover.hovered ? 1 : 0
+
+    Behavior on hoverStrength {
+        NumberAnimation {
+            duration: Tokens.anim.durations.expressiveDefaultEffects
+            easing: Tokens.anim.emphasizedDecel
+        }
+    }
 
     function magnifyFalloff(centerX: real): real {
-        if (!hover.hovered)
+        if (root.hoverStrength <= 0)
             return 1;
         const dist = Math.abs(centerX - hover.point.position.x);
         if (dist >= root.magnifyRadius)
             return 1;
         const t = 1 - dist / root.magnifyRadius;
-        return 1 + root.magnifyExtra * t * t;
+        return 1 + root.magnifyExtra * t * t * root.hoverStrength;
     }
 
     focus: true
 
+    // Called by the window when this layout becomes the visible one. The
+    // focus grab is the whole reason it exists: without it the arrow keys
+    // land on whatever had focus before and the deck cannot be driven from
+    // the keyboard at all.
     function focusActive(): void {
         const idx = root.model.activeIndex;
         strip.currentIndex = idx >= 0 ? idx : 0;
-        strip.positionViewAtIndex(strip.currentIndex, ListView.Center);
+        strip.contentX = root._centeredContentX(strip.currentIndex);
+        root.forceActiveFocus();
     }
 
+    // Only while nothing else owns contentX: recentring mid-glide or
+    // mid-drag would fight whoever is driving it.
+    function _recenterIfIdle(): void {
+        if (glide.running || strip.moving || strip.count === 0)
+            return;
+        strip.contentX = root._centeredContentX(strip.currentIndex);
+    }
+
+    function _maxContentX(): real {
+        return Math.max(0, strip.contentWidth - strip.width);
+    }
+
+    function _centeredContentX(index: int): real {
+        const raw = index * root.slotPitch + root.cellWidth / 2 - strip.width / 2;
+        return Math.max(0, Math.min(raw, root._maxContentX()));
+    }
+
+    // One path for the wheel and the arrow keys both. Scrolling used to
+    // pan contentX without touching currentIndex, so the deck slid under a
+    // selection that never moved and nothing ever previewed -- you could
+    // only apply whatever happened to be selected when the picker opened.
     function _step(delta: int): void {
         if (strip.count === 0)
             return;
@@ -51,12 +91,31 @@ Item {
         if (next === strip.currentIndex)
             return;
         strip.currentIndex = next;
-        strip.positionViewAtIndex(next, ListView.Center);
+        glide.to = root._centeredContentX(next);
+        glide.restart();
         root.model.queuePreview(next);
+    }
+
+    function _select(index: int): void {
+        if (index === strip.currentIndex)
+            return;
+        strip.currentIndex = index;
+        glide.to = root._centeredContentX(index);
+        glide.restart();
+        root.model.queuePreview(index);
     }
 
     Keys.onLeftPressed: root._step(-1)
     Keys.onRightPressed: root._step(1)
+    Keys.onPressed: event => {
+        if (event.key === Qt.Key_Home)
+            root._select(0);
+        else if (event.key === Qt.Key_End)
+            root._select(strip.count - 1);
+        else
+            return;
+        event.accepted = true;
+    }
     Keys.onReturnPressed: root.model.commit(strip.currentIndex)
     Keys.onEscapePressed: root.model.revertAndClose()
 
@@ -92,11 +151,13 @@ Item {
         }
 
         StyledRect {
+            id: tray
+
             anchors.horizontalCenter: parent.horizontalCenter
 
-            // The tray is sized to the screen, not to the content, so the
-            // deck neither jitters as cards magnify nor stretches to the
-            // full width of a hundred-wallpaper library.
+            // Sized to the screen rather than to the content, so the deck
+            // neither jitters as cards magnify nor stretches to the full
+            // width of a hundred-wallpaper library.
             implicitWidth: Math.min(root.width * 0.9, strip.contentWidth + Tokens.padding.large * 2)
             // Headroom for the tallest a magnified card can grow to, so a
             // card near the edge is never clipped by its own tray.
@@ -108,7 +169,7 @@ Item {
                 id: strip
 
                 anchors.centerIn: parent
-                width: Math.min(parent.implicitWidth - Tokens.padding.large * 2, strip.contentWidth)
+                width: tray.implicitWidth - Tokens.padding.large * 2
                 height: parent.height
                 orientation: ListView.Horizontal
                 spacing: root.cellGap
@@ -117,11 +178,79 @@ Item {
                 boundsBehavior: Flickable.StopAtBounds
 
                 model: root.model.count
+                reuseItems: true
+
+                onWidthChanged: Qt.callLater(root._recenterIfIdle)
+                onContentWidthChanged: Qt.callLater(root._recenterIfIdle)
+
+                // Dragging the deck by hand moves the selection to whatever
+                // ends up nearest the middle, so a drag and a wheel step
+                // leave the picker in the same state.
+                onMovementEnded: {
+                    if (glide.running || strip.count === 0)
+                        return;
+                    const nearest = Math.round((strip.contentX + strip.width / 2 - root.cellWidth / 2) / root.slotPitch);
+                    root._select(Math.max(0, Math.min(nearest, strip.count - 1)));
+                }
+
+                NumberAnimation {
+                    id: glide
+
+                    target: strip
+                    property: "contentX"
+                    duration: Tokens.anim.durations.expressiveFastSpatial
+                    easing: Tokens.anim.emphasizedDecel
+                }
+
+                // A moving highlight rather than one drawn per card: it
+                // slides between selections instead of blinking from one to
+                // the next, which is what makes stepping through the deck
+                // read as one continuous motion.
+                Rectangle {
+                    id: highlight
+
+                    readonly property real slotX: strip.currentIndex * root.slotPitch
+
+                    x: highlight.slotX - Tokens.padding.small
+                    y: strip.height - Tokens.padding.large - root.cellHeight - Tokens.padding.small
+                    z: -1
+                    width: root.cellWidth + Tokens.padding.small * 2
+                    height: root.cellHeight + Tokens.padding.small * 2
+                    radius: Tokens.rounding.large
+                    visible: strip.count > 0
+                    color: "transparent"
+                    border.width: 2
+                    border.color: Colours.palette.m3primary
+                    opacity: 0.55 + 0.45 * DepthFx.pulse
+
+                    Behavior on x {
+                        NumberAnimation {
+                            duration: Tokens.anim.durations.expressiveFastSpatial
+                            easing: Tokens.anim.emphasizedDecel
+                        }
+                    }
+
+                    Behavior on border.color {
+                        CAnim {}
+                    }
+                }
 
                 WheelHandler {
-                    // A horizontal deck is scrolled with a vertical wheel
-                    // far more often than a horizontal one.
-                    onWheel: event => strip.contentX = Math.max(0, Math.min(strip.contentWidth - strip.width, strip.contentX - (event.angleDelta.y !== 0 ? event.angleDelta.y : event.angleDelta.x)))
+                    // A horizontal deck gets scrolled with a vertical wheel
+                    // far more often than a horizontal one. Both are folded
+                    // into one axis, then accumulated: a trackpad sends many
+                    // small deltas where a mouse notch sends one large one,
+                    // and stepping per event would make a trackpad race.
+                    property real accumulated: 0
+
+                    onWheel: event => {
+                        const delta = event.angleDelta.y !== 0 ? event.angleDelta.y : event.angleDelta.x;
+                        accumulated += delta;
+                        while (Math.abs(accumulated) >= 120) {
+                            root._step(accumulated > 0 ? -1 : 1);
+                            accumulated += accumulated > 0 ? -120 : 120;
+                        }
+                    }
                 }
 
                 delegate: Item {
@@ -131,36 +260,54 @@ Item {
 
                     property bool hovered: false
 
+                    ListView.onReused: cell.hovered = false
+
                     readonly property real centerX: cell.x - strip.contentX + cell.width / 2
                     readonly property real magnify: root.magnifyFalloff(cell.centerX)
 
                     width: root.cellWidth
                     height: strip.height
 
-                    // Cards grow from their bottom edge so the deck keeps a
-                    // flat baseline as the wave passes along it. magnify is
-                    // a binding on the pointer position rather than an
-                    // animated property, which is what makes the wave track
-                    // the cursor instead of chasing it -- same as DockBar.
                     z: cell.index === strip.currentIndex ? 2 : Math.round(cell.magnify * 100)
 
-                    WallpaperCard {
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        anchors.bottom: parent.bottom
-                        anchors.bottomMargin: Tokens.padding.large
+                    // Scaling a wrapper rather than the card's own width and
+                    // height keeps every cell the same size, so the deck
+                    // never reflows as the wave passes along it -- only what
+                    // is painted changes. The Behavior is what makes the
+                    // zoom trail the pointer instead of snapping to it.
+                    Item {
+                        id: art
 
-                        width: root.cellWidth * cell.magnify
-                        height: root.cellHeight * cell.magnify
+                        anchors.fill: parent
 
-                        source: root.model.previewFor(cell.index)
-                        decodeWidth: Math.round(root.cellWidth * (1 + root.magnifyExtra))
-                        decodeHeight: Math.round(root.cellHeight * (1 + root.magnifyExtra))
-                        matteWidth: 64
-                        matteHeight: 36
-                        distance: 0
-                        hovered: cell.hovered
-                        active: cell.index === strip.currentIndex
-                        locked: cell.index === root.model.activeIndex
+                        scale: cell.magnify
+                        transformOrigin: Item.Bottom
+
+                        Behavior on scale {
+                            NumberAnimation {
+                                duration: Tokens.anim.durations.expressiveFastEffects
+                                easing: Tokens.anim.emphasizedDecel
+                            }
+                        }
+
+                        WallpaperCard {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            anchors.bottom: parent.bottom
+                            anchors.bottomMargin: Tokens.padding.large
+
+                            width: root.cellWidth
+                            height: root.cellHeight
+
+                            source: root.model.previewFor(cell.index)
+                            decodeWidth: Math.round(root.cellWidth * (1 + root.magnifyExtra))
+                            decodeHeight: Math.round(root.cellHeight * (1 + root.magnifyExtra))
+                            matteWidth: 64
+                            matteHeight: 36
+                            distance: 0
+                            hovered: cell.hovered
+                            active: cell.index === strip.currentIndex
+                            locked: cell.index === root.model.activeIndex
+                        }
                     }
 
                     MaterialIcon {
@@ -181,12 +328,10 @@ Item {
                         onEntered: cell.hovered = true
                         onExited: cell.hovered = false
                         onClicked: {
-                            if (cell.index === strip.currentIndex) {
+                            if (cell.index === strip.currentIndex)
                                 root.model.commit(cell.index);
-                            } else {
-                                strip.currentIndex = cell.index;
-                                root.model.queuePreview(cell.index);
-                            }
+                            else
+                                root._select(cell.index);
                         }
                     }
                 }

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperGrid.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperGrid.qml
@@ -23,10 +23,14 @@ Item {
 
     focus: true
 
+    // The focus grab is load-bearing: without it the arrow keys land on
+    // whatever had focus before and the grid cannot be driven from the
+    // keyboard at all.
     function focusActive(): void {
         const idx = root.model.activeIndex;
         grid.currentIndex = idx >= 0 ? idx : 0;
         grid.positionViewAtIndex(grid.currentIndex, GridView.Contain);
+        root.forceActiveFocus();
     }
 
     // Arrow keys move the selection and queue a preview; the preview itself
@@ -65,6 +69,7 @@ Item {
             cacheBuffer: root.cellHeight * 3
 
             model: root.model.count
+            reuseItems: true
 
             // A wheel-only view is against the rule in this repo, so the
             // scrollbar beside it is a real draggable one rather than an
@@ -82,6 +87,11 @@ Item {
                 required property int index
 
                 property bool hovered: false
+
+                // Recycled cells come back with whatever hover state they
+                // were pooled with; everything else here derives from
+                // index, which Qt re-evaluates on reuse.
+                GridView.onReused: cell.hovered = false
 
                 width: grid.cellWidth
                 height: grid.cellHeight

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperPickerModel.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperPickerModel.qml
@@ -90,6 +90,18 @@ Item {
         root.cancelPreview();
         root._originalTheme = Themes.activeTheme;
         root._originalWallpaper = Themes.activeWallpaper;
+        root.prewarm();
+    }
+
+    // Ask for every thumbnail up front rather than letting each delegate
+    // queue its own as it scrolls into view. Same total work either way,
+    // but it lands in one subprocess instead of one per scrolled-past
+    // burst, so the deck never waits on a cold cell mid-scroll.
+    // WallpaperThumbs skips anything already cached, so on a warm cache
+    // this costs one process that generates nothing.
+    function prewarm(): void {
+        for (const entry of root.entries)
+            WallpaperThumbs.thumbFor(entry.path);
     }
 
     function queuePreview(index: int): void {

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperPickerWindow.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperPickerWindow.qml
@@ -54,6 +54,7 @@ PanelWindow {
                 pickerModel.cancelPreview();
                 return;
             }
+            root.everOpened = true;
             // Nothing watches ~/.config/awww, so a wallpaper dropped in
             // since the shell started would otherwise not appear until a
             // restart. Opening the picker is the natural moment to look.
@@ -86,14 +87,25 @@ PanelWindow {
         onClicked: pickerModel.revertAndClose()
     }
 
+    // Built on first open and kept afterwards, so every later open is
+    // immediate rather than reconstructing a view over the whole
+    // wallpaper list. Nothing here runs while the window is hidden: the
+    // PanelWindow is not visible, the model's preview timer is stopped on
+    // close, and the layouts drive off the model rather than polling.
+    // Switching layout in Settings swaps sourceComponent and the old one
+    // goes, so at most one is ever resident.
+    property bool everOpened: false
+
+    onLayoutChanged: {
+        if (!root.screenState.wallpaperPicker)
+            root.everOpened = false;
+    }
+
     Loader {
         id: layoutLoader
 
         anchors.fill: parent
-        // Only built once the picker is actually opened, and torn down with
-        // it: three layouts kept resident would each hold a view over every
-        // wallpaper for the whole session.
-        active: root.screenState.wallpaperPicker
+        active: root.screenState.wallpaperPicker || root.everOpened
         sourceComponent: root.layout === "grid" ? gridComp : root.layout === "dock" ? dockComp : coverflowComp
 
         onLoaded: Qt.callLater(() => layoutLoader.item?.focusActive())

--- a/Configs/quickshell/aphotic/services/Themes.qml
+++ b/Configs/quickshell/aphotic/services/Themes.qml
@@ -55,6 +55,7 @@ Singleton {
     readonly property bool activeWallpaperIsVideo: root.isVideo(root.activeWallpaper)
     readonly property string activeVideoPath: root.activeWallpaperIsVideo && root.activeTheme ? `${root.awwwDir}/${root.activeTheme}/${root.activeWallpaper}` : ""
 
+    property string _lastScan: ""
     property bool _scanned: false
     property bool _stateLoaded: false
     property bool _writePending: false
@@ -364,7 +365,7 @@ Singleton {
                     }
                 }
 
-                root.themes = themeList.map(t => {
+                const scanned = themeList.map(t => {
                     const toml = t._tomlText ? root._parseFlatToml(t._tomlText) : {};
                     return {
                         name: t.name,
@@ -389,6 +390,17 @@ Singleton {
                         wallpapers: t.wallpapers.sort()
                     };
                 }).filter(t => t.wallpapers.length > 0).sort((a, b) => a.name.localeCompare(b.name));
+
+                // Reassigning an identical list is not free: every view
+                // bound to it resets, and a ListView resetting throws away
+                // contentX. The wallpaper picker rescans on open so a
+                // newly dropped file shows up, and that used to jump the
+                // deck back to the left edge the instant it opened.
+                const serialised = JSON.stringify(scanned);
+                if (serialised !== root._lastScan) {
+                    root._lastScan = serialised;
+                    root.themes = scanned;
+                }
 
                 root._scanned = true;
                 root._applyLoadedState();

--- a/lib/install/config_deploy.sh
+++ b/lib/install/config_deploy.sh
@@ -48,6 +48,45 @@ build_shell_shaders() {
 # (SDDM theme, wayland-sessions) so --config-only never asks for a
 # password -- extracted rather than duplicated so the sync path and the
 # full install can never drift apart.
+# Pre-generate the wallpaper picker's thumbnail cache so the first
+# SUPER+W is warm. Without this, opening the picker on a fresh install
+# spawns ffmpeg for every wallpaper in the theme and fills the cards in
+# as they land -- correct, but visibly so.
+#
+# Runs in the background and never blocks the install: the picker
+# generates whatever is missing on demand anyway, so the worst case for
+# a failure here is the behaviour we had before. Only the active theme's
+# wallpapers are warmed, not every theme's -- that is what the picker
+# opens on, and doing all of them on a large collection would spend real
+# time on images the user may never look at.
+build_wallpaper_thumbs() {
+  local script="${APHOTIC_DOTS_DIR:-$HOME/Aphotic-Hypr}/Configs/.local/lib/aphotic/wallpaper_thumbs.py"
+  local awww_dir="$HOME/.config/awww"
+  local theme=""
+
+  [[ -f "$script" ]] || return 0
+  command -v ffmpeg &>/dev/null || return 0
+  command -v python3 &>/dev/null || return 0
+  [[ -d "$awww_dir" ]] || return 0
+
+  if [[ -f "$HOME/.local/state/aphotic/theme.json" ]]; then
+    theme=$(jq -r '.theme // empty' "$HOME/.local/state/aphotic/theme.json" 2>/dev/null || true)
+  fi
+  [[ -n "$theme" && -d "$awww_dir/$theme" ]] || return 0
+
+  (
+    find "$awww_dir/$theme" -maxdepth 1 -type f \
+      \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' \
+         -o -iname '*.webp' -o -iname '*.mp4' -o -iname '*.webm' -o -iname '*.mov' \
+         -o -iname '*.mkv' -o -iname '*.m4v' \) -print0 \
+      | xargs -0 -r python3 "$script" >/dev/null 2>&1
+  ) &
+  disown 2>/dev/null || true
+
+  echo -e "$CNT - Warming the wallpaper thumbnail cache in the background..."
+  return 0
+}
+
 deploy_user_configs() {
   echo -e "$CNT - Copying config files..."
   CUSTOM_LUA="$HOME/.config/hypr/custom.lua"
@@ -201,6 +240,7 @@ deploy_user_configs() {
   "$HOME/.local/bin/aphotic" plugin relink-ui-modules &>> "$INSTLOG" || true
 
   build_shell_shaders
+  build_wallpaper_thumbs
 
   echo -e "$CNT - Enabling the Aphotic shell restart-supervision unit..."
   mkdir -p "$HOME/.config/systemd/user"


### PR DESCRIPTION
## The bug

The dock layout could not be navigated. You could open it and apply whatever was already selected, and that was all.

Two independent faults, both mine from #186:

**The wheel panned but never selected.** `WheelHandler` wrote `strip.contentX` directly and never touched `currentIndex`, so the deck slid underneath a selection that stayed put. No preview fired either, since previews hang off selection changes. The coverflow gets this right because scrolling there moves the selection.

**Arrow keys went nowhere.** Neither `WallpaperDock.focusActive()` nor `WallpaperGrid.focusActive()` called `forceActiveFocus()`. `WallpaperFilmstrip` always did, which is why only the coverflow responded to the keyboard. The grid was broken the same way and nobody had hit it yet.

Wheel and arrows now share one `_step()` that moves the selection, glides the deck to recentre, and queues the preview. Dragging the deck by hand snaps to whatever ends up nearest the middle, so a drag and a wheel step leave the same state. <kbd>Home</kbd>/<kbd>End</kbd> jump to either end.

## Motion

Zoom scales a wrapper `Item` rather than the card's `width`/`height`. Driving width and height meant a relayout on every pointer move; now only what is painted changes, and the deck cannot reflow as the wave passes along it. `Behavior on scale` at 150ms makes the zoom trail the pointer instead of snapping to it.

Hover strength eases 0→1 on enter and back on leave, so cards settle together when the pointer leaves rather than all dropping at once. The magnification curve itself is still `DockBar`'s quadratic falloff, tracking live.

The selection highlight is one rounded ring that slides between cards on the same curve as the deck, rather than one drawn per card blinking on and off.

Also fixes the highlight sitting too high. Cards are bottom-anchored in their cell, and I had positioned the ring as though they were centred.

## Speed

No visual change in any of this.

- **`Themes` only reassigns its list when a scan actually differs.** This was the worst one. The picker calls `Themes.rescan()` on open so a newly dropped wallpaper appears, and the unconditional reassignment reset the ListView model, which resets `contentX` — throwing away the centring `focusActive()` had just done, on every single open.
- **`reuseItems: true`** on both views. A `WallpaperCard` is a render target, a mask shader pass and a `Shape`, so recycling rather than rebuilding is worth real time on a long scroll.
- **Thumbnails prewarm in one batch on open** instead of one subprocess per scrolled-past burst. Same total work, but the deck never waits on a cold cell mid-scroll. Skips anything already cached, so a warm cache costs one process that generates nothing.
- **The layout stays resident after first open.** #186 made it tear down on close; the filmstrip was always resident. Reopening no longer rebuilds a view over the whole list. Switching layout in Settings still swaps it, so at most one is ever alive.
- **`install.sh` warms the active theme's thumbnail cache** in the background, so the first <kbd>Super</kbd>+<kbd>W</kbd> on a fresh install is already warm. Measured on this machine's 11-wallpaper theme: 0.46s cold, 0.08s warm. Never blocks the install and degrades to the on-demand path if ffmpeg or the script is missing.

Nothing here cuts a visual corner. I considered a lighter delegate for the grid and did not do it.

## Testing

Probed all three layouts: each compiles, instantiates and drives. Stepping the dock moves the index 3→4→5→6 with the backdrop following, which is exactly what was broken.

On `activeFocus`: a headless probe reports `false` for all three layouts including the already-working filmstrip, because there is no real window. So the probe confirms the dock and grid now match the filmstrip's mechanism, and the real check is using it.

`test_plugin_background_surface`, `test_plugin_overlay_surface`, `test_singleton_reachability`, `site/tests/test_site.py` and `bash -n` on the install script all pass.

No docs or `site/` changes, so nothing here needs a site redeploy.
