### PR TITLE
Wallpaper picker: dock selection z-order, grid backdrop band

### DIFF
--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperDock.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperDock.qml
@@ -22,6 +22,12 @@ Item {
 
     readonly property string backdropSource: root.model.fullSizeFor(strip.currentIndex)
 
+    // Unused while the dock renders its backdrop lossless (the wallpaper
+    // is the whole screen), stated so the window never has to fall back
+    // to another layout's geometry on this one's behalf.
+    readonly property int bandHeight: root.height
+    readonly property int bandFade: 0
+
     // Proximity magnification, the same quadratic falloff DockBar uses for
     // app icons so the two docks in this shell feel like one idea.
     readonly property real magnifyRadius: root.cellWidth * 1.3
@@ -213,7 +219,10 @@ Item {
 
                     x: highlight.slotX - Tokens.padding.small
                     y: strip.height - Tokens.padding.large - root.cellHeight - Tokens.padding.small
-                    z: -1
+                    // Under the selected card, which draws over the ring's
+                    // middle, but above every neighbour so a magnified one
+                    // beside it cannot paint over the border.
+                    z: 199
                     width: root.cellWidth + Tokens.padding.small * 2
                     height: root.cellHeight + Tokens.padding.small * 2
                     radius: Tokens.rounding.large
@@ -268,7 +277,13 @@ Item {
                     width: root.cellWidth
                     height: strip.height
 
-                    z: cell.index === strip.currentIndex ? 2 : Math.round(cell.magnify * 100)
+                    // magnifyFalloff returns 1 at rest, so every unmagnified
+                    // neighbour sits at 100 and a hovered one climbs to 130.
+                    // The selected cell was given 2, which put it and the
+                    // highlight ring behind its own neighbours rather than
+                    // on top of them -- the selection read as landing on the
+                    // wrong card. Above the whole magnify range instead.
+                    z: cell.index === strip.currentIndex ? 200 : Math.round(cell.magnify * 100)
 
                     // Scaling a wrapper rather than the card's own width and
                     // height keeps every cell the same size, so the deck

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperGrid.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperGrid.qml
@@ -21,6 +21,14 @@ Item {
 
     readonly property string backdropSource: root.model.fullSizeFor(grid.currentIndex)
 
+    // The grid fills the window, so its backdrop has to as well. The
+    // window used to hand every layout the coverflow's band (63% of the
+    // height, faded at the top), which left the rows below that point
+    // sitting on unblurred wallpaper. No fade for the same reason: there
+    // is no band edge to soften when the band is the whole screen.
+    readonly property int bandHeight: root.height
+    readonly property int bandFade: 0
+
     focus: true
 
     // The focus grab is load-bearing: without it the arrow keys land on

--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperPickerWindow.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperPickerWindow.qml
@@ -69,12 +69,17 @@ PanelWindow {
         active: root.screenState.wallpaperPicker
         source: layoutLoader.item?.backdropSource ?? ""
         lossless: root.losslessBackdrop
-        bandHeight: filmstripMetrics.bandHeight
-        fadeExtent: filmstripMetrics.bandFade
+        // Each layout states the band it needs. Every layout used to be
+        // handed the coverflow's (63% of the height, faded at the top),
+        // which is right for a filmstrip sitting in the lower two thirds
+        // and wrong for the grid, whose rows run the full height and so ran
+        // off the bottom of the blur onto bare wallpaper.
+        bandHeight: layoutLoader.item?.bandHeight ?? filmstripMetrics.bandHeight
+        fadeExtent: layoutLoader.item?.bandFade ?? filmstripMetrics.bandFade
     }
 
-    // The band geometry is the coverflow's, and the backdrop needs it before
-    // the layout that defines it necessarily exists.
+    // The coverflow's geometry, kept as the fallback for the window between
+    // the picker opening and its layout being built.
     QtObject {
         id: filmstripMetrics
 


### PR DESCRIPTION
## Problem

Two picker bugs, both from the three layouts sharing geometry that only suits one of them.

**Dock selection.** The highlight border looked like it was marking the wrong wallpaper. The cell z-order is `cell.index === strip.currentIndex ? 2 : Math.round(cell.magnify * 100)`, and `magnifyFalloff` returns `1` at rest, so every unmagnified neighbour sits at `100` and a hovered one climbs to `130`. The selected cell got `2`, below all of them, and the highlight ring sat at `-1` below that. The selected card and its border drew underneath the cards on either side.

**Grid backdrop.** `WallpaperPickerWindow` handed every layout the coverflow's band, `max(320, height * 0.63)` faded at the top. That is right for a filmstrip sitting in the lower two thirds. The grid fills the window, so its lower rows ran off the bottom of the blurred band onto bare wallpaper. The band was a coverflow measurement being applied to a layout it was never measured for, which the existing comment on it said out loud.

## Plan

Give the selection a z above the whole magnify range, and let each layout state the band it needs rather than inheriting one.

- Dock: selected cell to `200`, highlight ring to `199` so it stays under its own card and over its neighbours.
- Each layout exposes `bandHeight` and `bandFade` beside the `backdropSource` it already exposed. Grid asks for the full height and no fade, since there is no band edge to soften when the band is the whole screen. Dock is lossless so the values go unused, but it answers for itself rather than having the window fall back on its behalf.
- The window reads both off the loaded layout and keeps the coverflow's numbers as the fallback for the gap between the picker opening and its layout being built.

## Resolution

All five picker components compile and instantiate. No new binding loops.

Both are visual, so the sign-off is yours: the dock's border should sit on the card it names with neighbours passing under it, and the grid's blur should reach the bottom row.

While looking at the filmstrip I checked its `originX` handling, since an index-to-position conversion is the same class of bug. It is correct there and the dock does not need it: the dock's model is a plain count with no repetition, so its `originX` stays zero.