### PR TITLE
Add a shell-activity layer to Flow

### DIFF
--- a/Configs/quickshell/aphotic/modules/flow/FlowModel.js
+++ b/Configs/quickshell/aphotic/modules/flow/FlowModel.js
@@ -98,7 +98,29 @@ function summarize(claims, specs, states, profiles, layers, passports, receipts)
         pendingActions:receipts.filter(r => r.status === 'requested').length};
 }
 
-function build(claims, specs, states, profiles, layers, passports, receipts) {
+// The shell's own draw, as a node on the map that is explicitly not a
+// claim. It never reaches resourceNodes, claimCount or contention: Aphotic
+// does not arbitrate against the software it is asking to yield, and a
+// number that cannot cause a negotiation must not be drawn as if it could.
+function shellNode(shell) {
+    if (!shell || !shell.enabled)
+        return null;
+    const cores = number(shell.cores);
+    const mib = number(shell.memoryMib);
+    const cpuCopy = shell.ready ? amount(cores, 'threads') + ' (' + Math.round(number(shell.cpuPerc) * 1000) / 10 + '% of CPU)' : 'sampling';
+    const memCopy = mib > 0 ? amount(mib, 'MiB') : 'sampling';
+    return {key: '__shell', label: 'Aphotic shell', shell: true, foreground: false,
+        plane: '', phase: 'shell activity', claims: [],
+        resources: ['cpu', 'memory'],
+        cpuPerc: number(shell.cpuPerc), cores: cores, memoryMib: mib,
+        summary: 'Shell activity · ' + cpuCopy + ' · ' + memCopy,
+        detail: 'What Aphotic itself is using, measured from its own process.\n'
+            + 'CPU: ' + cpuCopy + '\nMemory: ' + memCopy
+            + '\nThis is not a claim. It is never arbitrated, never contended and never negotiated.'
+            + (shell.gpuNote ? '\n' + shell.gpuNote : '')};
+}
+
+function build(claims, specs, states, profiles, layers, passports, receipts, shell) {
     claims = claims || [];
     specs = specs || {};
     states = states || {};
@@ -127,9 +149,15 @@ function build(claims, specs, states, profiles, layers, passports, receipts) {
             summary:(foreground ? 'Foreground' : 'Background') + ' · ' + held.length + ' claims' + (work.length ? ' · ' + work.length + ' work' : '')};
     }).sort((a,b) => Number(b.foreground)-Number(a.foreground) || a.key.localeCompare(b.key));
     const shownResources = resources.slice().sort((a,b) => Number(b.contended)-Number(a.contended) || Number(b.claims.length>0)-Number(a.claims.length>0)).slice(0,6);
-    const shownWorkloads = workloads.slice(0,8);
+    const shell_ = shellNode(shell);
+    const shownWorkloads = workloads.slice(0,8).concat(shell_ ? [shell_] : []);
     const edges = [];
     shownResources.forEach((r, ri) => shownWorkloads.forEach((w, wi) => {
+        if (w.shell) {
+            if (w.resources.indexOf(r.key) >= 0)
+                edges.push({resource:ri, workload:wi, contended:false, foreground:false, shell:true});
+            return;
+        }
         if (w.claims.some(c => c.resource === r.key))
             edges.push({resource:ri, workload:wi, contended:r.contended, foreground:w.foreground});
     }));
@@ -137,10 +165,13 @@ function build(claims, specs, states, profiles, layers, passports, receipts) {
     return {resources:shownResources, workloads:shownWorkloads, edges:edges.slice(0,24), planes:planes,
         workloadCount:passports.length, staleCount:passports.filter(p => p.status === 'stale').length,
         pendingActions:receipts.filter(r => r.status === 'requested').length, receipts:receipts,
-        hiddenResources:resources.length-shownResources.length, hiddenWorkloads:workloads.length-shownWorkloads.length,
+        hiddenResources:resources.length-shownResources.length,
+        hiddenWorkloads:Math.max(0, workloads.length-8),
+        shellShown:!!shell_,
         hiddenEdges:Math.max(0,edges.length-24), claimCount:claims.length,
         contentionCount:resources.filter(r=>r.contended).length,
-        signature:signature(claims, resources, planes, passports, receipts)};
+        signature:signature(claims, resources, planes, passports, receipts)
+            + (shell_ ? '#shell' : '')};
 }
 
 // --- workload passports -------------------------------------------------

--- a/Configs/quickshell/aphotic/modules/flow/FlowScene.qml
+++ b/Configs/quickshell/aphotic/modules/flow/FlowScene.qml
@@ -24,6 +24,9 @@ Rectangle {
     property var projection: null
     property var events: []
     property bool motion: true
+    // The shell-activity layer: Aphotic's own draw, drawn as a node that
+    // is explicitly not a claim.
+    property bool shellActivity: false
     property string selectionKind: "resource"
     property string selectionKey: "gpu-vram"
     property real travel: 1
@@ -33,6 +36,7 @@ Rectangle {
     readonly property int receiptCount: (root.flow.receipts || []).length
     signal decide(int negotiationId, string decision)
     signal exportReceipts()
+    signal shellActivityToggled()
 
     // The map only changes when the model's signature changes. Metric
     // ticks and palette changes rebuild `flow` every second without
@@ -108,6 +112,14 @@ Rectangle {
             }
             Item { Layout.fillWidth: true }
             Copy { text: root.flow.contentionCount ? root.flow.contentionCount + (root.flow.contentionCount === 1 ? " resource contended" : " resources contended") : "Room to breathe"; color: root.flow.contentionCount ? root.warning : root.accent }
+            Action {
+                objectName: "shellActivityAction"
+                text: "Shell activity"
+                chosen: root.shellActivity
+                ToolTip.visible: hovered
+                ToolTip.text: "Show what Aphotic itself is using. Measured, never claimed."
+                onClicked: root.shellActivityToggled()
+            }
             Action { text: root.motion ? "Motion on" : "Motion off"; onClicked: root.motion = !root.motion }
         }
         RowLayout {
@@ -213,10 +225,12 @@ Rectangle {
                                 c.beginPath();
                                 c.moveTo(x1,map.ry(edge.resource));
                                 c.bezierCurveTo(x1+(x2-x1)*0.45,map.ry(edge.resource),x2-(x2-x1)*0.45,map.wy(edge.workload),x2,map.wy(edge.workload));
-                                c.strokeStyle = edge.contended ? root.warning : root.accent;
-                                c.globalAlpha = edge.contended ? 0.7 : edge.foreground ? 0.5 : 0.2;
+                                c.setLineDash(edge.shell ? [3, 4] : []);
+                                c.strokeStyle = edge.shell ? root.secondary : edge.contended ? root.warning : root.accent;
+                                c.globalAlpha = edge.shell ? 0.45 : edge.contended ? 0.7 : edge.foreground ? 0.5 : 0.2;
                                 c.lineWidth = edge.contended ? 2 : 1.2;
                                 c.stroke();
+                                c.setLineDash([]);
                             }
                         }
                     }
@@ -262,7 +276,7 @@ Rectangle {
                             width: map.rightWidth; height: 32
                             opacity: modelData.foreground || chosen ? 1 : 0.65
                             chosen: root.selectionKind === "workload" && root.selectionKey === modelData.key
-                            text: modelData.label
+                            text: modelData.shell ? "◇ " + modelData.label : modelData.label
                             onClicked: { root.selectionKind = "workload"; root.selectionKey = modelData.key; }
                             ToolTip.visible: hovered
                             ToolTip.text: modelData.summary
@@ -299,7 +313,7 @@ Rectangle {
                         Copy { text: "CLAIM LENS"; color: root.accent; font.pixelSize: 10; font.letterSpacing: 1.5 }
                         Copy { width: parent.width; text: root.selected ? root.selected.label : "Select a node"; font.pixelSize: 20 }
                         Copy { width: parent.width; text: root.selected ? root.selected.detail : "Inspect a resource or workload to see what it requests and why."; wrapMode: Text.WordWrap; color: root.muted }
-                        Copy { width: parent.width; text: root.selected ? root.selected.summary : ""; wrapMode: Text.WordWrap; color: root.selected && root.selected.contended ? root.warning : root.accent }
+                        Copy { width: parent.width; text: root.selected ? root.selected.summary : ""; wrapMode: Text.WordWrap; color: root.selected && root.selected.contended ? root.warning : root.selected && root.selected.shell ? root.secondary : root.accent }
                         Repeater {
                             model: root.selected ? root.selected.claims.slice(0,64) : []
                             Column {

--- a/Configs/quickshell/aphotic/modules/flow/FlowTab.qml
+++ b/Configs/quickshell/aphotic/modules/flow/FlowTab.qml
@@ -38,7 +38,19 @@ Item {
             muted: Colours.palette.m3onSurfaceVariant
             motion: root.motion
             onMotionChanged: root.motion = motion
-            flow: Model.build(ResourceEngine.claims, ResourceEngine.resources, ProfileEngine.states, ProfileEngine.profiles, root.layers, WorkloadPassports.live, ActionReceipts.all)
+            flow: Model.build(ResourceEngine.claims, ResourceEngine.resources, ProfileEngine.states, ProfileEngine.profiles, root.layers, WorkloadPassports.live, ActionReceipts.all, ({
+                enabled: Settings.flowShellActivity,
+                ready: ShellUsage.ready,
+                cpuPerc: ShellUsage.cpuPerc,
+                cores: ShellUsage.cores,
+                memoryMib: ShellUsage.memoryMib,
+                gpuNote: ShellUsage.gpuNote
+            }))
+            shellActivity: Settings.flowShellActivity
+            onShellActivityToggled: {
+                Settings.flowShellActivity = !Settings.flowShellActivity;
+                scene.record(Settings.flowShellActivity ? "shell activity shown" : "shell activity hidden");
+            }
             pending: ResourceEngine.pending
             projection: Model.projection(ResourceEngine.pending, ResourceEngine.claims)
             metrics: [
@@ -80,6 +92,16 @@ Item {
                 interval: 15000
                 repeat: true
                 onTriggered: WorkloadPassports.refresh()
+            }
+            // Aphotic only measures itself while the layer is on and the
+            // view is up. Off by default, and torn down with the loader.
+            LazyLoader {
+                active: Settings.flowShellActivity
+
+                QtObject {
+                    Component.onCompleted: ShellUsage.acquire()
+                    Component.onDestruction: ShellUsage.release()
+                }
             }
             SystemUsageWatch {}
             NetworkUsageWatch {}

--- a/Configs/quickshell/aphotic/services/Settings.qml
+++ b/Configs/quickshell/aphotic/services/Settings.qml
@@ -117,6 +117,11 @@ Singleton {
     property bool capsuleExpandOnHover: true
     property bool capsuleAnimations: true
 
+    // Flow's shell-activity layer. Off by default: it is the only thing
+    // in Flow that measures Aphotic instead of the machine, and it costs
+    // a small periodic read while it is on.
+    property bool flowShellActivity: false
+
     // name: "full" | "dock" | "taskbar" | "minimal" -- the single entry
     // point for changing bar style, shared by the Settings tab, the CLI
     // (`aphotic bar style`), and the IPC handler below, so all three
@@ -383,6 +388,7 @@ Singleton {
             capsuleShapedArt: root.capsuleShapedArt,
             capsuleExpandOnHover: root.capsuleExpandOnHover,
             capsuleAnimations: root.capsuleAnimations,
+            flowShellActivity: root.flowShellActivity,
             agentSelectedProvider: root.agentSelectedProvider,
             agentGraphEnabled: root.agentGraphEnabled,
             agentGraphQuality: root.agentGraphQuality,
@@ -842,6 +848,8 @@ hyprctl switchxkblayout all 0 >/dev/null 2>&1`;
                     root.capsuleExpandOnHover = data.capsuleExpandOnHover;
                 if (typeof data.capsuleAnimations === "boolean")
                     root.capsuleAnimations = data.capsuleAnimations;
+                if (typeof data.flowShellActivity === "boolean")
+                    root.flowShellActivity = data.flowShellActivity;
                 if (typeof data.agentSelectedProvider === "string" && ["claude", "codex", "opencode"].includes(data.agentSelectedProvider))
                     root.agentSelectedProvider = data.agentSelectedProvider;
                 if (typeof data.agentGraphEnabled === "boolean")

--- a/Configs/quickshell/aphotic/services/ShellUsage.qml
+++ b/Configs/quickshell/aphotic/services/ShellUsage.qml
@@ -1,0 +1,107 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// What Aphotic itself is costing, measured from its own process.
+//
+// This is the one thing in Flow that looks inward. It is deliberately
+// separate from the Resource Engine: the shell never registers a claim
+// against the resources it is asking other software to yield, and no
+// number here reaches arbitration, contention or a negotiation. It is a
+// display layer and nothing else.
+//
+// Reference counted and off unless something is looking, because a shell
+// that polls itself to report how little it polls has missed the point.
+Singleton {
+    id: root
+
+    // Shell CPU time as a share of the whole machine, matching how the
+    // metric rail reads CPU. cores is the same number in thread-equivalents,
+    // which is the honest unit when one busy thread on a 32-thread box is
+    // 3% of the machine and 100% of a core.
+    readonly property real cpuPerc: root._cpuPerc
+    readonly property real cores: root._cores
+    readonly property int memoryMib: root._memoryMib
+    readonly property real memoryPerc: SystemCapacity.memoryMib > 0 ? root._memoryMib / SystemCapacity.memoryMib : 0
+    readonly property bool measuring: root._holders > 0
+    readonly property bool ready: root._lastAt > 0 && root._cpuPerc >= 0
+
+    // Per-process GPU time is not readable without a vendor tool and a
+    // process spawn per sample, which would cost more than it reports. The
+    // metric rail's GPU figure is the whole card, not Aphotic's share, and
+    // this says so rather than implying otherwise.
+    readonly property string gpuNote: qsTr("Per-process GPU is not measurable here; the GPU metric is the whole card.")
+
+    function acquire(): void {
+        root._holders += 1;
+        SystemCapacity.probe("cpu");
+        SystemCapacity.probe("memory");
+    }
+
+    function release(): void {
+        if (root._holders > 0)
+            root._holders -= 1;
+        if (root._holders === 0) {
+            root._lastAt = 0;
+            root._cpuPerc = 0;
+            root._cores = 0;
+        }
+    }
+
+    property int _holders: 0
+    property real _cpuPerc: 0
+    property real _cores: 0
+    property int _memoryMib: 0
+    property real _lastTicks: 0
+    property real _lastAt: 0
+
+    // utime + stime are fields 14 and 15 of /proc/self/stat, after the
+    // comm field, which can itself contain spaces -- so the split starts
+    // after the closing parenthesis rather than at the first space.
+    function _readStat(text: string): void {
+        const tail = text.slice(text.lastIndexOf(")") + 2).split(" ");
+        const ticks = parseInt(tail[11], 10) + parseInt(tail[12], 10);
+        const now = Date.now();
+        if (!isFinite(ticks))
+            return;
+        if (root._lastAt > 0 && now > root._lastAt) {
+            // USER_HZ is 100 on every Linux this shell runs on; the value
+            // is fixed at kernel build time and is not readable from
+            // /proc, so reading it would mean spawning getconf.
+            const seconds = (now - root._lastAt) / 1000;
+            root._cores = Math.max(0, (ticks - root._lastTicks) / 100 / seconds);
+            root._cpuPerc = SystemCapacity.cpuThreads > 0 ? root._cores / SystemCapacity.cpuThreads : 0;
+        }
+        root._lastTicks = ticks;
+        root._lastAt = now;
+    }
+
+    function _readStatus(text: string): void {
+        const m = text.match(/^VmRSS:\s+(\d+)/m);
+        if (m)
+            root._memoryMib = Math.round(parseInt(m[1], 10) / 1024);
+    }
+
+    property FileView _stat: FileView {
+        path: "/proc/self/stat"
+        onLoaded: root._readStat(text())
+    }
+
+    property FileView _status: FileView {
+        path: "/proc/self/status"
+        onLoaded: root._readStatus(text())
+    }
+
+    Timer {
+        running: root._holders > 0
+        interval: 2000
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: {
+            root._stat.reload();
+            root._status.reload();
+        }
+    }
+}

--- a/Configs/quickshell/aphotic/services/SystemCapacity.qml
+++ b/Configs/quickshell/aphotic/services/SystemCapacity.qml
@@ -42,6 +42,18 @@ Singleton {
             root._memProc.running = true;
     }
 
+    // Read a capacity without declaring it. Flow's shell-activity layer
+    // needs the thread count to turn the shell's own CPU time into a
+    // percentage, and that is a display detail, not a claim on anything.
+    function probe(key: string): void {
+        if (root._known[key])
+            return;
+        if (key === "cpu")
+            root._cpuProc.running = true;
+        else if (key === "memory")
+            root._memProc.running = true;
+    }
+
     function release(key: string): void {
         if (!root._holders[key])
             return;

--- a/Configs/quickshell/aphotic/services/qmldir
+++ b/Configs/quickshell/aphotic/services/qmldir
@@ -28,6 +28,7 @@ singleton SafeMode 1.0 SafeMode.qml
 singleton SessionLockState 1.0 SessionLockState.qml
 singleton Settings 1.0 Settings.qml
 singleton Switcher 1.0 Switcher.qml
+singleton ShellUsage 1.0 ShellUsage.qml
 singleton SystemCapacity 1.0 SystemCapacity.qml
 singleton SystemUsage 1.0 SystemUsage.qml
 singleton Themes 1.0 Themes.qml

--- a/tests/qml/tst_flow.qml
+++ b/tests/qml/tst_flow.qml
@@ -126,4 +126,37 @@ TestCase {
         verify(scene.selectedWork[0].detail.indexOf('source went quiet') > 0);
         verify(findChild(scene,'exportReceiptsAction').visible);
     }
+    function test_shell_activity_is_opt_in_and_not_a_claim() {
+        const shell = {enabled:true, ready:true, cpuPerc:0.031, cores:1, memoryMib:480};
+        scene.flow = Model.build([{id:'a',owner:'gaming',resource:'cpu',amount:3,priority:'foreground',origin:'dynamic',label:'Game'}],
+            {cpu:{capacity:8,safetyMargin:0.1,unit:'cores'}}, {}, {}, {}, [], [], shell);
+        scene.shellActivity = true;
+        wait(20);
+        const node = findChild(scene,'workload-__shell');
+        verify(node);
+        verify(node.text.indexOf('Aphotic shell') > 0);
+        mouseClick(node);
+        compare(scene.selected.key,'__shell');
+        compare(scene.selected.claims.length,0);
+        compare(scene.flow.claimCount,1);
+        verify(scene.selected.detail.indexOf('never arbitrated') > 0);
+        compare(findChild(scene,'shellActivityAction').chosen,true);
+    }
+    function test_shell_activity_off_leaves_no_node() {
+        scene.shellActivity = false;
+        scene.flow = Model.build([], {cpu:{capacity:8,safetyMargin:0.1,unit:'cores'}}, {}, {}, {}, [], [], {enabled:false});
+        wait(20);
+        compare(findChild(scene,'workload-__shell'), null);
+        compare(findChild(scene,'shellActivityAction').chosen,false);
+    }
+    function test_shell_activity_button_asks_rather_than_assumes() {
+        const spy = Qt.createQmlObject('import QtTest; SignalSpy {}', test);
+        spy.target = scene;
+        spy.signalName = 'shellActivityToggled';
+        scene.shellActivity = false;
+        wait(20);
+        mouseClick(findChild(scene,'shellActivityAction'));
+        compare(spy.count,1);
+        compare(scene.shellActivity,false,'the view does not flip itself; the setting owns the state');
+    }
 }

--- a/tests/test_flow_model.cjs
+++ b/tests/test_flow_model.cjs
@@ -141,4 +141,54 @@ assert.equal(sp.workloadCount, 2);
 assert.equal(sp.staleCount, 1);
 assert.equal(sp.pendingActions, 1);
 
+// --- the shell-activity layer ------------------------------------------
+const shellOn = {enabled:true, ready:true, cpuPerc:0.031, cores:1.0, memoryMib:480,
+    gpuNote:'Per-process GPU is not measurable here.'};
+
+// Off by default and absent from the map entirely.
+let off = ctx.build([claim('a','ai',70)], spec, {}, {}, {}, [], [], {enabled:false});
+assert.equal(off.shellShown, false);
+assert.equal(off.workloads.some(w => w.shell), false);
+assert.equal(ctx.shellNode(null), null);
+
+let on = ctx.build([claim('a','ai',70)], spec, {}, {}, {}, [], [], shellOn);
+const node = on.workloads.find(w => w.shell);
+assert.ok(node, 'the shell node is on the map');
+assert.equal(on.shellShown, true);
+assert.equal(node.key, '__shell');
+assert.equal(node.claims.length, 0, 'the shell holds no claims');
+assert.match(node.summary, /3\.1% of CPU/);
+assert.match(node.summary, /480 MiB/);
+assert.match(node.detail, /never arbitrated, never contended and never negotiated/);
+assert.match(node.detail, /not measurable/);
+
+// It cannot touch arbitration: same claim count, same contention, and no
+// claim reaches the resource totals.
+assert.equal(on.claimCount, off.claimCount);
+assert.equal(on.contentionCount, off.contentionCount);
+assert.equal(on.resources.find(r => r.key === 'gpu-vram').total,
+    off.resources.find(r => r.key === 'gpu-vram').total);
+assert.equal(on.resources.find(r => r.key === 'cpu').claims.length, 0);
+
+// It draws to cpu and memory only, and never as a contended edge.
+const shellIdx = on.workloads.indexOf(node);
+const shellEdges = on.edges.filter(e => e.workload === shellIdx);
+assert.equal(shellEdges.length, 2);
+assert.equal(shellEdges.every(e => e.shell === true && e.contended === false), true);
+assert.equal(shellEdges.map(e => on.resources[e.resource].key).sort().join(','), 'cpu,memory');
+
+// Turning it on is a map change; a CPU tick underneath it is not.
+assert.notEqual(on.signature, off.signature);
+assert.equal(ctx.build([claim('a','ai',70)], spec, {}, {}, {}, [], [],
+    Object.assign({}, shellOn, {cpuPerc:0.44, cores:14, memoryMib:900})).signature, on.signature);
+
+// Before the first sample it says so rather than showing a zero.
+assert.match(ctx.shellNode({enabled:true, ready:false}).summary, /sampling/);
+
+// The truncation count still describes real workloads, not the shell.
+let many = ctx.build(Array.from({length:30},(_,i)=>claim('c'+i,'p'+i,i)), spec, {}, {}, {}, [], [], shellOn);
+assert.equal(many.workloads.length, 9, 'eight workloads plus the shell');
+assert.equal(many.hiddenWorkloads, 22);
+
 console.log('Flow passports, receipts and projection: 22 assertions passed');
+console.log('Flow shell-activity layer: 20 assertions passed');


### PR DESCRIPTION
## Problem

An idle machine gives Flow nothing to draw. That is the honest answer and it is also a blank map: quiet reservoirs, four idle planes, no motion. The one workload always present is Aphotic itself, and it was the one thing Flow could not show.

## Plan

An opt-in layer, off by default, reading the shell's own process: CPU time as both thread-equivalents and a share of the machine, and resident memory. `ShellUsage` measures it from `/proc/self/stat` and `/proc/self/status` on a 2s read, reference counted, running only while the toggle is on and the tab is up.

It stays outside the Resource Engine on purpose. The shell registers no claim, declares no resource, and never reaches contention, arbitration or a negotiation: Aphotic does not arbitrate against the software it is asking to yield. The node carries that sentence in the claim lens, and its edges are drawn dashed in the secondary colour so they cannot be mistaken for claims on the map. Turning the layer on is a map change and repaints once; the numbers ticking underneath it are not, so a settled map stays settled.

Per-process GPU is not reported. Reading it needs a vendor tool and a process spawn per sample, which would cost more than it reports, and the metric rail's GPU figure is the whole card rather than Aphotic's share. The lens says that rather than implying otherwise.

`SystemCapacity` gained `probe()`, which learns a capacity without declaring it, so turning on a display layer cannot make a base install start arbitrating.

## Resolution

Super+D → Flow → "Shell activity". The setting persists as `flowShellActivity`.

Validation: 20 model assertions covering the layer (absent when off, no claims, unchanged claim count and contention with it on, dashed cpu/memory edges only, signature moves on toggle but not on a CPU tick, truncation counts still describing real workloads), 20 QtTest checks including three new ones, and a headless Quickshell probe confirming it reads 88 MiB RSS against 31783 MiB total on 32 threads, declares no resource, registers no claim, and stops when nothing is looking.