### PR TITLE
Capsule bar: let a side-docked pill fit its own icons

### DIFF
--- a/Configs/quickshell/aphotic/modules/bar/CapsuleBar.qml
+++ b/Configs/quickshell/aphotic/modules/bar/CapsuleBar.qml
@@ -30,7 +30,13 @@ Item {
     // That is the whole fix for the worst bug in the first pass: the pill
     // is centred along its length, so any change to that length slid every
     // control sideways out from under the pointer.
-    readonly property int rowThickness: Settings.barInnerWidth + Tokens.padding.extraSmall * 2
+    // The pill's length already grows to its content; its thickness did
+    // not, so a control wider than the configured bar width was clipped by
+    // the pill rather than fitting inside it. Docked to a side, that is
+    // what cut the status icons off. Same floor-not-cap rule the row
+    // itself uses along its length.
+    readonly property real rowCross: root.horizontal ? collapsedRow.implicitHeight : collapsedRow.implicitWidth
+    readonly property int rowThickness: Math.max(Settings.barInnerWidth, root.rowCross) + Tokens.padding.extraSmall * 2
     readonly property real rowExtent: root.horizontal ? collapsedRow.implicitWidth : collapsedRow.implicitHeight
     readonly property real alongExtent: Math.max(rowExtent + Tokens.padding.medium * 2, Config.bar.capsule.minLength)
 

--- a/Configs/quickshell/aphotic/modules/bar/components/StatusIcons.qml
+++ b/Configs/quickshell/aphotic/modules/bar/components/StatusIcons.qml
@@ -76,8 +76,16 @@ Item {
         return out;
     }
 
-    implicitWidth: Settings.barHorizontal ? groupLayout.implicitWidth : Settings.barInnerWidth
-    implicitHeight: Settings.barHorizontal ? Settings.barInnerWidth : groupLayout.implicitHeight
+    // The cross-axis is a floor, not a cap. A status entry that draws an
+    // icon beside text (Bluetooth with a battery percentage, for one) is
+    // wider than it is tall, so it clears a horizontal bar's thickness and
+    // overflows a vertical one -- where the pill below clips, and the icon
+    // is simply cut off. Taking the larger of the configured thickness and
+    // what the content actually measures lets a side bar widen to fit
+    // instead of truncating, and changes nothing for a bar whose icons
+    // already fit.
+    implicitWidth: Settings.barHorizontal ? groupLayout.implicitWidth : Math.max(Settings.barInnerWidth, groupLayout.implicitWidth)
+    implicitHeight: Settings.barHorizontal ? Math.max(Settings.barInnerWidth, groupLayout.implicitHeight) : groupLayout.implicitHeight
 
 
     GridLayout {
@@ -147,8 +155,11 @@ Item {
                 radius: Tokens.rounding.full
                 clip: true
 
-                Layout.preferredWidth: Settings.barHorizontal ? pillIcons.implicitWidth + Tokens.padding.medium * 2 : Settings.barInnerWidth
-                Layout.preferredHeight: Settings.barHorizontal ? Settings.barInnerWidth : pillIcons.implicitHeight + Tokens.padding.medium * 2
+                // Same floor on the cross-axis as the root above, for the
+                // same reason: this rect clips, so a pill pinned to the
+                // configured thickness cuts any entry wider than it.
+                Layout.preferredWidth: Settings.barHorizontal ? pillIcons.implicitWidth + Tokens.padding.medium * 2 : Math.max(Settings.barInnerWidth, pillIcons.implicitWidth + Tokens.padding.medium * 2)
+                Layout.preferredHeight: Settings.barHorizontal ? Math.max(Settings.barInnerWidth, pillIcons.implicitHeight + Tokens.padding.medium * 2) : pillIcons.implicitHeight + Tokens.padding.medium * 2
 
                 HoverPill {
                     container: pillIcons


### PR DESCRIPTION
## Problem

Docked left or right, the capsule bar cuts the Bluetooth icon off and the status icons read as sitting outside the pill's border.

The cross-axis was a cap rather than a floor, in two places.

`StatusIcons.qml` declared `implicitWidth: Settings.barHorizontal ? groupLayout.implicitWidth : Settings.barInnerWidth`. In a vertical bar the width is pinned to the configured bar width no matter what the icons measure, and the pill each group draws into sets `Layout.preferredWidth` the same way while clipping. A status entry that draws an icon beside text, Bluetooth with a battery percentage being the obvious one, is wider than it is tall. It clears a horizontal bar's thickness and overflows a vertical one, so the overflow was cut.

`CapsuleBar.qml` had the same shape a level up. `alongExtent` grows the pill to fit its content along its length, but `rowThickness` was a flat `Settings.barInnerWidth + padding`, so even a correctly measured control was clipped by the pill rather than fitting inside it.

## Plan

Make the cross-axis a floor instead of a cap, matching what the along-axis already did.

- `StatusIcons` root and per-group pill take `Math.max(Settings.barInnerWidth, <measured>)` on whichever axis is the thickness.
- `CapsuleBar` derives `rowCross` from the collapsed row and folds it into `rowThickness` the same way `rowExtent` feeds `alongExtent`.

## Resolution

A side bar widens to fit its icons instead of truncating them. A bar whose icons already fit is unchanged, because the measured value only wins when it exceeds the configured width.

All five bar styles plus `StatusIcons` compile and instantiate. I did not instantiate the bar itself to check it live: that maps a real second bar over the running desktop.

Visual sign-off is yours, and you are already on the affected config (`barHorizontal: false`, `barSkin: capsule`).