### PR TITLE
Wallpaper dock: centre the deck and keep the ring on its card

### DIFF
--- a/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperDock.qml
+++ b/Configs/quickshell/aphotic/modules/wallpaperpicker/WallpaperDock.qml
@@ -77,13 +77,30 @@ Item {
         strip.contentX = root._centeredContentX(strip.currentIndex);
     }
 
-    function _maxContentX(): real {
-        return Math.max(0, strip.contentWidth - strip.width);
+    // Half a viewport minus half a card, so the first and last cards can sit
+    // in the middle of the tray like every card between them. Without it the
+    // clamp below pinned contentX at zero for the opening slots, and the deck
+    // read as sitting left of the tray it is drawn inside. Only applied once
+    // the deck actually scrolls: a handful of cards that already fit are
+    // centred as a group by the tray itself.
+    readonly property real edgeMargin: strip.contentWidth > strip.width ? Math.max(0, (strip.width - root.cellWidth) / 2) : 0
+
+    // contentX runs from -leftMargin, not from zero. A margined ListView
+    // leaves originX at zero and moves the lower bound instead, so clamping
+    // at zero is what stopped the leading cards from ever centring.
+    function _minContentX(): real {
+        return -strip.leftMargin;
     }
 
+    function _maxContentX(): real {
+        return Math.max(root._minContentX(), strip.contentWidth + strip.rightMargin - strip.width);
+    }
+
+    // Items sit at index * slotPitch. originX stays zero here because this
+    // model is a plain count with no repetition, unlike the filmstrip's.
     function _centeredContentX(index: int): real {
         const raw = index * root.slotPitch + root.cellWidth / 2 - strip.width / 2;
-        return Math.max(0, Math.min(raw, root._maxContentX()));
+        return Math.max(root._minContentX(), Math.min(raw, root._maxContentX()));
     }
 
     // One path for the wheel and the arrow keys both. Scrolling used to
@@ -186,6 +203,9 @@ Item {
                 model: root.model.count
                 reuseItems: true
 
+                leftMargin: root.edgeMargin
+                rightMargin: root.edgeMargin
+
                 onWidthChanged: Qt.callLater(root._recenterIfIdle)
                 onContentWidthChanged: Qt.callLater(root._recenterIfIdle)
 
@@ -217,6 +237,12 @@ Item {
 
                     readonly property real slotX: strip.currentIndex * root.slotPitch
 
+                    // The cards magnify under the pointer and the ring did
+                    // not, so the border drifted off whichever card it was
+                    // meant to be hugging. Same factor, same origin as the
+                    // card's own scale: the bottom centre of its cell.
+                    readonly property real mag: strip.currentItem?.magnify ?? 1
+
                     x: highlight.slotX - Tokens.padding.small
                     y: strip.height - Tokens.padding.large - root.cellHeight - Tokens.padding.small
                     // Under the selected card, which draws over the ring's
@@ -231,6 +257,15 @@ Item {
                     border.width: 2
                     border.color: Colours.palette.m3primary
                     opacity: 0.55 + 0.45 * DepthFx.pulse
+
+                    transform: Scale {
+                        origin.x: highlight.width / 2
+                        // Distance from this ring's top edge down to the cell
+                        // bottom, which is where the card scales from.
+                        origin.y: Tokens.padding.large + root.cellHeight + Tokens.padding.small
+                        xScale: highlight.mag
+                        yScale: highlight.mag
+                    }
 
                     Behavior on x {
                         NumberAnimation {


### PR DESCRIPTION
## Problem

Two faults on the dock layout, both reported from use.

**The deck sat left of its tray.** The tray is drawn centred, so the cards inside it read as off-centre, most obviously on the opening wallpapers. `_centeredContentX` clamped `contentX` with `Math.max(0, ...)`, and the ideal position for the leading cards is negative, so they were pinned at zero and could never reach the middle. The same applied at the far end.

**The selection ring drifted off its card.** Cards magnify under the pointer with `transformOrigin: Item.Bottom`; the ring was a fixed-size rectangle that did not. Whenever the wave touched the selected card, the border no longer hugged it.

## Plan

Measured the `ListView` semantics first rather than assuming them, because this is the same family of bug the filmstrip hit:

    originX=0  leftMargin=400  contentWidth=8468  contentX=-400
    idx0 item.x=0
    idx5 item.x=1060   (5 * 212)

So a margined `ListView` leaves `originX` at zero, lays items out at `index * slotPitch`, and moves the lower bound of `contentX` to `-leftMargin` instead. The filmstrip's `originX` handling comes from its repeated model, not from margins, and the dock does not need it. The clamp was the whole problem.

- Give the deck half a viewport minus half a card of margin at each end, applied only once the deck actually scrolls. A handful of cards that already fit are still centred as a group by the tray.
- Clamp `contentX` to `[-leftMargin, contentWidth + rightMargin - width]`.
- Scale the ring by the current card's own `magnify`, about the bottom centre of its cell, which is the point the card scales from.

## Resolution

The centring is exact rather than approximately better. For index 0 the target reduces to `-edgeMargin`, which is the new lower bound; for the last index it reduces to the upper bound; both put the card's centre on the viewport centre. Verified across the range:

    idx=0   contentX=-400.0   cardCentre=500.0   viewportCentre=500   CENTRED
    idx=1   contentX=-188.0   cardCentre=500.0   viewportCentre=500   CENTRED
    idx=20  contentX=3840.0   cardCentre=500.0   viewportCentre=500   CENTRED
    idx=38  contentX=7656.0   cardCentre=500.0   viewportCentre=500   CENTRED
    idx=39  contentX=7868.0   cardCentre=500.0   viewportCentre=500   CENTRED

All four picker components compile and instantiate, no new warnings. Visual sign-off is yours.