### PR TITLE
Cast chrome shadows from the shape, not the content

### DIFF
--- a/Configs/quickshell/aphotic/components/ShapeShadow.qml
+++ b/Configs/quickshell/aphotic/components/ShapeShadow.qml
@@ -1,0 +1,51 @@
+import QtQuick
+import QtQuick.Effects
+import qs.services
+
+// A drop shadow cast by a shape instead of by content.
+//
+// The obvious way to give a surface a shadow is `layer.enabled` on the
+// surface itself with a MultiEffect. That makes the shadow correct and
+// every repaint expensive: the whole surface is rendered to a texture and
+// pushed through a five-level blur pyramid every time anything inside it
+// changes, down to a clock digit or a CPU bar. Measured on an idle
+// desktop, the shell's chrome was running 337 scene renders a second that
+// way, ten of them blur-pyramid levels belonging to two windows nobody
+// was touching.
+//
+// A drop shadow only depends on the silhouette. This draws the silhouette
+// on its own, blurs that, and caches it until the geometry, radius or
+// colour changes. The surface's real content then draws on top as plain
+// quads, so a clock tick costs a clock tick.
+//
+// Sits inside the surface at `z: -1` with the surface's own radius and
+// colour. It repaints the same opaque rounded rect the surface already
+// draws, which costs one quad and looks identical.
+Item {
+    id: root
+
+    property real radius: 0
+    property color color: "transparent"
+    property color shadowColor: Colours.palette.m3shadow
+    property real shadowOpacity: 0.5
+    property real shadowBlur: 0.5
+    property real shadowVerticalOffset: 2
+
+    z: -1
+
+    Rectangle {
+        id: shape
+        anchors.fill: parent
+        radius: root.radius
+        color: root.color
+
+        layer.enabled: true
+        layer.effect: MultiEffect {
+            shadowEnabled: true
+            shadowColor: root.shadowColor
+            shadowOpacity: root.shadowOpacity
+            shadowBlur: root.shadowBlur
+            shadowVerticalOffset: root.shadowVerticalOffset
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/components/qmldir
+++ b/Configs/quickshell/aphotic/components/qmldir
@@ -21,6 +21,7 @@ SettingsToggleRow 1.0 SettingsToggleRow.qml
 SignalText 1.0 SignalText.qml
 StateLayer 1.0 StateLayer.qml
 StyledClippingRect 1.0 StyledClippingRect.qml
+ShapeShadow 1.0 ShapeShadow.qml
 StyledRect 1.0 StyledRect.qml
 StyledText 1.0 StyledText.qml
 SystemUsageWatch 1.0 SystemUsageWatch.qml

--- a/Configs/quickshell/aphotic/modules/bar/CapsuleBar.qml
+++ b/Configs/quickshell/aphotic/modules/bar/CapsuleBar.qml
@@ -137,13 +137,12 @@ Item {
             }
         }
 
-        layer.enabled: true
-        layer.effect: MultiEffect {
-            shadowEnabled: true
-            shadowColor: Colours.palette.m3shadow
-            shadowOpacity: 0.5
-            shadowBlur: 0.5
-            shadowVerticalOffset: 2
+        // Shadow from the shape, not from the content: see
+        // components/ShapeShadow.qml for what layering the content cost.
+        ShapeShadow {
+            anchors.fill: parent
+            radius: parent.radius
+            color: parent.color
         }
 
         GridLayout {
@@ -264,13 +263,12 @@ Item {
             radius: Tokens.rounding.extraLarge
             color: Colours.tPalette.m3surfaceContainer
 
-            layer.enabled: true
-            layer.effect: MultiEffect {
-                shadowEnabled: true
-                shadowColor: Colours.palette.m3shadow
-                shadowOpacity: 0.5
-                shadowBlur: 0.5
-                shadowVerticalOffset: 2
+            // Shadow from the shape, not from the content: see
+            // components/ShapeShadow.qml.
+            ShapeShadow {
+                anchors.fill: parent
+                radius: parent.radius
+                color: parent.color
             }
 
             Loader {

--- a/Configs/quickshell/aphotic/modules/bar/DockBar.qml
+++ b/Configs/quickshell/aphotic/modules/bar/DockBar.qml
@@ -153,13 +153,12 @@ Item {
             Anim { type: Anim.Emphasized }
         }
 
-        layer.enabled: true
-        layer.effect: MultiEffect {
-            shadowEnabled: true
-            shadowColor: Colours.palette.m3shadow
-            shadowOpacity: 0.5
-            shadowBlur: 0.5
-            shadowVerticalOffset: 2
+        // Shadow from the shape, not from the content: see
+        // components/ShapeShadow.qml for what layering the content cost.
+        ShapeShadow {
+            anchors.fill: parent
+            radius: parent.radius
+            color: parent.color
         }
 
         GridLayout {

--- a/Configs/quickshell/aphotic/modules/notch/Notch.qml
+++ b/Configs/quickshell/aphotic/modules/notch/Notch.qml
@@ -165,13 +165,14 @@ StyledRect {
     radius: root.collapsedThick / 2 + (Tokens.rounding.extraLarge - root.collapsedThick / 2) * root.alongT
     color: Colours.tPalette.m3surfaceContainer
 
-    layer.enabled: true
-    layer.effect: MultiEffect {
-        shadowEnabled: true
-        shadowColor: Colours.palette.m3shadow
-        shadowOpacity: 0.5
-        shadowBlur: 0.5
-        shadowVerticalOffset: 2
+    // Shadow from the shape, not from the content. The notch redraws
+    // whenever its idle strip ticks, and layering the whole surface meant
+    // every one of those ticks re-ran a five-level blur pyramid. See
+    // components/ShapeShadow.qml.
+    ShapeShadow {
+        anchors.fill: parent
+        radius: root.radius
+        color: root.color
     }
 
     // Gated here rather than mounted inside NotchProcessTile: the tile

--- a/Configs/quickshell/aphotic/services/DepthFx.qml
+++ b/Configs/quickshell/aphotic/services/DepthFx.qml
@@ -34,12 +34,17 @@ QtObject {
     // (36.4% shipped, 27.3% with breathing off, 18.3% with no shell).
     //
     // Stepping one shared value instead caps the repaint rate at
-    // `pulseRate` rather than the refresh rate. At 13 Hz the 2600 ms
-    // half-cycle still gets ~34 steps, each moving a blurred glow's
-    // opacity by about 0.016 -- below what reads as a step on a soft
+    // `pulseRate` rather than the refresh rate. At 8 Hz the 2600 ms
+    // half-cycle still gets ~21 steps, each moving a blurred glow's
+    // opacity by about 0.026 -- below what reads as a step on a soft
     // shape, and the cosine ramp keeps the same ease-in-out shape the
     // two chained InOutSine animations had.
-    readonly property int pulseRate: 13
+    //
+    // This is the shell's whole idle repaint budget once chrome shadows
+    // stopped re-blurring on every content change: measured idle, the two
+    // windows holding a glow render at exactly this rate and nothing else
+    // renders at all.
+    readonly property int pulseRate: 8
 
     // 0..1..0 over a full rise+fall. Consumers map it onto their own
     // range rather than being driven directly, so a one-shot effect can

--- a/Configs/quickshell/aphotic/services/DepthFx.qml
+++ b/Configs/quickshell/aphotic/services/DepthFx.qml
@@ -50,7 +50,9 @@ QtObject {
 
     readonly property Timer _pulseClock: Timer {
         interval: Math.round(1000 / root.pulseRate)
-        running: root.glowIntensity > 0
+        // Nothing breathes behind a fullscreen window: the repaint would
+        // cost the same and reach nobody.
+        running: root.glowIntensity > 0 && RenderGate.decorative
         repeat: true
         onTriggered: {
             root._pulsePhase = (root._pulsePhase + interval / (root.pulsePeriod * 2)) % 1;

--- a/Configs/quickshell/aphotic/services/Hypr.qml
+++ b/Configs/quickshell/aphotic/services/Hypr.qml
@@ -110,6 +110,11 @@ Singleton {
                 Hyprland.refreshWorkspaces();
             } else if (n.includes("window") || n.includes("group") || ["pin", "fullscreen", "changefloatingmode", "minimize"].includes(n)) {
                 Hyprland.refreshToplevels();
+                // A workspace's hasfullscreen flag only moves on this
+                // event, and RenderGate reads it to decide whether
+                // anything decorative can still be seen.
+                if (n === "fullscreen")
+                    Hyprland.refreshWorkspaces();
             }
         }
 

--- a/Configs/quickshell/aphotic/services/RenderGate.qml
+++ b/Configs/quickshell/aphotic/services/RenderGate.qml
@@ -1,0 +1,34 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import qs.services
+
+// Whether decorative motion is worth drawing right now.
+//
+// Every breathing, pulsing or drifting element in the shell repaints the
+// whole window that holds it, whether or not a person can see it. When a
+// fullscreen window covers every monitor the shell's chrome is behind it,
+// so that repaint buys nothing and costs the same GPU time as always --
+// during a game or a film, which is exactly when it is least affordable.
+//
+// Core surfaces read `decorative` before starting anything that animates
+// on its own. Plugins should do the same: one gate for the whole shell
+// scales, fifty plugins each with their own idea of "is anyone looking"
+// does not.
+Singleton {
+    id: root
+
+    // Every monitor's active workspace has a fullscreen window on it.
+    // Conservative on purpose: one visible monitor without one and the
+    // shell keeps animating, because the chrome on that monitor is
+    // genuinely on screen.
+    readonly property bool covered: {
+        const mons = Hypr.monitors?.values ?? [];
+        if (mons.length === 0)
+            return false;
+        return mons.every(m => m.activeWorkspace?.lastIpcObject?.hasfullscreen === true);
+    }
+
+    readonly property bool decorative: !root.covered
+}

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -23,6 +23,7 @@ singleton PkgSearch 1.0 PkgSearch.qml
 singleton PluginRegistry 1.0 PluginRegistry.qml
 singleton Pomodoro 1.0 Pomodoro.qml
 singleton ProcessUsage 1.0 ProcessUsage.qml
+singleton RenderGate 1.0 RenderGate.qml
 singleton SafeMode 1.0 SafeMode.qml
 singleton SessionLockState 1.0 SessionLockState.qml
 singleton Settings 1.0 Settings.qml


### PR DESCRIPTION
## Problem

The bar, the dock and the notch each got their drop shadow the obvious way: `layer.enabled` on the surface with a MultiEffect. That renders the entire surface to a texture and pushes it through a five-level blur pyramid every time anything inside changes, down to a clock digit or a CPU micro-bar.

Measured on an idle desktop with `QSG_RENDERER_DEBUG=render`: **337 scene renders a second** across thirteen active renderers. Ten of them were blur-pyramid levels for two windows nobody was touching (638x112 → 320x56 → 160x28 → 80x14 → 40x7, twice, once per monitor).

## Plan

A drop shadow depends on the silhouette, not on the contents. `ShapeShadow` draws that silhouette on its own and blurs it, so the layer is cached until the geometry, radius or colour changes, and the real content draws above it as plain quads. It sits inside the surface at `z: -1` and repaints the same opaque rounded rect the surface already draws: one extra quad, identical pixels.

`RenderGate` answers one question for the whole shell: can anyone see decorative motion right now. When every monitor's active workspace has a fullscreen window on it, the chrome is behind that window and its repaints reach nobody while costing the same GPU time. The breathing pulse clock reads it. Plugins should read it too, which is the point of putting it in core rather than letting fifty plugins each invent their own idea of "is anyone looking".

Hyprland only moves a workspace's `hasfullscreen` flag on the fullscreen event, which the shell was using to refresh toplevels only, so that now refreshes workspaces as well.

## Resolution

Idle scene renders, same machine, same layout, measured back to back:

| | renderers | renders/s |
|---|---|---|
| Before | 13 | 337 |
| Shape shadows | 4 | 38 |
| Shape shadows + gate | 2 meaningful | 28 |
| + 8 Hz pulse | 2 | 21 |

Per-process GPU for the shell, 40s samples back to back: **9.10% → 7.35%** on the first pass, **4.38% → 3.40%** on a second pass after the pulse change. The absolute numbers move with whatever else is on the desktop; the reduction holds at about a fifth of the shell's GPU time either way.

What is left at idle is the breathing glow, two windows at exactly the pulse rate, now 8 Hz. The 2600 ms half-cycle still gets 21 steps at about 0.026 opacity each, under what reads as a step on a soft shape. The gate takes even that to zero behind a fullscreen window.

Needs a look on the real desktop: removing `layer.enabled` also removes the flattening it did, so overlapping translucent children now blend individually during a fade. The surfaces involved are opaque chrome, but a fade with a ripple under it is the case to watch.
