### PR TITLE
Give the Resource Engine CPU and memory claims to arbitrate

### DIFF
--- a/Configs/quickshell/aphotic/services/SystemCapacity.qml
+++ b/Configs/quickshell/aphotic/services/SystemCapacity.qml
@@ -1,0 +1,97 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services.profile
+
+// Declares CPU and system-memory capacity to the Resource Engine, but
+// only while something is actually claiming against it.
+//
+// Core declares no resources at rest on purpose: a base install with
+// nothing running has nothing to arbitrate and can never raise a
+// negotiation prompt. So this is reference counted. The first claimant
+// calls acquire(), the last one to leave calls release(), and the
+// declaration disappears with it.
+//
+// Capacity is read once, from the machine, with one-shot reads. There is
+// no timer here: a machine does not grow cores while the shell is up, and
+// an unreadable capacity stays undeclared rather than being guessed --
+// the Resource Engine treats unknown capacity as unknown, never as free.
+Singleton {
+    id: root
+
+    readonly property var known: root._known
+    readonly property int cpuThreads: root._known.cpu || 0
+    readonly property int memoryMib: root._known.memory || 0
+
+    property var _known: ({})
+    property var _holders: ({})
+
+    // Claimants call this before they register against `key`. It is safe
+    // to call repeatedly; the count is what matters.
+    function acquire(key: string): void {
+        if (key !== "cpu" && key !== "memory")
+            return;
+        root._holders[key] = (root._holders[key] || 0) + 1;
+        if (root._known[key])
+            root._declare(key);
+        else if (key === "cpu")
+            root._cpuProc.running = true;
+        else
+            root._memProc.running = true;
+    }
+
+    function release(key: string): void {
+        if (!root._holders[key])
+            return;
+        root._holders[key] -= 1;
+        if (root._holders[key] > 0)
+            return;
+        delete root._holders[key];
+        ResourceEngine.undeclareResource(key);
+    }
+
+    function _declare(key: string): void {
+        if (!root._holders[key] || !root._known[key])
+            return;
+        ResourceEngine.declareResource(key, key === "cpu" ? {
+            label: qsTr("CPU"),
+            unit: "threads",
+            capacity: root._known.cpu,
+            safetyMargin: 0.15
+        } : {
+            label: qsTr("Memory"),
+            unit: "MiB",
+            capacity: root._known.memory,
+            safetyMargin: 0.2
+        });
+    }
+
+    function _learn(key: string, value: int): void {
+        if (!(value > 0))
+            return;
+        const next = Object.assign({}, root._known);
+        next[key] = value;
+        root._known = next;
+        root._declare(key);
+    }
+
+    property Process _cpuProc: Process {
+        command: ["nproc"]
+        stdout: StdioCollector {
+            onStreamFinished: root._learn("cpu", parseInt(text.trim(), 10))
+        }
+    }
+
+    property Process _memProc: Process {
+        command: ["cat", "/proc/meminfo"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const m = text.match(/^MemTotal:\s+(\d+)/m);
+                if (m)
+                    root._learn("memory", Math.round(parseInt(m[1], 10) / 1024));
+            }
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/ai/OllamaClaims.qml
+++ b/Configs/quickshell/aphotic/services/ai/OllamaClaims.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import Quickshell.Io
+import qs.services
 import qs.services.profile
 
 // Ollama as the Resource Engine's first real claimant: every model
@@ -35,6 +36,7 @@ QtObject {
     // unclassified rather than being guessed into this plane.
     property var _tokens: ({})
     property var _unloads: ({})
+    property bool _memoryHeld: false
 
     onEnabledChanged: root._register()
     onRunningModelsChanged: root._sync()
@@ -60,11 +62,11 @@ QtObject {
     //
     // A model /api/ps reports with size_vram 0 is resident in system RAM,
     // not on the GPU (Ollama falls back to CPU inference when it can't fit
-    // or can't reach the card), so it is not a gpu-vram claimant at all.
-    // Registering it anyway would put a zero-amount claim in the table that
-    // adds nothing to the total but can still be picked as the incumbent to
-    // suspend -- offering to stop a CPU-resident model to free VRAM it was
-    // never holding.
+    // or can't reach the card), so it is not a gpu-vram claimant. A
+    // zero-amount VRAM claim would add nothing to the total and could
+    // still be picked as the incumbent to suspend -- offering to stop a
+    // CPU-resident model to free VRAM it was never holding. It claims
+    // against memory instead, where the bytes actually are.
     function _sync(): void {
         if (!root._registered)
             return;
@@ -74,6 +76,42 @@ QtObject {
             if (!model?.name)
                 continue;
             const amount = Math.round((model.size_vram ?? 0) / (1024 * 1024));
+            // A model Ollama loaded into system RAM is resident work
+            // holding real memory, and until now it was dropped on the
+            // floor because it holds no VRAM. It claims against memory
+            // instead, at the same measured precision.
+            const ram = Math.round(((model.size ?? 0) - (model.size_vram ?? 0)) / (1024 * 1024));
+            if (ram > 0) {
+                const ramId = `${model.name} (system RAM)`;
+                resident[ramId] = true;
+                if (!root._memoryHeld) {
+                    root._memoryHeld = true;
+                    SystemCapacity.acquire("memory");
+                }
+                root._tokens[ramId] = WorkloadPassports.open({
+                    plane: "ai",
+                    owner: root.owner,
+                    label: ramId,
+                    trigger: "model-resident-cpu",
+                    workloadId: `ollama-${model.name}-ram`,
+                    sessionId: `model-ram:${model.name}`,
+                    sourceAt: Date.now(),
+                    claims: [{ resource: "memory", amount: ram, unit: "MiB",
+                        measuredAt: Date.now(), origin: "measured" }]
+                });
+                const knownRam = ResourceEngine.claimById(ramId);
+                if (!knownRam || knownRam.owner !== root.owner || knownRam.amount !== ram) {
+                    ResourceEngine.register({
+                        id: ramId,
+                        owner: root.owner,
+                        resource: "memory",
+                        amount: ram,
+                        priority: "background",
+                        label: ramId,
+                        origin: "dynamic"
+                    });
+                }
+            }
             if (amount <= 0)
                 continue;
             resident[model.name] = true;
@@ -105,6 +143,11 @@ QtObject {
         for (const claim of ResourceEngine.claimsOf(root.owner)) {
             if (!resident[claim.id])
                 ResourceEngine.release(claim.id);
+        }
+
+        if (root._memoryHeld && ResourceEngine.claimsOf(root.owner).every(c => c.resource !== "memory")) {
+            root._memoryHeld = false;
+            SystemCapacity.release("memory");
         }
 
         // The poll that proves a model left is also what settles the

--- a/Configs/quickshell/aphotic/services/profile/DevProfile.qml
+++ b/Configs/quickshell/aphotic/services/profile/DevProfile.qml
@@ -64,6 +64,23 @@ Singleton {
         if (!root.enabled || !label)
             return "";
         const now = Date.now();
+
+        // A worker count the wrapper asked for is a real reservation, so
+        // it becomes a real claim. Capacity comes with it and goes away
+        // with the last build, which is how core avoids declaring a
+        // resource on a machine that never builds anything.
+        if (workers > 0) {
+            SystemCapacity.acquire("cpu");
+            ResourceEngine.register({
+                id: `dev-build-${pid}`,
+                owner: root.profileId,
+                resource: "cpu",
+                amount: workers,
+                priority: "background",
+                label: label,
+                origin: "declared"
+            });
+        }
         return WorkloadPassports.open({
             plane: "dev",
             owner: root.profileId,
@@ -77,7 +94,11 @@ Singleton {
         });
     }
 
-    function buildFinished(token: string, reason: string): bool {
+    function buildFinished(token: string, reason: string, pid: int): bool {
+        if (pid > 0 && ResourceEngine.claimById(`dev-build-${pid}`)) {
+            ResourceEngine.release(`dev-build-${pid}`);
+            SystemCapacity.release("cpu");
+        }
         return WorkloadPassports.close(token, reason || "build-end");
     }
 

--- a/Configs/quickshell/aphotic/services/profile/SecurityProfile.qml
+++ b/Configs/quickshell/aphotic/services/profile/SecurityProfile.qml
@@ -38,6 +38,13 @@ Singleton {
     function registerEngagementClaim(resourceKey: string, amount: real): var {
         if (!root.enabled || !resourceKey || !(amount > 0))
             return null;
+        // Capacity arrives with the first claim against it and leaves with
+        // the last, so an install that never runs an engagement still
+        // declares nothing.
+        if (!root._capacityHeld[resourceKey]) {
+            root._capacityHeld[resourceKey] = true;
+            SystemCapacity.acquire(resourceKey);
+        }
         return ResourceEngine.register({
             id: `security-engagement-${resourceKey}`,
             owner: root.profileId,
@@ -68,6 +75,15 @@ Singleton {
         return WorkloadPassports.close(token, reason || "engagement-end");
     }
 
+    function releaseEngagementClaims(): void {
+        for (const key of Object.keys(root._capacityHeld)) {
+            ResourceEngine.release(`security-engagement-${key}`);
+            SystemCapacity.release(key);
+            delete root._capacityHeld[key];
+        }
+    }
+
+    property var _capacityHeld: ({})
     property bool _registered: false
     property string _vpnToken: ""
     property string _dndReceipt: ""
@@ -146,6 +162,7 @@ Singleton {
             return;
         root._registered = false;
         root._vpnToken = "";
+        root.releaseEngagementClaims();
         WorkloadPassports.closeOwner(root.profileId, "layer-disabled");
         ProfileEngine.unregister(root.profileId);
     }
@@ -177,6 +194,7 @@ Singleton {
                     WorkloadPassports.close(root._vpnToken, "vpn-disconnect");
                     root._vpnToken = "";
                 }
+                root.releaseEngagementClaims();
             }
         }
     }

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -27,6 +27,7 @@ singleton SafeMode 1.0 SafeMode.qml
 singleton SessionLockState 1.0 SessionLockState.qml
 singleton Settings 1.0 Settings.qml
 singleton Switcher 1.0 Switcher.qml
+singleton SystemCapacity 1.0 SystemCapacity.qml
 singleton SystemUsage 1.0 SystemUsage.qml
 singleton Themes 1.0 Themes.qml
 singleton UiPickerState 1.0 UiPickerState.qml


### PR DESCRIPTION
## Problem

Flow could only ever draw one arbitrated resource. GPU VRAM was the single declared capacity, so CPU and memory read "Capacity undeclared · not arbitrated" and the map had one reservoir with anything real in it. Meanwhile an Ollama model resident in system RAM was dropped on the floor: it holds no VRAM, so it produced no claim at all, even though the bytes are real and measured.

Core declares no resources at rest on purpose. A base install with nothing running has nothing to arbitrate and must never raise a negotiation prompt, so declaring cpu and memory at startup was not an option.

## Plan

`SystemCapacity` declares cpu and memory capacity under a reference count. The first claimant acquires, the last to leave releases, and the declaration goes with it. Capacity is read once from the machine with one-shot reads (`nproc`, `/proc/meminfo`) and no timer, because a machine does not grow cores while the shell is up. A capacity that cannot be read stays undeclared rather than guessed.

Three real claimants feed it:

- A dev build wrapper's requested worker count becomes a declared cpu reservation, released when the build ends.
- An Ollama model loaded into system RAM becomes a measured memory claim at the same precision as the VRAM path, with its own workload passport.
- A security engagement acquires capacity for whatever resource it claims, and releases both when the engagement or the layer ends.

## Resolution

Flow has three reservoirs with real budgets, contention arithmetic that means something on a machine running a build and a model at once, and a claim lens that tells a declared reservation from a measured one.

Verified with a headless Quickshell probe: nothing declared at rest, cpu and memory declared on acquire (32 threads, 31783 MiB here), the refcount holding through a partial release, the last release undeclaring, and an unbalanced release being a no-op. Profile substrate guards, 102 pytest and the Flow javascript assertions pass.