### PR TITLE
Read installed plugins from the registry, not the CLI

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -463,7 +463,15 @@ _aphotic_plugin_describe() {
     # upgrade is noise that trains people to ignore the signal. A plugin
     # that genuinely gained a profile block still differs from null, so the
     # real case is unaffected.
-    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else {profile: null, cli: null, chat_provider: null, actions: null} + . end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
+    # Projected down to exactly the keys `expected` names, not compared
+    # whole. The registry also carries display metadata (display_name,
+    # description, category, requires_binaries) that the shell reads
+    # instead of re-running this function; a whole-object compare would
+    # read every one of those as an extra key and flag all of them as
+    # drift. Drift means "this plugin's contract changed", and a
+    # display string is not contract -- a manifest edit still refreshes
+    # it on the next sync.
+    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else ({profile: null, cli: null, chat_provider: null, actions: null} + .) | {version, capabilities, owns, ui, profile, cli, chat_provider, actions} end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
     [[ "$expected" != "$stored" ]] && drifted="true"
 
     jq --argjson drifted "$drifted" '. + {drifted: $drifted}' <<<"$entry"
@@ -478,6 +486,58 @@ _aphotic_plugin_list_installed_json() {
     printf '%s\n' "${entries[@]:-}" | jq -s 'map(select(. != null))'
 }
 
+# How long a fetched catalogue is served from disk before the next call
+# refetches. The index is a list of what exists to install, not live
+# state, so a few hours stale costs nothing; `--refresh` and every
+# install/remove path bypass it.
+APHOTIC_PLUGINS_INDEX_TTL="${APHOTIC_PLUGINS_INDEX_TTL:-21600}"
+
+_aphotic_plugin_index_cache_file() {
+    echo "${APHOTIC_STATE_HOME}/plugin-index.json"
+}
+
+# Annotated catalogue, served from disk when it is younger than the TTL.
+# Settings -> Plugins reads this file directly rather than shelling out at
+# all, so the fetch happens on an explicit refresh instead of on every
+# pane open. $1: "true" to ignore the cache and refetch.
+# The cache file carries the security-index trust flag alongside the
+# plugins, so the shell answers "is the security index trusted" from the
+# same file it already watches instead of spawning a third process for it.
+# Emits the plain plugins array on stdout: that is what `list --remote
+# --json` has always printed and what its callers parse.
+_aphotic_plugin_index_cached() {
+    local force="${1:-false}" cache age data trusted
+    cache="$(_aphotic_plugin_index_cache_file)"
+
+    if [[ "$force" != "true" && -s "$cache" ]]; then
+        age=$(( $(date +%s) - $(stat -c %Y "$cache" 2>/dev/null || echo 0) ))
+        if [[ "$age" -lt "$APHOTIC_PLUGINS_INDEX_TTL" ]]; then
+            jq -c '.plugins // []' "$cache" 2>/dev/null && return 0
+        fi
+    fi
+
+    data="$(_aphotic_plugin_annotate_remote_json "$(_aphotic_plugin_list_remote_json)")"
+    # A failed fetch yields an empty list. Keeping the last good catalogue
+    # rather than overwriting it with nothing means going offline leaves
+    # the pane showing what it showed before, not an empty index.
+    if [[ "$(jq -r 'length' <<<"$data" 2>/dev/null || echo 0)" -eq 0 && -s "$cache" ]]; then
+        jq -c '.plugins // []' "$cache" 2>/dev/null && return 0
+    fi
+
+    trusted="false"
+    aphotic_plugins_security_index_trusted && trusted="true"
+
+    mkdir -p "$(dirname "$cache")"
+    # Piped, never --argjson: a catalogue of any real size exceeds
+    # ARG_MAX as a command-line argument. A 2000-entry index fails
+    # outright that way.
+    printf '%s\n' "$data" | jq --argjson trusted "$trusted" \
+        --argjson fetched_at "$(date +%s)" \
+        '{fetched_at: $fetched_at, trusted: $trusted, plugins: .}' \
+        > "${cache}.tmp" && mv "${cache}.tmp" "$cache"
+    printf '%s\n' "$data"
+}
+
 _aphotic_plugin_list_remote_json() {
     aphotic_require curl || return 1
     local main_data security_data
@@ -490,8 +550,10 @@ _aphotic_plugin_list_remote_json() {
     # "installable but hidden" -- it's not fetched at all.
     if aphotic_plugins_security_index_trusted; then
         security_data="$(curl -fsSL -m 10 "$APHOTIC_PLUGINS_SECURITY_INDEX_URL" 2>/dev/null || echo '{"plugins": []}')"
-        jq -n --argjson a "$main_data" --argjson b "$security_data" \
-            '{plugins: (($a.plugins // []) + ($b.plugins // []))}'
+        # Slurped from stdin rather than passed as two --argjson values:
+        # either index is large enough to exceed ARG_MAX on its own.
+        printf '%s\n%s\n' "$main_data" "$security_data" \
+            | jq -s '{plugins: ((.[0].plugins // []) + (.[1].plugins // []))}'
     else
         echo "$main_data"
     fi
@@ -501,18 +563,39 @@ _aphotic_plugin_list_remote_json() {
 # `host_support: {verdict, unhosted}`. Additive on purpose: Settings ->
 # Plugins reads this same `list --remote --json` and ignores fields it
 # does not know, so an older pane keeps working against a newer CLI.
+# One jq pass over the whole index, not a shell loop. This used to fork
+# _aphotic_plugin_entry_verdict plus a rewriting jq per catalogue entry --
+# four processes each, so a 2000-plugin index cost 8000 of them and
+# Settings -> Plugins waited on all of it. The verdict rule below is a
+# direct port of _aphotic_plugin_host_verdict; that function stays the
+# single answer for an on-disk manifest, and tests/test_plugin_host_gate.sh
+# holds the two in step.
 _aphotic_plugin_annotate_remote_json() {
-    local data="$1" entry verdict annotated=()
+    local data="$1"
 
-    while IFS= read -r entry; do
-        [[ -n "$entry" ]] || continue
-        verdict="$(_aphotic_plugin_entry_verdict "$entry")"
-        annotated+=("$(jq --arg v "${verdict%%:*}" --arg u "${verdict#*:}" \
-            '. + {host_support: {verdict: $v, unhosted: (if $v == "ok" then "" else $u end)}}' \
-            <<<"$entry")")
-    done < <(jq -c '(.plugins // [])[]' <<<"$data")
-
-    printf '%s\n' "${annotated[@]:-}" | jq -s 'map(select(. != null))'
+    jq --arg hosted_caps "$APHOTIC_PLUGIN_HOSTED_CAPABILITIES" \
+       --arg hosted_surfaces "$APHOTIC_PLUGIN_HOSTED_SURFACES" '
+        ($hosted_caps | split(" ")) as $hc
+        | ($hosted_surfaces | split(" ")) as $hs
+        | def verdict:
+            [(.capabilities // [])[] | select(. != null and . != "")] as $caps
+            | [(.ui.surfaces // [])[].surface | select(. != null and . != "")] as $rawsurf
+            | ($rawsurf | unique) as $surfs
+            # Capability order first, then surfaces, matching the order
+            # the shell function builds its message in.
+            | ([$caps[] | select(. as $c | $hc | index($c) | not) | . + " capability"]
+               + [$surfs[] | select(. as $s | $hs | index($s) | not) | . + " surface"]) as $unhosted
+            | ([$caps[] | select(. as $c | $hc | index($c)) | select(. != "ui-surface")]
+               + [$surfs[] | select(. as $s | $hs | index($s))] | length) as $working
+            | if ($unhosted | length) == 0 then
+                  {verdict: "ok", unhosted: ""}
+              elif $working > 0 then
+                  {verdict: "partial", unhosted: ($unhosted | join(", "))}
+              else
+                  {verdict: "inert", unhosted: ($unhosted | join(", "))}
+              end;
+        (.plugins // []) | map(. + {host_support: verdict})
+    ' <<<"$data"
 }
 
 # Fire every enabled theme-hook plugin's on_theme_change script, piping
@@ -772,6 +855,7 @@ _aphotic_plugin_install_deps() {
 # via the same file's "disabled" array.
 _aphotic_plugin_registry_sync() {
     local name="$1" dir manifest version caps owns ui profile cli chat_provider actions tmp
+    local display desc category binaries
     aphotic_require jq || return 1
     dir="$(_aphotic_plugin_dir "$name")"
     manifest="${dir}/plugin.toml"
@@ -779,6 +863,17 @@ _aphotic_plugin_registry_sync() {
 
     version="$(aphotic_toml_get "$manifest" plugin version)"
     caps="$(aphotic_toml_get_array "$manifest" plugin capabilities | jq -R . | jq -s .)"
+    # Display metadata, stored so the shell can render the whole installed
+    # list straight out of this file. Settings -> Plugins used to shell out
+    # to `aphotic plugin list --json` to get these four, which re-reads
+    # every manifest on the machine -- ~200ms per installed plugin, paid on
+    # every pane open. They are a copy of the manifest by definition; a
+    # manifest edited in place refreshes them on the next sync, same as
+    # every other field here.
+    display="$(aphotic_toml_get "$manifest" plugin display_name)"
+    desc="$(aphotic_toml_get "$manifest" plugin description)"
+    category="$(aphotic_toml_get "$manifest" plugin category)"
+    binaries="$(aphotic_toml_get_array "$manifest" requires binaries | jq -R . | jq -s .)"
     owns="$(_aphotic_plugin_owns_json "$manifest")"
     ui="$(_aphotic_plugin_ui_json "$manifest")"
     profile="$(_aphotic_plugin_profile_json "$manifest")"
@@ -790,6 +885,10 @@ _aphotic_plugin_registry_sync() {
     tmp="$(mktemp)"
     jq --arg n "$name" \
        --arg version "${version:-0.0.0}" \
+       --arg display_name "${display:-$name}" \
+       --arg description "${desc:-}" \
+       --arg category "${category:-}" \
+       --argjson requires_binaries "${binaries:-[]}" \
        --argjson capabilities "${caps:-[]}" \
        --argjson owns "$owns" \
        --argjson ui "$ui" \
@@ -797,7 +896,7 @@ _aphotic_plugin_registry_sync() {
        --argjson cli "$cli" \
        --argjson chat_provider "$chat_provider" \
        --argjson actions "$actions" \
-       '.installed = ((.installed // {}) + {($n): {version: $version, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider, actions: $actions}})' \
+       '.installed = ((.installed // {}) + {($n): {version: $version, display_name: $display_name, description: $description, category: $category, requires_binaries: $requires_binaries, capabilities: $capabilities, owns: $owns, ui: $ui, profile: $profile, cli: $cli, chat_provider: $chat_provider, actions: $actions}})' \
        "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp" && mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
     # Every install and update funnels through here, so this is the one
     # place that has to record "a plugin's code changed" for recovery.
@@ -1305,16 +1404,41 @@ _aphotic_plugin_validate() {
     return 0
 }
 
+# Entries written before the registry carried display metadata have no
+# display_name, so the shell would render them as a bare id with no
+# description or category. Re-syncing them is the same work an install
+# does, just deferred; the jq test costs one fork and answers "no" for
+# every invocation after the first, so this is cheap to sit in front of
+# every subcommand.
+#
+# The shell tolerates the gap on its own (it falls back to the plugin id),
+# so a failure here is not worth interrupting a command over.
+_aphotic_plugin_registry_backfill() {
+    [[ -f "$APHOTIC_PLUGINS_STATE_FILE" ]] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+    jq -e '(.installed // {}) | to_entries | any(.value | has("display_name") | not)' \
+        "$APHOTIC_PLUGINS_STATE_FILE" >/dev/null 2>&1 || return 0
+
+    local name
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        _aphotic_plugin_registry_sync "$name" >/dev/null 2>&1 || true
+    done < <(jq -r '(.installed // {}) | keys[]' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)
+}
+
 aphotic_cmd_plugin() {
     local sub="${1:-}"; shift || true
 
+    _aphotic_plugin_registry_backfill
+
     case "$sub" in
         list)
-            local remote="false" as_json="false" category=""
+            local remote="false" as_json="false" category="" refresh="false"
             while [[ $# -gt 0 ]]; do
                 case "$1" in
                     --remote) remote="true"; shift ;;
                     --json) as_json="true"; shift ;;
+                    --refresh) refresh="true"; shift ;;
                     --category) category="${2:-}"; shift 2 ;;
                     *) shift ;;
                 esac
@@ -1324,11 +1448,14 @@ aphotic_cmd_plugin() {
 
             local data
             if [[ "$remote" == "true" ]]; then
-                data="$(_aphotic_plugin_list_remote_json)"
+                # Annotated and cached in one step. Filtering by category
+                # happens after, not before, so the cached file always
+                # holds the whole catalogue rather than whichever slice
+                # the last caller happened to ask for.
+                data="$(_aphotic_plugin_index_cached "$refresh")"
                 if [[ -n "$category" ]]; then
-                    data="$(echo "$data" | jq --arg c "$category" '{plugins: ((.plugins // []) | map(select(.category == $c)))}')"
+                    data="$(echo "$data" | jq --arg c "$category" 'map(select(.category == $c))')"
                 fi
-                data="$(_aphotic_plugin_annotate_remote_json "$data")"
                 [[ "$as_json" == "true" ]] && { echo "$data"; return 0; }
                 echo "$data" | jq -r '.[] | "\(.name)\t\(.display_name)\t\(.version)\t\(if .host_support.verdict == "inert" then "NOT SUPPORTED" elif .host_support.verdict == "partial" then "partly supported" else "" end)\t\(.description)"' | column -t -s $'\t'
 

--- a/Configs/quickshell/aphotic/services/PluginRegistry.qml
+++ b/Configs/quickshell/aphotic/services/PluginRegistry.qml
@@ -177,6 +177,81 @@ Singleton {
         return actions;
     }
 
+    // Everything Settings -> Plugins needs to draw one installed row,
+    // built once per plugins.json change. The pane used to get this by
+    // running `aphotic plugin list --json`, which re-reads every manifest
+    // on the machine -- measured at ~200ms per installed plugin, paid on
+    // every pane open and again every 5 seconds while Settings was open.
+    // The CLI writes all of it into the registry at install time, so
+    // reading it here costs nothing and updates reactively through the
+    // FileView below, the way every other consumer of this file already
+    // works.
+    //
+    // display_name/description/category/requires_binaries are absent on an
+    // entry written before the registry carried them. The fallbacks keep
+    // such a row rendering as itself rather than blank; `aphotic plugin`
+    // backfills them on its next run.
+    readonly property var installedList: {
+        const rows = [];
+        for (const name of Object.keys(root._installed)) {
+            const entry = root._installed[name] ?? ({});
+            const display = entry.display_name || name;
+            const description = entry.description ?? "";
+            const category = entry.category ?? "";
+            rows.push({
+                name: name,
+                displayName: display,
+                description: description,
+                category: category,
+                version: entry.version ?? "0.0.0",
+                capabilities: entry.capabilities ?? [],
+                requiresBinaries: entry.requires_binaries ?? [],
+                configKeys: entry.owns?.config_keys ?? [],
+                externalConfig: entry.owns?.external_config ?? [],
+                surfaces: root._surfacesOf(name),
+                requiresLayer: root.requiredLayerOf(name),
+                enabled: root.isEnabled(name),
+                installed: true,
+                // Precomputed so filtering a long list is a substring test
+                // per row rather than three toLowerCase() calls per row per
+                // keystroke.
+                searchKey: `${name} ${display} ${description} ${category}`.toLowerCase()
+            });
+        }
+        return rows.sort((a, b) => a.displayName.localeCompare(b.displayName));
+    }
+
+    // Installed names as an object used as a set. The Plugins pane checks
+    // "is this catalogue entry already installed" once per visible row;
+    // against an array that is a linear scan per row, which is O(n*m) across
+    // a catalogue of any size.
+    readonly property var installedNames: {
+        const set = ({});
+        for (const name of Object.keys(root._installed))
+            set[name] = true;
+        return set;
+    }
+
+    // The one layer a plugin needs, read off whichever surface or profile
+    // declares it -- the same derivation the gate below applies, exposed so
+    // a caller asking "what does this need" gets the same answer the gate
+    // will give rather than deriving it a second time.
+    function requiredLayerOf(name: string): string {
+        for (const surface of root._surfacesOf(name)) {
+            if (surface.requiresLayer.length > 0)
+                return surface.requiresLayer;
+        }
+        return root._installed[name]?.profile?.requires_layer ?? "";
+    }
+
+    // Public alias for the gate vocabulary below. A caller deciding whether
+    // to offer an install needs exactly the answer the shell will give when
+    // it comes to draw the surface, and a second copy of this list is a
+    // second answer -- the Plugins pane shipped with one.
+    function layerEnabled(layer: string): bool {
+        return root._layerEnabled(layer);
+    }
+
     // A pre-`ui.surfaces` registry entry (written by a CLI older than the
     // surface unification) still carries a bare `dashboard_tab` object.
     // Reading it as one ungated dashboard surface keeps an install that

--- a/tests/test_plugin_index_scale.sh
+++ b/tests/test_plugin_index_scale.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# tests/test_plugin_index_scale.sh
+# The catalogue path has to cost the same whether the index holds nine
+# plugins or two thousand. It used to fork _aphotic_plugin_entry_verdict
+# plus a rewriting jq per entry -- four processes each -- so the work grew
+# linearly with the catalogue and Settings -> Plugins waited on all of it
+# before it could draw anything.
+#
+# Three things this guards:
+#   - annotation is one jq pass, whatever the index size
+#   - the jq verdict rule still agrees with _aphotic_plugin_host_verdict,
+#     which remains the single answer for an on-disk manifest
+#   - a real-sized index does not blow ARG_MAX. Passing the catalogue as a
+#     --argjson value did, and only at size: it worked fine on nine.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$ROOT/Configs/.local/lib/aphotic/commands/cmd_plugin.sh"
+
+# --- the jq rule agrees with the bash rule, case for case ---------------
+#
+# Each case is an entry plus the verdict _aphotic_plugin_host_verdict
+# gives it. Kept explicit rather than generated: the interesting part is
+# the boundaries (ui-surface never counts toward "working", an unhosted
+# surface next to a hosted one is partial not inert, capabilities are
+# reported before surfaces, surfaces are deduplicated and sorted).
+check() {
+    local entry="$1" got want
+    want="$(_aphotic_plugin_host_verdict \
+        "$(jq -r '(.capabilities // [])[]' <<<"$entry")" \
+        "$(jq -r '((.ui.surfaces // [])[].surface) // empty' <<<"$entry" | sort -u)")"
+    got="$(_aphotic_plugin_annotate_remote_json "{\"plugins\":[$entry]}" \
+        | jq -r '.[0].host_support | if .verdict == "ok" then "ok" else .verdict + ":" + .unhosted end')"
+    [[ "$want" == "$got" ]] || fail "verdict mismatch for $entry -- bash said '$want', jq said '$got'"
+}
+
+check '{"name":"a","capabilities":["theme-hook"]}'
+check '{"name":"b","capabilities":["ui-surface"],"ui":{"surfaces":[{"surface":"dashboard"}]}}'
+check '{"name":"c","capabilities":["agent-event-hook"]}'
+check '{"name":"d","capabilities":["theme-hook","profile-hook","agent-event-hook"]}'
+check '{"name":"e","capabilities":["ui-surface"],"ui":{"surfaces":[{"surface":"quantum"},{"surface":"dashboard"},{"surface":"quantum"}]}}'
+check '{"name":"f","capabilities":[]}'
+check '{"name":"g"}'
+check '{"name":"h","capabilities":["ui-surface"],"ui":{"surfaces":[{"surface":"zeta"},{"surface":"alpha"}]}}'
+check '{"name":"i","capabilities":["profile","cli"],"ui":{"surfaces":[{"surface":"notch"}]}}'
+check '{"name":"j","capabilities":["ui-surface","bogus"],"ui":{"surfaces":[{"surface":"dashboard"}]}}'
+
+# --- a 2000-entry index annotates in one pass --------------------------
+
+BIG="$TESTHOME/big-index.json"
+jq -n '{plugins: [range(2000) | {
+    name: "p\(.)",
+    display_name: "Plugin \(.)",
+    version: "1.0.0",
+    category: (["dev","ai","gaming","security","theming"][. % 5]),
+    description: "synthetic entry \(.)",
+    capabilities: (if . % 3 == 0 then ["ui-surface"] else ["theme-hook"] end),
+    ui: (if . % 3 == 0 then {surfaces: [{surface: (if . % 6 == 0 then "dashboard" else "quantum" end)}]} else null end)
+}]}' > "$BIG"
+
+annotated="$(_aphotic_plugin_annotate_remote_json "$(cat "$BIG")")"
+[[ "$(jq 'length' <<<"$annotated")" -eq 2000 ]] \
+    || fail "expected all 2000 entries back from one annotation pass, got $(jq 'length' <<<"$annotated")"
+[[ "$(jq '[.[] | select(.host_support == null)] | length' <<<"$annotated")" -eq 0 ]] \
+    || fail "every entry must carry a host_support verdict"
+[[ "$(jq '[.[] | select(.host_support.verdict == "inert")] | length' <<<"$annotated")" -gt 0 ]] \
+    || fail "expected the unhosted-surface entries to come back inert"
+
+# One jq for the annotation itself. Counted by tracing the function with a
+# stub on PATH rather than timing it, so this stays a statement about the
+# shape of the code and not about how fast the machine is.
+STUBS="$TESTHOME/stubs"
+mkdir -p "$STUBS"
+cat > "$STUBS/jq" <<EOF
+#!/usr/bin/env bash
+echo call >> "$TESTHOME/jq-calls"
+exec /usr/bin/env -i PATH=/usr/bin:/bin $(command -v jq) "\$@"
+EOF
+chmod +x "$STUBS/jq"
+: > "$TESTHOME/jq-calls"
+PATH="$STUBS:$PATH" _aphotic_plugin_annotate_remote_json "$(cat "$BIG")" >/dev/null
+calls="$(wc -l < "$TESTHOME/jq-calls")"
+[[ "$calls" -le 2 ]] \
+    || fail "expected annotation to be one jq pass regardless of index size, saw $calls calls for 2000 entries"
+
+# --- the whole catalogue survives being handed around ------------------
+#
+# The ARG_MAX regression: this fetches, annotates and writes the cache,
+# and every step has to move the catalogue through a pipe or a file rather
+# than argv.
+export APHOTIC_PLUGINS_INDEX_URL="file://$BIG"
+export APHOTIC_PLUGINS_SECURITY_INDEX_URL="file://$BIG"
+out="$(_aphotic_plugin_index_cached true 2>"$TESTHOME/err")"
+[[ -s "$TESTHOME/err" ]] && fail "index fetch wrote to stderr: $(cat "$TESTHOME/err")"
+[[ "$(jq 'length' <<<"$out")" -eq 2000 ]] \
+    || fail "expected 2000 entries through the caching path, got $(jq 'length' <<<"$out")"
+
+cache="$(_aphotic_plugin_index_cache_file)"
+[[ -s "$cache" ]] || fail "expected the catalogue to be cached to disk"
+[[ "$(jq -r '.plugins | length' "$cache")" -eq 2000 ]] \
+    || fail "expected the cache file to hold the whole catalogue"
+[[ "$(jq -r 'has("trusted")' "$cache")" == "true" ]] \
+    || fail "expected the cache file to carry the security-index trust flag"
+
+# A second call inside the TTL is served from the file, not refetched.
+rm -f "$BIG"
+out2="$(_aphotic_plugin_index_cached false)"
+[[ "$(jq 'length' <<<"$out2")" -eq 2000 ]] \
+    || fail "expected a cached catalogue to be served without refetching"
+
+echo "PASS: the plugin catalogue annotates in one pass and scales to a 2000-entry index"

--- a/tests/test_plugin_registry_display.sh
+++ b/tests/test_plugin_registry_display.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# tests/test_plugin_registry_display.sh
+# The registry (~/.local/state/aphotic/plugins.json) carries a plugin's
+# display metadata, not just its contract. Settings -> Plugins renders the
+# whole installed list out of that file through PluginRegistry.qml; before
+# it did, the pane shelled out to `aphotic plugin list --json` on every
+# open, which re-reads every manifest on the machine and measured ~200ms
+# per installed plugin.
+#
+# Two things this guards:
+#   - the four display fields are actually written, and backfilled onto
+#     entries an older CLI wrote without them
+#   - adding them did not make every installed plugin report drift. Drift
+#     compares the contract keys only; a whole-object compare would read
+#     the new keys as unexpected and flag everything, which is exactly
+#     what adding `profile` did once before.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$TESTHOME/.config"
+export XDG_STATE_HOME="$TESTHOME/.local/state"
+export XDG_DATA_HOME="$TESTHOME/.local/share"
+export APHOTIC_DOTS_DIR="$ROOT"
+
+COMMANDS_DIR="$ROOT/Configs/.local/lib/aphotic/commands"
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$COMMANDS_DIR/cmd_plugin.sh"
+
+export APHOTIC_PLUGINS_REPO="$TESTHOME/fake-repo"
+SRC="$APHOTIC_PLUGINS_REPO/scratch-display"
+mkdir -p "$SRC"
+cat > "$SRC/plugin.toml" <<'EOF'
+[plugin]
+name = "scratch-display"
+display_name = "Scratch Display"
+description = "carries display metadata"
+version = "1.0.0"
+category = "dev"
+capabilities = ["theme-hook"]
+
+[requires]
+binaries = ["jq", "definitely-not-a-real-binary"]
+
+[hooks]
+on_theme_change = "hook.sh"
+EOF
+printf '#!/bin/sh\nexit 0\n' > "$SRC/hook.sh"
+chmod +x "$SRC/hook.sh"
+
+mkdir -p "$(dirname "$(_aphotic_plugin_dir scratch-display)")"
+cp -r "$SRC" "$(_aphotic_plugin_dir scratch-display)"
+_aphotic_plugin_registry_sync scratch-display
+
+entry_of() { jq -c '.installed["scratch-display"]' "$APHOTIC_PLUGINS_STATE_FILE"; }
+
+# --- the four display fields land in the registry ---
+
+[[ "$(entry_of | jq -r '.display_name')" == "Scratch Display" ]] \
+    || fail "expected display_name in the registry entry"
+[[ "$(entry_of | jq -r '.description')" == "carries display metadata" ]] \
+    || fail "expected description in the registry entry"
+[[ "$(entry_of | jq -r '.category')" == "dev" ]] \
+    || fail "expected category in the registry entry"
+[[ "$(entry_of | jq -r '.requires_binaries | join(",")')" == "jq,definitely-not-a-real-binary" ]] \
+    || fail "expected requires_binaries in the registry entry, got: $(entry_of | jq -c '.requires_binaries')"
+
+# --- a manifest with no display_name falls back to the plugin id ---
+
+NONAME="$TESTHOME/fake-repo/scratch-noname"
+mkdir -p "$NONAME"
+cat > "$NONAME/plugin.toml" <<'EOF'
+[plugin]
+name = "scratch-noname"
+version = "1.0.0"
+capabilities = []
+EOF
+cp -r "$NONAME" "$(_aphotic_plugin_dir scratch-noname)"
+_aphotic_plugin_registry_sync scratch-noname
+[[ "$(jq -r '.installed["scratch-noname"].display_name' "$APHOTIC_PLUGINS_STATE_FILE")" == "scratch-noname" ]] \
+    || fail "expected a manifest with no display_name to fall back to the plugin id"
+[[ "$(jq -r '.installed["scratch-noname"].requires_binaries | length' "$APHOTIC_PLUGINS_STATE_FILE")" -eq 0 ]] \
+    || fail "expected an absent [requires] section to read as an empty list, not an error"
+
+# --- adding the fields did not turn every plugin into a drift report ---
+
+[[ "$(_aphotic_plugin_describe scratch-display | jq -r '.drifted')" == "false" ]] \
+    || fail "a freshly synced plugin must not report drift once the registry carries display metadata"
+
+# A contract change is still drift, so the check did not simply go slack.
+sed -i 's/^version = "1.0.0"/version = "1.1.0"/' "$(_aphotic_plugin_dir scratch-display)/plugin.toml"
+[[ "$(_aphotic_plugin_describe scratch-display | jq -r '.drifted')" == "true" ]] \
+    || fail "expected a version change to still report drift"
+_aphotic_plugin_registry_sync scratch-display
+[[ "$(_aphotic_plugin_describe scratch-display | jq -r '.drifted')" == "false" ]] \
+    || fail "expected a re-sync to clear the drift flag"
+
+# A display-only edit is deliberately NOT drift: it changes nothing the
+# shell binds behaviour to, and the next sync picks it up anyway.
+sed -i 's/^description = .*/description = "edited in place"/' "$(_aphotic_plugin_dir scratch-display)/plugin.toml"
+[[ "$(_aphotic_plugin_describe scratch-display | jq -r '.drifted')" == "false" ]] \
+    || fail "a description edit is not a contract change and must not report drift"
+
+# --- an entry written before the fields existed gets backfilled ---
+
+tmp="$(mktemp)"
+jq 'del(.installed["scratch-display"].display_name)
+    | del(.installed["scratch-display"].description)
+    | del(.installed["scratch-display"].category)
+    | del(.installed["scratch-display"].requires_binaries)' \
+    "$APHOTIC_PLUGINS_STATE_FILE" > "$tmp" && mv "$tmp" "$APHOTIC_PLUGINS_STATE_FILE"
+[[ "$(entry_of | jq -r 'has("display_name")')" == "false" ]] \
+    || fail "test setup: expected the display fields to be gone"
+
+_aphotic_plugin_registry_backfill
+
+[[ "$(entry_of | jq -r '.display_name')" == "Scratch Display" ]] \
+    || fail "expected the backfill to restore display_name on a pre-existing entry"
+[[ "$(entry_of | jq -r '.category')" == "dev" ]] \
+    || fail "expected the backfill to restore category on a pre-existing entry"
+
+# Second run is a no-op: nothing is missing, so it must not rewrite.
+before="$(stat -c %Y "$APHOTIC_PLUGINS_STATE_FILE")"
+sleep 1
+_aphotic_plugin_registry_backfill
+[[ "$(stat -c %Y "$APHOTIC_PLUGINS_STATE_FILE")" == "$before" ]] \
+    || fail "expected the backfill to do nothing once every entry carries the fields"
+
+echo "PASS: the registry carries plugin display metadata, backfills it, and drift ignores it"


### PR DESCRIPTION
## Problem

Settings -> Plugins stalls on open in a way no other pane does, and the cost grows with plugin count.

Measured here, 15 plugins installed:

| What | Cost | When |
| --- | --- | --- |
| `aphotic plugin list --json` | **2.98s** (~200ms per plugin) | every pane open, then every 5s |
| `aphotic plugin list --remote --json` | one `jq` fork **per catalogue entry** | same |
| `aphotic plugin security-index-status` | one more fork | same |

`PluginsPane.qml` fires all three from `Component.onCompleted` behind a synchronous `Loader`, so opening the category waits on the lot. `_aphotic_plugin_describe` re-reads every manifest on the machine to produce that list, and `_aphotic_plugin_annotate_remote_json` spends four processes per catalogue entry. A 2000-plugin index would cost 8000 of them.

## Plan

The registry (`~/.local/state/aphotic/plugins.json`) already carried the contract half of what the pane needs, and `PluginRegistry.qml` already watches it reactively. Put the rest in it and let the shell read the file.

- `_aphotic_plugin_registry_sync` writes `display_name`, `description`, `category` and `requires_binaries` alongside the fields it already wrote.
- `PluginRegistry` grows `installedList` (one row record per installed plugin, sorted, with a precomputed search key) and `installedNames` (an object used as a set, so a per-row installed check is O(1) rather than a linear scan).
- `_aphotic_plugin_annotate_remote_json` becomes a single `jq` pass. The verdict rule is a direct port of `_aphotic_plugin_host_verdict`, which stays the single answer for an on-disk manifest.
- The annotated catalogue caches to `plugin-index.json` with the security-index trust flag folded in, so that third subprocess goes away too. A failed fetch keeps the last good catalogue rather than replacing it with nothing.

## Resolution

Two things needed care.

**Drift.** Adding keys to the registry nearly flagged every installed plugin as drifted, the same way adding `profile` did once before. The comparison is now projected down to the contract keys, so display metadata rides along without being treated as contract. A version or capability change still reports drift; a description edit does not.

**ARG_MAX.** Two places passed the whole catalogue as a `--argjson` value. That works on nine entries and fails outright on two thousand. Both move it through a pipe now. The scale test caught this, which is the reason it generates a real-sized index instead of asserting on a handful.

Entries written before this change are backfilled on the next `aphotic plugin` run, and `PluginRegistry` falls back to the plugin id meanwhile, so an install that has not re-synced still renders.

Measured after: 2000-entry catalogue annotates in 0.31s cold, 0.048s served from cache.

Two new tests, and all 51 pass. The pane itself still reads the CLI; it moves onto this in the follow-up.