### PR TITLE
Add host handover leases, TTY recovery and passthrough drift

### DIFF
--- a/Configs/.local/lib/aphotic/commands/cmd_diff.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_diff.sh
@@ -79,6 +79,12 @@ HELP
     [[ "$dm_state" == "conflict" ]] && changes=$((changes + 1))
     [[ "$drift_status" == "behind" ]] && changes=$((changes + 1))
 
+    local passthrough
+    passthrough="$(_aphotic_state_passthrough --json)"
+    local passthrough_changes
+    passthrough_changes="$(jq '[.checks[] | select(.status != "ok")] | length' <<<"$passthrough")"
+    [[ "$(jq -r '.status' <<<"$passthrough")" != INVALID ]] || passthrough_changes=1
+    changes=$((changes + passthrough_changes))
     if [[ "$as_json" -eq 1 ]]; then
         local missing_json="[]" plugin_missing_json="[]" plugin_extra_json="[]" plugin_disabled_json="[]"
         [[ -n "$missing_packages" ]] && missing_json="$(printf '%s\n' "$missing_packages" | jq -R . | jq -sc .)"
@@ -87,6 +93,7 @@ HELP
         [[ "${#plugin_disabled[@]}" -gt 0 ]] && plugin_disabled_json="$(printf '%s\n' "${plugin_disabled[@]}" | jq -R . | jq -sc .)"
 
         jq -nc \
+            --argjson passthrough "$passthrough" \
             --argjson missingPackages "$missing_json" \
             --argjson pluginsDeclared "$plugins_declared" \
             --argjson pluginsOk "$plugin_ok" \
@@ -99,7 +106,7 @@ HELP
             --arg versionStatus "$drift_status" \
             --argjson versionCommitsBehind "${drift_behind:-0}" \
             --argjson changesRequired "$changes" \
-            '{missingPackages: $missingPackages,
+            '{passthrough: $passthrough, missingPackages: $missingPackages,
               plugins: {declared: $pluginsDeclared, ok: $pluginsOk, missing: $pluginsMissing, extra: $pluginsExtra, disabled: $pluginsDisabled},
               services: {daemon: $daemon, displayManager: $displayManager, displayManagerDetail: $displayManagerDetail},
               version: {status: $versionStatus, commitsBehind: $versionCommitsBehind},
@@ -108,6 +115,8 @@ HELP
     fi
 
     echo "Aphotic system drift"
+    printf 'Passthrough: %s\n' "$(jq -r '.status' <<<"$passthrough")"
+    jq -r '.checks[] | "  [\(.status)] \(.key): desired \(.desired), actual \(.actual)"' <<<"$passthrough"
     echo
 
     if [[ "$missing_count" -eq 0 ]]; then

--- a/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_doctor.sh
@@ -153,4 +153,6 @@ aphotic_cmd_doctor() {
     echo
     echo "Version:"
     _aphotic_doctor_version_drift
+    echo
+    _aphotic_state_passthrough
 }

--- a/Configs/.local/lib/aphotic/commands/cmd_handover.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_handover.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# @cmd: handover
+# @cmd.desc: Rehearse, acquire and recover durable host resource leases
+# @cmd.group: LIFECYCLE
+aphotic_cmd_handover() {
+    if [[ "${1:-}" == "drift" ]]; then
+        shift
+        python3 "${LIB_DIR}/passthrough.py" --config "${APHOTIC_DOTS_DIR}/aphotic.toml" "$@"
+        return $?
+    fi
+    python3 "${LIB_DIR}/handover.py" "$@"
+}

--- a/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_plugin.sh
@@ -167,7 +167,7 @@ _aphotic_plugin_owns_json() {
 }
 
 _aphotic_plugin_surface_json() {
-    local manifest="$1" section="$2" surface="$3" id icon label component layer data parent anchor width height trigger
+    local manifest="$1" section="$2" surface="$3" id icon label component layer dependency data parent anchor width height trigger
     component="$(aphotic_toml_get "$manifest" "$section" component)"
     [[ -n "$component" ]] || return 1
 
@@ -175,6 +175,7 @@ _aphotic_plugin_surface_json() {
     icon="$(aphotic_toml_get "$manifest" "$section" icon)"
     label="$(aphotic_toml_get "$manifest" "$section" label)"
     layer="$(aphotic_toml_get "$manifest" "$section" requires_layer)"
+    dependency="$(aphotic_toml_get "$manifest" "$section" requires_plugin)"
     data="$(aphotic_toml_get "$manifest" "$section" requires_data)"
     parent="$(aphotic_toml_get "$manifest" "$section" parent)"
     # Overlay only -- the surface budget the host sizes its window from
@@ -194,13 +195,14 @@ _aphotic_plugin_surface_json() {
         --arg label "${label:-}" \
         --arg component "$component" \
         --arg requires_layer "${layer:-}" \
+        --arg requires_plugin "${dependency:-}" \
         --arg requires_data "${data:-}" \
         --arg parent "${parent:-}" \
         --argjson anchor "$(jq -n --arg a "${anchor:-}" '$a')" \
         --argjson width "${width:-0}" \
         --argjson height "${height:-0}" \
         --argjson trigger "$(jq -n --arg t "${trigger:-}" '$t')" \
-        '{surface: $surface, id: $id, icon: $icon, label: $label, component: $component, requires_layer: $requires_layer, requires_data: $requires_data, parent: $parent, anchor: $anchor, width: $width, height: $height, trigger: $trigger}'
+        '{surface: $surface, id: $id, icon: $icon, label: $label, component: $component, requires_layer: $requires_layer, requires_plugin: $requires_plugin, requires_data: $requires_data, parent: $parent, anchor: $anchor, width: $width, height: $height, trigger: $trigger}'
 }
 
 _aphotic_plugin_ui_json() {
@@ -265,7 +267,7 @@ _aphotic_plugin_ui_json() {
 # component, and a second declaration in the manifest would be a second
 # source of truth for the same fact, drifting the moment one is edited.
 _aphotic_plugin_profile_json() {
-    local manifest="$1" id label component layer data snapshot
+    local manifest="$1" id label component layer dependency data snapshot
     component="$(aphotic_toml_get "$manifest" profile component)"
     id="$(aphotic_toml_get "$manifest" profile id)"
     if [[ -z "$component" ]] || [[ -z "$id" ]]; then
@@ -275,6 +277,7 @@ _aphotic_plugin_profile_json() {
 
     label="$(aphotic_toml_get "$manifest" profile label)"
     layer="$(aphotic_toml_get "$manifest" profile requires_layer)"
+    dependency="$(aphotic_toml_get "$manifest" profile requires_plugin)"
     data="$(aphotic_toml_get "$manifest" profile requires_data)"
     snapshot="$(aphotic_toml_get_array "$manifest" profile snapshot | jq -R . | jq -s .)"
 
@@ -283,9 +286,10 @@ _aphotic_plugin_profile_json() {
         --arg label "${label:-$id}" \
         --arg component "$component" \
         --arg requires_layer "${layer:-}" \
+        --arg requires_plugin "${dependency:-}" \
         --arg requires_data "${data:-}" \
         --argjson snapshot "${snapshot:-[]}" \
-        '{id: $id, label: $label, component: $component, requires_layer: $requires_layer, requires_data: $requires_data, snapshot: $snapshot}'
+        '{id: $id, label: $label, component: $component, requires_layer: $requires_layer, requires_plugin: $requires_plugin, requires_data: $requires_data, snapshot: $snapshot}'
 }
 
 # The `cli` capability (manifest v3.2). A plugin declaring one contributes
@@ -296,7 +300,7 @@ _aphotic_plugin_profile_json() {
 # reads the manifest directly through aphotic_plugin_cli_resolve, since a
 # command must work whether or not a registry sync has run.
 _aphotic_plugin_cli_json() {
-    local manifest="$1" command subcommand script summary
+    local manifest="$1" command subcommand script summary layer dependency
     command="$(aphotic_toml_get "$manifest" cli command)"
     script="$(aphotic_toml_get "$manifest" cli script)"
     if [[ -z "$command" ]] || [[ -z "$script" ]]; then
@@ -306,13 +310,17 @@ _aphotic_plugin_cli_json() {
 
     subcommand="$(aphotic_toml_get "$manifest" cli subcommand)"
     summary="$(aphotic_toml_get "$manifest" cli summary)"
+    layer="$(aphotic_toml_get "$manifest" cli requires_layer)"
+    dependency="$(aphotic_toml_get "$manifest" cli requires_plugin)"
 
     jq -n \
+        --arg requires_layer "${layer:-}" \
+        --arg requires_plugin "${dependency:-}" \
         --arg command "$command" \
         --arg subcommand "${subcommand:-}" \
         --arg script "$script" \
         --arg summary "${summary:-}" \
-        '{command: $command, subcommand: $subcommand, script: $script, summary: $summary}'
+        '{requires_layer: $requires_layer, requires_plugin: $requires_plugin, command: $command, subcommand: $subcommand, script: $script, summary: $summary}'
 }
 
 # The `chat-provider` capability (manifest v3.3). A plugin declaring one
@@ -331,7 +339,7 @@ _aphotic_plugin_cli_json() {
 # re-pull or a re-render is a single atomic write the shell picks up live
 # rather than a snapshot that goes stale.
 _aphotic_plugin_chat_provider_json() {
-    local manifest="$1" id label backend state layer data
+    local manifest="$1" id label backend state layer dependency data
     id="$(aphotic_toml_get "$manifest" chat_provider id)"
     backend="$(aphotic_toml_get "$manifest" chat_provider backend)"
     if [[ -z "$id" ]] || [[ -z "$backend" ]]; then
@@ -342,6 +350,7 @@ _aphotic_plugin_chat_provider_json() {
     label="$(aphotic_toml_get "$manifest" chat_provider label)"
     state="$(aphotic_toml_get "$manifest" chat_provider state)"
     layer="$(aphotic_toml_get "$manifest" chat_provider requires_layer)"
+    dependency="$(aphotic_toml_get "$manifest" chat_provider requires_plugin)"
     data="$(aphotic_toml_get "$manifest" chat_provider requires_data)"
 
     jq -n \
@@ -350,8 +359,9 @@ _aphotic_plugin_chat_provider_json() {
         --arg backend "$backend" \
         --arg state "${state:-provider.json}" \
         --arg requires_layer "${layer:-}" \
+        --arg requires_plugin "${dependency:-}" \
         --arg requires_data "${data:-}" \
-        '{id: $id, label: $label, backend: $backend, state: $state, requires_layer: $requires_layer, requires_data: $requires_data}'
+        '{id: $id, label: $label, backend: $backend, state: $state, requires_layer: $requires_layer, requires_plugin: $requires_plugin, requires_data: $requires_data}'
 }
 
 # The `action` capability (manifest v3.7, `ACT-01`). An action is a named
@@ -368,7 +378,7 @@ _aphotic_plugin_chat_provider_json() {
 # this capability is given before that reader has to grow, and the sixth
 # action a plugin wants is the trigger to revisit it.
 _aphotic_plugin_action_entry_json() {
-    local manifest="$1" section="$2" id component icon label layer data
+    local manifest="$1" section="$2" id component icon label layer dependency data
     id="$(aphotic_toml_get "$manifest" "$section" id)"
     component="$(aphotic_toml_get "$manifest" "$section" component)"
     if [[ -z "$id" ]] || [[ -z "$component" ]]; then
@@ -378,6 +388,7 @@ _aphotic_plugin_action_entry_json() {
     icon="$(aphotic_toml_get "$manifest" "$section" icon)"
     label="$(aphotic_toml_get "$manifest" "$section" label)"
     layer="$(aphotic_toml_get "$manifest" "$section" requires_layer)"
+    dependency="$(aphotic_toml_get "$manifest" "$section" requires_plugin)"
     data="$(aphotic_toml_get "$manifest" "$section" requires_data)"
 
     jq -n \
@@ -386,8 +397,9 @@ _aphotic_plugin_action_entry_json() {
         --arg label "${label:-$id}" \
         --arg component "$component" \
         --arg requires_layer "${layer:-}" \
+        --arg requires_plugin "${dependency:-}" \
         --arg requires_data "${data:-}" \
-        '{id: $id, icon: $icon, label: $label, component: $component, requires_layer: $requires_layer, requires_data: $requires_data}'
+        '{id: $id, icon: $icon, label: $label, component: $component, requires_layer: $requires_layer, requires_plugin: $requires_plugin, requires_data: $requires_data}'
 }
 
 _aphotic_plugin_actions_json() {
@@ -455,7 +467,7 @@ _aphotic_plugin_describe() {
     # second time is deliberate: a second description of that shape is the
     # class of bug the flag exists to catch.
     local stored expected drifted="false"
-    expected="$(jq -cS '{version, capabilities, owns, ui, profile, cli, chat_provider, actions}' <<<"$entry")"
+    expected="$(jq -cS '{version, capabilities, owns, ui, profile, cli, chat_provider, actions} | walk(if type == "object" then (if .requires_plugin == "" then del(.requires_plugin) else . end) | (if .requires_layer == "" then del(.requires_layer) else . end) else . end)' <<<"$entry")"
     # Missing keys are filled with the same null a fresh sync would write
     # BEFORE comparing. Without this, every entry on disk reports drift the
     # moment the registry schema grows a field -- one did (`profile`,
@@ -471,7 +483,7 @@ _aphotic_plugin_describe() {
     # drift. Drift means "this plugin's contract changed", and a
     # display string is not contract -- a manifest edit still refreshes
     # it on the next sync.
-    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else ({profile: null, cli: null, chat_provider: null, actions: null} + .) | {version, capabilities, owns, ui, profile, cli, chat_provider, actions} end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
+    stored="$(jq -cS --arg n "$name" '.installed[$n] // empty | if . == {} then empty else ({profile: null, cli: null, chat_provider: null, actions: null} + .) | {version, capabilities, owns, ui, profile, cli, chat_provider, actions} | walk(if type == "object" then (if .requires_plugin == "" then del(.requires_plugin) else . end) | (if .requires_layer == "" then del(.requires_layer) else . end) else . end) end' "$APHOTIC_PLUGINS_STATE_FILE" 2>/dev/null)"
     [[ "$expected" != "$stored" ]] && drifted="true"
 
     jq --argjson drifted "$drifted" '. + {drifted: $drifted}' <<<"$entry"

--- a/Configs/.local/lib/aphotic/commands/cmd_status.sh
+++ b/Configs/.local/lib/aphotic/commands/cmd_status.sh
@@ -67,8 +67,11 @@ HELP
     IFS=$'\t' read -r _ daemon_state _ <<<"$(grep '^daemon' <<<"$services")"
     IFS=$'\t' read -r _ dm_state _ <<<"$(grep '^displaymanager' <<<"$services")"
 
+    local passthrough
+    passthrough="$(_aphotic_state_passthrough --json)"
     if [[ "$as_json" -eq 1 ]]; then
         jq -nc \
+            --argjson passthrough "$passthrough" \
             --arg version "$APHOTIC_VERSION" \
             --arg profile "${profile:-}" \
             --arg layers "${layers:-}" \
@@ -83,7 +86,7 @@ HELP
             --argjson pluginsDisabled "$disabled" \
             --arg daemon "$daemon_state" \
             --arg displayManager "$dm_state" \
-            '{version: $version, profile: $profile, layers: ($layers | split(",") | map(select(length > 0))),
+            '{passthrough: $passthrough, version: $version, profile: $profile, layers: ($layers | split(",") | map(select(length > 0))),
               versionDrift: {status: $driftStatus, branch: $driftBranch, head: $driftHead, commitsBehind: $driftBehind},
               plugins: {declared: $pluginsDeclared, ok: $pluginsOk, missing: $pluginsMissing, extra: $pluginsExtra, disabled: $pluginsDisabled},
               services: {daemon: $daemon, displayManager: $displayManager}}'
@@ -113,6 +116,7 @@ HELP
     else
         echo "Plugins:  not declared in aphotic.toml, drift not tracked"
     fi
+    printf 'Passthrough: %s\n' "$(jq -r '.status' <<<"$passthrough")"
     printf 'Daemon:   %s\n' "$daemon_state"
     printf 'Display manager: %s\n' "$dm_state"
 }

--- a/Configs/.local/lib/aphotic/globalcontrol.sh
+++ b/Configs/.local/lib/aphotic/globalcontrol.sh
@@ -325,6 +325,27 @@ aphotic_plugin_is_enabled() {
 #
 # Prints "<plugin>\t<script path>" for the first enabled plugin whose [cli]
 # block matches, and fails if none does.
+aphotic_plugin_cli_gate() {
+    local manifest="$1" dependency layer layers
+    dependency="$(aphotic_toml_get "$manifest" cli requires_plugin)"
+    if [[ -n "$dependency" ]]; then
+        [[ "$dependency" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]] || return 1
+        [[ "$manifest" != "$APHOTIC_PLUGINS_DIR/$dependency/plugin.toml" ]] || return 1
+        [[ -f "$APHOTIC_PLUGINS_DIR/$dependency/plugin.toml" ]] || return 1
+        aphotic_plugin_is_enabled "$dependency" || return 1
+    fi
+    layer="$(aphotic_toml_get "$manifest" cli requires_layer)"
+    [[ -n "$layer" ]] || return 0
+    case "$layer" in ai|dev|gaming|security) ;; *) return 1 ;; esac
+    [[ -f "$APHOTIC_DOTS_DIR/aphotic.toml" ]] || return 0
+    layers="$(aphotic_toml_get_array "$APHOTIC_DOTS_DIR/aphotic.toml" install layers)"
+    if [[ "$layer" == security ]]; then
+        grep -Eq '^exploit($|-)' <<<"$layers"
+    else
+        grep -qx "$layer" <<<"$layers"
+    fi
+}
+
 aphotic_plugin_cli_resolve() {
     local command="$1" subcommand="${2:-}"
     local name dir manifest caps script
@@ -335,6 +356,7 @@ aphotic_plugin_cli_resolve() {
 
         dir="${APHOTIC_PLUGINS_DIR}/${name}"
         manifest="${dir}/plugin.toml"
+        aphotic_plugin_cli_gate "$manifest" || continue
         caps="$(aphotic_toml_get_array "$manifest" plugin capabilities)"
         grep -qx "cli" <<<"$caps" || continue
 
@@ -375,6 +397,7 @@ aphotic_plugin_cli_top_level() {
 
         dir="${APHOTIC_PLUGINS_DIR}/${name}"
         manifest="${dir}/plugin.toml"
+        aphotic_plugin_cli_gate "$manifest" || continue
         caps="$(aphotic_toml_get_array "$manifest" plugin capabilities)"
         grep -qx "cli" <<<"$caps" || continue
         [[ -z "$(aphotic_toml_get "$manifest" cli subcommand)" ]] || continue
@@ -398,6 +421,7 @@ aphotic_plugin_cli_help() {
 
         dir="${APHOTIC_PLUGINS_DIR}/${name}"
         manifest="${dir}/plugin.toml"
+        aphotic_plugin_cli_gate "$manifest" || continue
         caps="$(aphotic_toml_get_array "$manifest" plugin capabilities)"
         grep -qx "cli" <<<"$caps" || continue
         [[ "$(aphotic_toml_get "$manifest" cli command)" == "$command" ]] || continue

--- a/Configs/.local/lib/aphotic/handover.py
+++ b/Configs/.local/lib/aphotic/handover.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Durable, typed host leases. No commands are accepted from a lease plan."""
+import argparse
+import base64
+from contextlib import contextmanager
+import fcntl
+import json
+import math
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+
+
+class HandoverError(Exception):
+    pass
+
+
+def atomic(path, data, mode=0o600, metadata=None):
+    path = Path(path)
+    fd, temporary = tempfile.mkstemp(prefix='.handover-', dir=path.parent)
+    try:
+        with os.fdopen(fd, 'wb') as stream:
+            os.fchmod(stream.fileno(), mode)
+            stream.write(data)
+            stream.flush()
+            if metadata:
+                os.fchown(stream.fileno(), -1, metadata['gid'])
+                for key, value in metadata.get('xattrs', {}).items():
+                    os.setxattr(stream.fileno(), key, base64.b64decode(value))
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def file_state(path):
+    path = Path(path)
+    if path.is_symlink() or path.resolve() != path:
+        raise HandoverError('file stage refuses symlinks')
+    if not path.exists():
+        return {'exists': False}
+    info = path.stat()
+    if not stat.S_ISREG(info.st_mode) or info.st_size > 1024 * 1024:
+        raise HandoverError('file stage requires a regular file under 1 MiB')
+    if info.st_uid != os.getuid() or info.st_nlink != 1:
+        raise HandoverError('file stage requires a private file owned by this user')
+    return {'exists': True, 'data': base64.b64encode(path.read_bytes()).decode(),
+            'mode': stat.S_IMODE(info.st_mode), 'gid': info.st_gid,
+            'xattrs': {key: base64.b64encode(os.getxattr(path, key)).decode() for key in os.listxattr(path)}}
+
+
+class Bridge:
+    def call(self, method, payload):
+        for attempt in range(30):
+            try:
+                result = subprocess.run(['qs', '-c', 'aphotic', 'ipc', 'call', 'handover', method,
+                                         json.dumps(payload, separators=(',', ':'))],
+                                        capture_output=True, text=True, timeout=15, check=True)
+                response = json.loads(result.stdout)
+            except (OSError, subprocess.SubprocessError, ValueError) as error:
+                raise HandoverError(f'Flow bridge unavailable: {error}') from error
+            if response.get('ok'):
+                return response
+            if response.get('retry') and method == 'preview':
+                time.sleep(.1)
+                continue
+            raise HandoverError(response.get('error', 'Flow refused operation'))
+        raise HandoverError('Host capacity is still unknown; retry rehearsal')
+
+
+class Engine:
+    def __init__(self, directory, bridge=None):
+        self.directory = Path(directory)
+        self.bridge = bridge or Bridge()
+
+    @contextmanager
+    def lock(self):
+        self.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        info = self.directory.lstat()
+        if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+            raise HandoverError('lease directory must be private and owned by this user')
+        fd = os.open(self.directory / '.lock', os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            yield
+        except BlockingIOError as error:
+            raise HandoverError('another handover operation is in progress') from error
+        finally:
+            os.close(fd)
+
+    def validate(self, plan):
+        if not isinstance(plan, dict) or not re.fullmatch(r'[a-zA-Z0-9_-]{1,64}', str(plan.get('id', ''))):
+            raise HandoverError('invalid lease id')
+        if plan['id'] in ('index', '__proto__', 'constructor', 'prototype'):
+            raise HandoverError('reserved lease id')
+        if not plan.get('owner') or plan.get('plane') not in ('ai', 'dev', 'gaming', 'security'):
+            raise HandoverError('owner and workload plane required')
+        resources = plan.get('resources')
+        if not isinstance(resources, list) or not resources or len(resources) > 128:
+            raise HandoverError('bounded resource list required')
+        keys = set()
+        for resource in resources:
+            if not isinstance(resource, dict):
+                raise HandoverError('resource must be an object')
+            key, amount = resource.get('key'), resource.get('amount')
+            if not isinstance(key, str) or not re.fullmatch(r'[a-zA-Z0-9:._-]{1,160}', key) or key in keys:
+                raise HandoverError('invalid or duplicate resource key')
+            keys.add(key)
+            if type(amount) not in (int, float) or not math.isfinite(amount) or amount <= 0:
+                raise HandoverError('resource amount must be positive and finite')
+            if key not in ('memory', 'cpu') and resource.get('exclusive') is not True:
+                raise HandoverError('device resources must be exclusive')
+            if key == 'memory' and resource.get('unit') != 'MiB':
+                raise HandoverError('memory reservations use MiB')
+        stages = plan.get('stages', [])
+        if not isinstance(stages, list) or len(stages) > 64:
+            raise HandoverError('invalid stages')
+        ids, targets = {'reserve'}, set()
+        for stage in stages:
+            if not isinstance(stage, dict) or not re.fullmatch(r'[a-zA-Z0-9_-]{1,64}', str(stage.get('id', ''))) or stage['id'] in ids:
+                raise HandoverError('invalid or duplicate stage id')
+            ids.add(stage['id'])
+            if stage.get('kind') == 'file':
+                path = Path(stage.get('path', ''))
+                if not path.is_absolute() or str(path) in targets or not path.parent.is_dir():
+                    raise HandoverError('file paths must be unique absolute paths with existing parents')
+                if path.resolve().is_relative_to(self.directory.resolve()):
+                    raise HandoverError('file stage cannot target lease journal storage')
+                if str(path).startswith(('/dev/', '/sys/', '/proc/')):
+                    raise HandoverError('device and kernel paths are forbidden')
+                if not isinstance(stage.get('content'), str) or len(stage['content'].encode()) > 1024 * 1024:
+                    raise HandoverError('bounded file content required')
+                targets.add(str(path))
+            elif stage.get('kind') == 'shelter':
+                if not isinstance(stage.get('owner'), str) or not stage['owner']:
+                    raise HandoverError('shelter owner required')
+            else:
+                raise HandoverError('unsupported stage kind')
+        return plan
+
+    def load(self, lease_id):
+        if not re.fullmatch(r'[a-zA-Z0-9_-]{1,64}', lease_id):
+            raise HandoverError('invalid lease id')
+        path = self.directory / f'{lease_id}.json'
+        if path.is_symlink():
+            raise HandoverError('symlink journal refused')
+        data = json.loads(path.read_text())
+        if data.get('schema') != 1 or data.get('writtenBy') != 'aphotic-handover' or data.get('id') != lease_id:
+            raise HandoverError('unrecognized journal; refusing recovery')
+        stages = data.get('stages', [])
+        if not stages or stages[0].get('kind') != 'reserve' or stages[0].get('id') != 'reserve':
+            raise HandoverError('journal has no reservation stage')
+        self.validate(dict(data, stages=stages[1:]))
+        for stage in stages:
+            if stage.get('status') not in ('prepared', 'applying', 'applied', 'restored', 'restore-failed'):
+                raise HandoverError('unrecognized stage status')
+        return data
+
+    def status(self):
+        return [self.load(path.stem) for path in sorted(self.directory.glob('*.json')) if path.name != 'index.json']
+
+    def save(self, journal):
+        journal['updatedAt'] = int(time.time() * 1000)
+        atomic(self.directory / f"{journal['id']}.json", json.dumps(journal, indent=2).encode())
+        # Index is a view only; recovery always reads the per-lease journal.
+        leases, errors = [], []
+        for path in sorted(self.directory.glob('*.json')):
+            if path.name == 'index.json':
+                continue
+            try:
+                leases.append(self.load(path.stem))
+            except (HandoverError, ValueError, OSError, TypeError, KeyError) as error:
+                errors.append({'file': path.name, 'error': str(error)})
+        atomic(self.directory / 'index.json', json.dumps({'schema': 1, 'leases': leases, 'errors': errors}).encode())
+
+    def check_resources(self, plan):
+        active = [j for j in self.status() if j['status'] != 'restored']
+        if any(j['id'] == plan['id'] for j in active):
+            raise HandoverError('lease already exists; release or recover it first')
+        for request in plan['resources']:
+            key = request['key']
+            held = [(j, r) for j in active for r in j['resources'] if r['key'] == key]
+            if held and (request.get('exclusive') or any(r.get('exclusive') for _, r in held)):
+                raise HandoverError(f"{key} held by {held[0][0]['id']}")
+            total = request['amount'] + sum(r['amount'] for _, r in held)
+            if key == 'memory':
+                capacity = os.sysconf('SC_PHYS_PAGES') * os.sysconf('SC_PAGE_SIZE') / 1048576
+                if total > capacity - max(2048, capacity * .1):
+                    raise HandoverError('memory reservations exceed capacity with host reserve')
+            elif key == 'cpu' and total > max(0, (os.cpu_count() or 1) - 1):
+                raise HandoverError('CPU reservations leave no host capacity')
+        targets = {s['path'] for s in plan.get('stages', []) if s['kind'] == 'file'}
+        shelters = {s['owner'] for s in plan.get('stages', []) if s['kind'] == 'shelter'}
+        for journal in active:
+            if shelters & {s['owner'] for s in journal['stages'] if s['kind'] == 'shelter'}:
+                raise HandoverError('shelter owner is held by another lease')
+            if targets & {s['path'] for s in journal['stages'] if s['kind'] == 'file'}:
+                raise HandoverError('file is owned by another lease')
+
+    def prepare(self, plan):
+        self.validate(plan)
+        self.check_resources(plan)
+        preview = self.bridge.call('preview', plan)
+        if preview.get('agents') and not plan.get('acknowledgeAgents'):
+            raise HandoverError('live agent sessions: ' + ', '.join(str(x) for x in preview['agents']))
+        stages = [{'id': 'reserve', 'kind': 'reserve', 'plan': {k: v for k, v in plan.items() if k != 'stages'}, 'before': None}]
+        for source in plan.get('stages', []):
+            stage = dict(source)
+            if stage['kind'] == 'file':
+                stage['before'] = file_state(stage['path'])
+                stage['after'] = {'exists': True, 'data': base64.b64encode(stage['content'].encode()).decode(),
+                                  'mode': stage['before'].get('mode', 0o600),
+                                  'gid': stage['before'].get('gid', os.getegid()),
+                                  'xattrs': stage['before'].get('xattrs', {})}
+            else:
+                stage['before'] = self.bridge.call('shelterSnapshot', stage)['value']
+                stage['after'] = 'sheltered'
+            stages.append(stage)
+        for stage in stages:
+            stage['status'] = 'prepared'
+        return stages
+
+    def rehearse(self, plan):
+        stages = self.prepare(plan)
+        return {'id': plan['id'], 'mutation': False, 'resources': plan['resources'], 'stages': stages}
+
+    def apply_stage(self, stage):
+        if stage['kind'] == 'reserve':
+            self.bridge.call('reserve', stage['plan'])
+        elif stage['kind'] == 'file':
+            if file_state(stage['path']) != stage['before']:
+                raise HandoverError('file changed since snapshot')
+            atomic(stage['path'], base64.b64decode(stage['after']['data']), stage['after']['mode'], stage['after'])
+        else:
+            self.bridge.call('shelterApply', stage)
+
+    def undo_stage(self, stage):
+        if stage['kind'] == 'reserve':
+            # The durable index releases the claim even when the shell is down.
+            try:
+                self.bridge.call('release', {'id': stage['plan']['id']})
+            except HandoverError:
+                pass
+        elif stage['kind'] == 'file':
+            current = file_state(stage['path'])
+            if current == stage['before']:
+                return
+            if current != stage['after']:
+                raise HandoverError('value changed outside Aphotic; preserving it')
+            if stage['before']['exists']:
+                atomic(stage['path'], base64.b64decode(stage['before']['data']), stage['before']['mode'], stage['before'])
+            else:
+                Path(stage['path']).unlink()
+                directory = os.open(Path(stage['path']).parent, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+        else:
+            self.bridge.call('shelterRestore', stage)
+
+    def acquire(self, plan):
+        with self.lock():
+            stages = self.prepare(plan)
+            journal = dict(plan, schema=1, writtenBy='aphotic-handover', status='acquiring', stages=stages, createdAt=int(time.time() * 1000))
+            self.save(journal)
+            try:
+                for stage in stages:
+                    stage['requestedAt'] = int(time.time() * 1000)
+                    stage['status'] = 'applying'
+                    self.save(journal)
+                    self.apply_stage(stage)
+                    stage['status'] = 'applied'
+                    stage['completedAt'] = int(time.time() * 1000)
+                    self.save(journal)
+            except Exception as error:
+                stage['applyError'] = str(error)
+                journal['failedStage'] = stage['id']
+                journal['error'] = str(error)
+                self._recover(journal)
+                raise HandoverError(f"stage {stage['id']}: {error}") from error
+            journal['status'] = 'active'
+            self.save(journal)
+            return journal
+
+    def _recover(self, journal):
+        journal['status'] = 'restoring'
+        self.save(journal)
+        failed = False
+        for stage in reversed(journal['stages']):
+            if stage['status'] in ('prepared', 'restored'):
+                continue
+            if stage['kind'] == 'reserve' and failed:
+                continue
+            try:
+                self.undo_stage(stage)
+                stage['status'] = 'restored'
+                stage['restoredAt'] = int(time.time() * 1000)
+                stage.pop('error', None)
+            except Exception as error:
+                stage['status'] = 'restore-failed'
+                stage['error'] = str(error)
+                failed = True
+            self.save(journal)
+        journal['status'] = 'recovery-required' if failed else 'restored'
+        self.save(journal)
+        return journal
+
+    def recover(self, lease_id):
+        with self.lock():
+            return self._recover(self.load(lease_id))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--state-dir', default=str(Path(os.environ.get('XDG_STATE_HOME', str(Path.home() / '.local/state'))) / 'aphotic/handover'))
+    commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('status')
+    for name in ('recover', 'release'):
+        commands.add_parser(name).add_argument('id')
+    commands.add_parser('rehearse').add_argument('plan')
+    acquire = commands.add_parser('acquire')
+    acquire.add_argument('plan')
+    acquire.add_argument('--confirm', action='store_true')
+    args = parser.parse_args()
+    engine = Engine(args.state_dir)
+    try:
+        if args.command == 'status':
+            result = engine.status()
+        elif args.command in ('recover', 'release'):
+            result = engine.recover(args.id)
+        else:
+            plan = json.loads(Path(args.plan).read_text())
+            if args.command == 'acquire' and not args.confirm:
+                raise HandoverError('review rehearse output, then pass --confirm to acquire')
+            result = engine.acquire(plan) if args.command == 'acquire' else engine.rehearse(plan)
+        print(json.dumps(result, indent=2))
+        return 2 if isinstance(result, dict) and result.get('status') == 'recovery-required' else 0
+    except (HandoverError, OSError, ValueError, TypeError, KeyError) as error:
+        print(json.dumps({'error': str(error)}), file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Configs/.local/lib/aphotic/passthrough.py
+++ b/Configs/.local/lib/aphotic/passthrough.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Compare declared passthrough prerequisites with the running host. Never apply changes."""
+import argparse
+import json
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import sys
+import tomllib
+
+PCI = re.compile(r'[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-7]')
+MODULE = re.compile(r'[a-zA-Z0-9_-]+')
+
+
+def validate(desired):
+    if not isinstance(desired, dict) or set(desired) - {'devices', 'modules', 'kernel_parameters', 'initramfs_images'}:
+        raise ValueError('Invalid [passthrough] fields')
+    devices = desired.get('devices')
+    if not isinstance(devices, list) or not devices:
+        raise ValueError('[passthrough] must declare at least one device')
+    seen = set()
+    for device in devices:
+        if not isinstance(device, dict) or set(device) != {'pci', 'vendor', 'device', 'driver', 'group_members'}:
+            raise ValueError('Each passthrough device needs pci, vendor, device, driver and group_members')
+        address = device['pci']
+        if not isinstance(address, str) or not PCI.fullmatch(address) or address in seen:
+            raise ValueError('Invalid or duplicate passthrough PCI address')
+        seen.add(address)
+        if any(not isinstance(device[k], str) or not re.fullmatch('[0-9a-f]{4}', device[k]) for k in ('vendor', 'device')):
+            raise ValueError('PCI vendor/device IDs must be four lowercase hex digits')
+        if device['driver'] != 'vfio-pci':
+            raise ValueError('Declared passthrough devices must use vfio-pci')
+        group = device['group_members']
+        if not isinstance(group, list) or not group or address not in group or len(set(group)) != len(group) or any(not isinstance(p, str) or not PCI.fullmatch(p) for p in group):
+            raise ValueError('group_members must contain unique PCI addresses including the device')
+    for key in ('modules', 'kernel_parameters', 'initramfs_images'):
+        items = desired.get(key)
+        if not isinstance(items, list) or not items or any(not isinstance(s, str) or not s for s in items):
+            raise ValueError(key + ' must be a nonempty string array')
+    if any(not MODULE.fullmatch(m) for m in desired['modules']):
+        raise ValueError('Invalid module name')
+    if any(any(c.isspace() for c in p) for p in desired['kernel_parameters']):
+        raise ValueError('Kernel parameters must be individual tokens')
+    if any(not Path(p).is_absolute() or '..' in Path(p).parts for p in desired['initramfs_images']):
+        raise ValueError('Initramfs images must use absolute paths without parent traversal')
+    return desired
+
+
+def text(path):
+    try:
+        return path.read_text().strip()
+    except (OSError, UnicodeError):
+        return None
+
+
+def initramfs_listing(path):
+    try:
+        result = subprocess.run(['lsinitcpio', '-l', str(path)], capture_output=True, text=True,
+                                timeout=20, check=False)
+        return result.stdout if result.returncode == 0 else None
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def discover(desired, root=Path('/'), listing=initramfs_listing):
+    validate(desired)
+    root = Path(root)
+    devices = {}
+    for device in desired['devices']:
+        node = root / 'sys/bus/pci/devices' / device['pci']
+        if not node.is_dir():
+            continue
+        driver_path = node / 'driver'
+        driver = driver_path.resolve().name if driver_path.exists() else None
+        group = node / 'iommu_group/devices'
+        members = sorted(p.name for p in group.iterdir()) if group.is_dir() else None
+        connectors = list((node / 'drm').glob('card*/card*-*'))
+        connector_states = [text(c / 'enabled') for c in connectors]
+        boot_vga = text(node / 'boot_vga')
+        # Without DRM evidence, only an already bound VFIO device proves no host display.
+        display = True if boot_vga == '1' or 'enabled' in connector_states else (
+            False if driver == 'vfio-pci' or connector_states and all(s == 'disabled' for s in connector_states) else None)
+        devices[device['pci']] = {'vendor': (text(node / 'vendor') or '').removeprefix('0x'),
+                                  'device': (text(node / 'device') or '').removeprefix('0x'),
+                                  'driver': driver, 'group_members': members, 'display': display}
+    modules = sorted(p.name.replace('-', '_') for p in (root / 'sys/module').glob('*'))
+    cmdline = text(root / 'proc/cmdline')
+    initramfs = {}
+    for image in desired['initramfs_images']:
+        output = listing(root / image.lstrip('/'))
+        initramfs[image] = (sorted(set(m.replace('-', '_') for m in re.findall(
+            r'(?:^|/)([A-Za-z0-9_-]+)\.ko(?:\.(?:zst|xz|gz))?(?=\s|$)', output, re.M))) if output is not None else None)
+    return {'devices': devices, 'modules': modules,
+            'kernel_parameters': shlex.split(cmdline) if cmdline is not None else None, 'initramfs': initramfs}
+
+
+def compare(desired, actual):
+    validate(desired)
+    checks = []
+    def add(key, expected, observed, remedy, unknown=False, display=False):
+        status = 'UNKNOWN' if unknown else ('ok' if expected == observed else 'DRIFTED')
+        if display and observed is True:
+            status = 'MANUAL ACTION REQUIRED'
+        checks.append({'key': key, 'status': status, 'desired': expected, 'actual': observed, 'remedy': remedy})
+    for device in desired['devices']:
+        pci = device['pci']
+        found = actual['devices'].get(pci)
+        add(pci + ':present', True, found is not None, 'Check hardware and declared PCI addresses after firmware changes')
+        if found is None:
+            continue
+        for key in ('vendor', 'device', 'driver', 'group_members'):
+            expected = sorted(device[key]) if key == 'group_members' else device[key]
+            value = found.get(key)
+            if key == 'group_members' and isinstance(value, list): value = sorted(value)
+            add(pci + ':' + key, expected, value,
+                'Review the rendered diff and repair host configuration with explicit approval; do not apply ACS override')
+        add(pci + ':display', False, found.get('display'),
+            'Stop: move the host display to another GPU and confirm ownership before any rebind, launch or boot apply',
+            unknown=found.get('display') is None, display=True)
+    for module in desired['modules']:
+        normalized = module.replace('-', '_')
+        add('module:' + module, True, normalized in actual['modules'], 'Review loaded VFIO modules before launch')
+        for image in desired['initramfs_images']:
+            listed = actual['initramfs'].get(image)
+            add('initramfs:' + image + ':' + module, True, normalized in listed if listed is not None else None,
+                'Inspect the initramfs. Review a config diff before an approved rebuild', unknown=listed is None)
+    for parameter in desired['kernel_parameters']:
+        cmdline = actual.get('kernel_parameters')
+        add('kernel:' + parameter, True, parameter in cmdline if cmdline is not None else None,
+            'Review the boot configuration diff; applying kernel parameters requires approval and a reboot', unknown=cmdline is None)
+    statuses = {c['status'] for c in checks}
+    status = next((s for s in ('MANUAL ACTION REQUIRED', 'DRIFTED', 'UNKNOWN') if s in statuses), 'READY')
+    return {'opted_in': True, 'status': status, 'checks': checks}
+
+
+def report(config, probe=discover):
+    path = Path(config)
+    if not path.exists():
+        return {'opted_in': False, 'status': 'OPTED OUT', 'checks': []}
+    try:
+        data = tomllib.loads(path.read_text())
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError('Cannot read desired state: ' + str(exc)) from exc
+    if 'passthrough' not in data:
+        return {'opted_in': False, 'status': 'OPTED OUT', 'checks': []}
+    desired = validate(data['passthrough'])
+    return compare(desired, probe(desired))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--config', required=True, type=Path)
+    parser.add_argument('--json', action='store_true')
+    args = parser.parse_args()
+    try:
+        result = report(args.config)
+    except (ValueError, OSError, TypeError) as exc:
+        result = {'opted_in': True, 'status': 'INVALID', 'checks': [], 'error': str(exc)}
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print('Passthrough readiness: ' + result['status'])
+        if result.get('error'): print('  ' + result['error'])
+        for check in result['checks']:
+            print(f"  [{check['status']}] {check['key']}: desired {check['desired']!r}, actual {check['actual']!r}")
+            if check['status'] != 'ok': print('    ' + check['remedy'])
+    return 0 if result['status'] in ('READY', 'OPTED OUT') else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Configs/.local/lib/aphotic/state.sh
+++ b/Configs/.local/lib/aphotic/state.sh
@@ -149,3 +149,11 @@ _aphotic_state_service_drift() {
         printf 'displaymanager\tok\t\n'
     fi
 }
+
+# Opted-out passthrough performs no hardware discovery.
+_aphotic_state_passthrough() {
+    python3 "${LIB_DIR}/passthrough.py" --config "${APHOTIC_DOTS_DIR}/aphotic.toml" "$@" || {
+        local result=$?
+        [[ "$result" -eq 1 ]] || return "$result"
+    }
+}

--- a/Configs/quickshell/aphotic/modules/flow/FlowTab.qml
+++ b/Configs/quickshell/aphotic/modules/flow/FlowTab.qml
@@ -25,8 +25,21 @@ Item {
         dev: InstallProfile.devEnabled
     })
 
+    Text {
+        id: recoveryNotice
+        anchors.top: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: parent.width
+        wrapMode: Text.Wrap
+        color: Colours.palette.m3error
+        visible: Handover.recovery.length > 0 || Handover.error.length > 0
+        text: (Handover.error || "Host handover needs recovery: " + Handover.recovery.map(l => l.id).join(", "))
+            + "\nFrom a terminal: aphotic handover status; aphotic handover recover <lease-id>"
+    }
+
     Loader {
         anchors.fill: parent
+        anchors.topMargin: recoveryNotice.visible ? recoveryNotice.implicitHeight + 8 : 0
         active: root.presented
         sourceComponent: FlowScene {
             id: scene

--- a/Configs/quickshell/aphotic/services/PluginRegistry.qml
+++ b/Configs/quickshell/aphotic/services/PluginRegistry.qml
@@ -99,6 +99,7 @@ Singleton {
                 label: profile.label || profile.id,
                 snapshot: profile.snapshot ?? [],
                 requiresLayer: profile.requires_layer ?? "",
+                requiresPlugin: profile.requires_plugin ?? "",
                 requiresData: profile.requires_data ?? "",
                 componentUrl: `file://${root.pluginsDir}/${name}/${profile.component}`
             };
@@ -133,6 +134,7 @@ Singleton {
                 label: provider.label || provider.id,
                 backend: provider.backend,
                 requiresLayer: provider.requires_layer ?? "",
+                requiresPlugin: provider.requires_plugin ?? "",
                 requiresData: provider.requires_data ?? "",
                 statePath: `${Quickshell.env("HOME")}/.config/aphotic/plugins/${name}/${provider.state || "provider.json"}`
             };
@@ -167,6 +169,7 @@ Singleton {
                     label: action.label || action.id,
                     icon: action.icon || "bolt",
                     requiresLayer: action.requires_layer ?? "",
+                    requiresPlugin: action.requires_plugin ?? "",
                     requiresData: action.requires_data ?? "",
                     componentUrl: `file://${root.pluginsDir}/${name}/${action.component}`
                 };
@@ -271,6 +274,7 @@ Singleton {
             icon: s.icon || "extension",
             label: s.label || name,
             requiresLayer: s.requires_layer ?? "",
+            requiresPlugin: s.requires_plugin ?? "",
             requiresData: s.requires_data ?? "",
             parent: s.parent || root._defaultParent(s),
             // Overlay only. The host budgets its surface from these once
@@ -302,7 +306,8 @@ Singleton {
     }
 
     function _gateSatisfied(surface: var): bool {
-        return root._layerEnabled(surface.requiresLayer) && root._dataAvailable(surface.requiresData);
+        return root._layerEnabled(surface.requiresLayer) && root._dataAvailable(surface.requiresData)
+            && (!surface.requiresPlugin || (surface.requiresPlugin !== surface.plugin && root.isEnabled(surface.requiresPlugin)));
     }
 
     // An unrecognised token fails closed. A manifest naming a layer or a

--- a/Configs/quickshell/aphotic/services/profile/ActionReceipts.qml
+++ b/Configs/quickshell/aphotic/services/profile/ActionReceipts.qml
@@ -22,6 +22,11 @@ Singleton {
     property var _state: Receipts.newState()
     property var _all: []
 
+    function importHandover(lease: var, stage: var): void {
+        if (Receipts.importHandover(root._state, lease, stage))
+            root._refresh();
+    }
+
     function request(input: var): string {
         const result = Receipts.request(root._state, input, Date.now());
         if (!result.ok)

--- a/Configs/quickshell/aphotic/services/profile/Handover.qml
+++ b/Configs/quickshell/aphotic/services/profile/Handover.qml
@@ -1,0 +1,172 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.services
+import qs.services.profile
+import qs.services.ai
+
+Singleton {
+    id: root
+    readonly property string statePath: (Quickshell.env("XDG_STATE_HOME") || Quickshell.env("HOME") + "/.local/state") + "/aphotic/handover/index.json"
+    property var leases: []
+    property var reservations: ({})
+    property var passports: ({})
+    property var capacityHeld: ({})
+    property string error: ""
+    readonly property var recovery: leases.filter(l => l.status !== "restored" && !reservations[l.id])
+
+    function preview(plan: var): var {
+        if (root.error) return {ok: false, error: root.error};
+        if (!plan?.id || !plan.owner || !Array.isArray(plan.resources) || !plan.resources.length)
+            return {ok: false, error: "Malformed lease"};
+        const seen = {};
+        for (const r of plan.resources) {
+            if (!r.key || seen[r.key] || typeof r.amount !== "number" || !isFinite(r.amount) || r.amount <= 0)
+                return {ok: false, error: "Malformed resource"};
+            seen[r.key] = true;
+            if (!["cpu", "memory"].includes(r.key) && r.exclusive !== true)
+                return {ok: false, error: "Device resources must be exclusive"};
+            const held = ResourceEngine.claimsFor(r.key).filter(c => c.leaseId !== plan.id);
+            let spec = ResourceEngine.resourceSpec(r.key);
+            if (!spec && (r.key === "memory" || r.key === "cpu")) {
+                SystemCapacity.probe(r.key);
+                const capacity = SystemCapacity.known[r.key];
+                if (!capacity) return {ok: false, retry: true, error: "Reading host capacity"};
+                spec = {capacity: capacity, safetyMargin: 0.15};
+            }
+            if (held.length && (r.exclusive || held.some(c => c.exclusive)))
+                return {ok: false, error: "Exclusive resource occupied: " + r.key};
+            if (!r.exclusive && (!spec || held.reduce((n,c) => n+c.amount, r.amount) > spec.capacity * (1-spec.safetyMargin)))
+                return {ok: false, error: "Insufficient declared capacity: " + r.key};
+        }
+        return {ok: true, claims: plan.resources, agents: AgentEvents.liveSessions.map(s => s.label || s.harness || s.id)};
+    }
+
+    function reserve(plan: var): var {
+        const result = preview(plan);
+        if (!result.ok) return result;
+        if (result.agents.length && !plan.acknowledgeAgents)
+            return {ok: false, error: "Live agent sessions require acknowledgement: " + result.agents.join(", ")};
+        if (reservations[plan.id]) return {ok: false, error: "Lease already reserved"};
+        reservations = Object.assign({}, reservations, {[plan.id]: plan});
+        syncClaims();
+        return {ok: true};
+    }
+
+    function releaseLease(payload: var): var {
+        const next = Object.assign({}, reservations);
+        delete next[payload.id];
+        reservations = next;
+        // Durable journals remain authoritative until terminal recovery has finished.
+        syncClaims();
+        return {ok: true};
+    }
+
+    function shelterSnapshot(stage: var): var {
+        const p = ProfileEngine.profiles[stage.owner];
+        if (!ProfileEngine.canShelter(stage.owner) || typeof p?.handoverState !== "function"
+                || typeof p?.handoverShelter !== "function" || typeof p?.handoverRestore !== "function")
+            return {ok: false, error: "Owner lacks a durable exact-state restore contract: " + stage.owner,
+                canShelter: ProfileEngine.canShelter(stage.owner), canSuspend: ProfileEngine.canSuspend(stage.owner)};
+        const value = p.handoverState();
+        if (typeof value !== "string" || value.length > 64)
+            return {ok: false, error: "Owner state must be a bounded string"};
+        return {ok: true, value: value};
+    }
+
+    function shelterChange(stage: var, restore: bool): var {
+        const snapshot = shelterSnapshot(stage);
+        if (!snapshot.ok) return snapshot;
+        const expected = restore ? stage.after : stage.before;
+        const target = restore ? stage.before : stage.after;
+        if (snapshot.value === target) return {ok: true};
+        if (snapshot.value !== expected) return {ok: false, error: "Owner changed outside this lease; preserving state"};
+        const p = ProfileEngine.profiles[stage.owner];
+        const result = restore ? p.handoverRestore(target) : p.handoverShelter(target);
+        if (result !== true || p.handoverState() !== target)
+            return {ok: false, error: "Owner did not confirm requested state"};
+        return {ok: true};
+    }
+
+    function syncClaims(): void {
+        const active = {};
+        leases.filter(l => l.status !== "restored").forEach(l => active[l.id] = l);
+        Object.keys(reservations).forEach(id => active[id] = reservations[id]);
+        const claims = [];
+        Object.keys(active).forEach(id => {
+            const l = active[id];
+            l.resources.forEach(r => claims.push({id: "handover:"+id+":"+r.key, leaseId: id,
+                owner: l.owner, resource: r.key, amount: r.amount, exclusive: !!r.exclusive,
+                priority: "foreground", origin: "dynamic", label: l.label || id}));
+            if (!passports[id]) passports[id] = WorkloadPassports.open({owner: l.owner, plane: l.plane,
+                label: l.label || id, trigger: "host handover", sessionId: id, sourceAt: Date.now()});
+        });
+        Object.keys(passports).forEach(id => {
+            if (!active[id]) { WorkloadPassports.close(passports[id], "host restored"); delete passports[id]; }
+        });
+        const wanted = {};
+        claims.forEach(c => { if (c.resource === "memory" || c.resource === "cpu") wanted[c.resource] = true; });
+        Object.keys(wanted).forEach(key => { if (!capacityHeld[key]) SystemCapacity.acquire(key); });
+        Object.keys(capacityHeld).forEach(key => { if (!wanted[key]) SystemCapacity.release(key); });
+        capacityHeld = wanted;
+        ResourceEngine.leaseClaims = claims;
+        ResourceEngine.leaseRecoveryBlocked = !!error;
+    }
+
+    function ingest(text: string): void {
+        try {
+            const data = JSON.parse(text);
+            if (data.schema !== 1 || !Array.isArray(data.leases)) throw "Malformed handover index";
+            for (const l of data.leases) {
+                if (!l.id || ["index", "__proto__", "constructor", "prototype"].includes(l.id) || !l.owner || !Array.isArray(l.resources) || !Array.isArray(l.stages)) throw "Malformed lease journal";
+                if (l.resources.some(r => !r || typeof r.key !== "string" || typeof r.amount !== "number" || !isFinite(r.amount) || r.amount <= 0))
+                    throw "Malformed lease resources";
+                if (!["acquiring", "active", "restoring", "recovery-required", "restored"].includes(l.status)) throw "Unknown lease state";
+            }
+            leases = data.leases;
+            error = data.errors?.length ? "One or more lease journals need repair; use aphotic handover status" : "";
+            for (const l of leases) {
+                for (const s of l.stages) ActionReceipts.importHandover(l, s);
+                if (l.status === "restored") { const next = Object.assign({}, reservations); delete next[l.id]; reservations = next; }
+            }
+        } catch (e) { error = "Handover recovery required: " + e; }
+        syncClaims();
+    }
+
+    function dispatch(method: string, input: string): string {
+        try {
+            const payload = JSON.parse(input);
+            if (method === "preview") return JSON.stringify(preview(payload));
+            if (method === "reserve") return JSON.stringify(reserve(payload));
+            if (method === "release") return JSON.stringify(releaseLease(payload));
+            if (method === "shelterSnapshot") return JSON.stringify(shelterSnapshot(payload));
+            if (method === "shelterApply") return JSON.stringify(shelterChange(payload, false));
+            if (method === "shelterRestore") return JSON.stringify(shelterChange(payload, true));
+            return JSON.stringify({ok: false, error: "Unknown operation"});
+        } catch (e) { return JSON.stringify({ok: false, error: String(e)}); }
+    }
+
+    FileView {
+        path: root.statePath
+        watchChanges: true
+        onFileChanged: reload()
+        onLoaded: root.ingest(text())
+        onLoadFailed: error => {
+            if (error !== FileViewError.FileNotFound || root.leases.length) {
+                root.error = "Cannot read handover journal; use aphotic handover status";
+                root.syncClaims();
+            }
+        }
+    }
+    IpcHandler {
+        target: "handover"
+        function preview(input: string): string { return root.dispatch("preview", input); }
+        function reserve(input: string): string { return root.dispatch("reserve", input); }
+        function release(input: string): string { return root.dispatch("release", input); }
+        function shelterSnapshot(input: string): string { return root.dispatch("shelterSnapshot", input); }
+        function shelterApply(input: string): string { return root.dispatch("shelterApply", input); }
+        function shelterRestore(input: string): string { return root.dispatch("shelterRestore", input); }
+    }
+}

--- a/Configs/quickshell/aphotic/services/profile/ProfileEngine.qml
+++ b/Configs/quickshell/aphotic/services/profile/ProfileEngine.qml
@@ -74,7 +74,10 @@ Singleton {
             gracefulStop: descriptor.gracefulStop ?? null,
             onShelter: descriptor.onShelter ?? null,
             onUnshelter: descriptor.onUnshelter ?? null,
-            shelterState: descriptor.shelterState ?? null
+            shelterState: descriptor.shelterState ?? null,
+            handoverState: descriptor.handoverState ?? null,
+            handoverShelter: descriptor.handoverShelter ?? null,
+            handoverRestore: descriptor.handoverRestore ?? null
         };
         root._profiles = profiles;
 
@@ -154,6 +157,10 @@ Singleton {
         const waiting = [];
         for (const claim of profile.claims) {
             const negotiation = ResourceEngine.register(Object.assign({}, claim, { owner: id }));
+            if (negotiation?.blocked) {
+                root.deactivate(id, negotiation.reason);
+                return false;
+            }
             if (negotiation)
                 waiting.push(negotiation.id);
         }

--- a/Configs/quickshell/aphotic/services/profile/Receipts.js
+++ b/Configs/quickshell/aphotic/services/profile/Receipts.js
@@ -7,7 +7,7 @@
 // label only when the owner reports the operation succeeded, so a failed
 // action can never read as a visual success.
 
-var KINDS = ['dnd', 'scheduler', 'power', 'model-unload', 'workspace', 'shelter'];
+var KINDS = ['dnd', 'scheduler', 'power', 'model-unload', 'workspace', 'shelter', 'handover'];
 var STATUSES = ['requested', 'applied', 'failed', 'restored', 'restore-failed'];
 var LIMITS = {items: 128, text: 64};
 
@@ -160,4 +160,20 @@ function stats(state) {
     return {total: state.items.length, pending: pending(state).length,
         failed: state.items.filter(function (r) { return r.status === 'failed' || r.status === 'restore-failed'; }).length,
         dropped: state.dropped, rejected: state.rejected};
+}
+
+function importHandover(state, lease, stage) {
+    var id = 'handover:' + lease.id + ':' + stage.id;
+    var existing = byId(state, id);
+    var statuses = {prepared: 'requested', applying: 'requested', applied: 'applied', restored: 'restored', 'restore-failed': 'restore-failed'};
+    if (!statuses[stage.status]) return false;
+    var receipt = {id: id, profileId: lease.owner, workloadId: lease.id,
+        kind: 'handover', status: statuses[stage.status], requestedAt: stage.requestedAt || lease.createdAt || 0,
+        completedAt: stage.restoredAt || stage.completedAt || null, before: redact(stage.kind === 'file' ? 'saved host file' : JSON.stringify(stage.before)),
+        after: redact(stage.kind === 'file' ? 'owned host file' : JSON.stringify(stage.after)),
+        reason: redact(stage.id), error: redact(stage.error || stage.applyError || ''), preserved: !!stage.preserved};
+    if (existing) Object.assign(existing, receipt);
+    else state.items.push(receipt);
+    while (state.items.length > LIMITS.items) { state.items.shift(); state.dropped++; }
+    return true;
 }

--- a/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
+++ b/Configs/quickshell/aphotic/services/profile/ResourceEngine.qml
@@ -30,7 +30,9 @@ import qs.services.profile
 Singleton {
     id: root
 
-    readonly property var claims: root._claims
+    readonly property var claims: root._claims.concat(root.leaseClaims)
+    property var leaseClaims: []
+    property bool leaseRecoveryBlocked: false
     readonly property var resources: root._resources
 
     // Head of the negotiation queue -- the one the prompt is showing.
@@ -39,7 +41,7 @@ Singleton {
     readonly property var pending: root._queue.length > 0 ? root._queue[0] : null
     readonly property int pendingCount: root._queue.length
 
-    readonly property bool dormant: root._claims.length === 0 && root._queue.length === 0
+    readonly property bool dormant: root.claims.length === 0 && root._queue.length === 0
 
     // Resources that have claims but no declared capacity. _contentionFor
     // skips those deliberately -- an undeclared resource has nothing to
@@ -123,11 +125,11 @@ Singleton {
     }
 
     function claimsFor(resource: string): var {
-        return root._claims.filter(c => c.resource === resource);
+        return root.claims.filter(c => c.resource === resource);
     }
 
     function claimsOf(owner: string): var {
-        return root._claims.filter(c => c.owner === owner);
+        return root.claims.filter(c => c.owner === owner);
     }
 
     // Returns the negotiation this registration raised, or null. A caller
@@ -140,6 +142,12 @@ Singleton {
             return null;
         }
 
+        const held = root.leaseClaims.filter(c => c.resource === claim.resource);
+        const spec = root.resourceSpec(claim.resource);
+        const total = root.claimsFor(claim.resource).filter(c => c.id !== claim.id).reduce((n, c) => n + c.amount, claim.amount);
+        if (root.leaseRecoveryBlocked || held.some(c => c.exclusive)
+                || (held.length && (!spec || total > spec.capacity * (1 - spec.safetyMargin))))
+            return {blocked: true, reason: "Resource held by host handover", resource: claim.resource};
         const next = root._claims.filter(c => c.id !== claim.id);
         next.push(claim);
         root._claims = next;

--- a/Configs/quickshell/aphotic/services/profile/qmldir
+++ b/Configs/quickshell/aphotic/services/profile/qmldir
@@ -1,4 +1,5 @@
 module qs.services.profile
+singleton Handover 1.0 Handover.qml
 singleton ActionReceipts 1.0 ActionReceipts.qml
 singleton DevDrift 1.0 DevDrift.qml
 singleton DevProfile 1.0 DevProfile.qml

--- a/Configs/quickshell/aphotic/shell.qml
+++ b/Configs/quickshell/aphotic/shell.qml
@@ -505,7 +505,7 @@ ShellRoot {
     // services/ that runs on its own rather than answering a reader
     // belongs in this list, and tests/test_singleton_reachability.py
     // fails the build if it does not.
-    readonly property var _residentSingletons: [SecurityProfile, WallpaperCycle, DevDrift, SafeMode, WorkspaceKeybind, Switcher]
+    readonly property var _residentSingletons: [Handover, SecurityProfile, WallpaperCycle, DevDrift, SafeMode, WorkspaceKeybind, Switcher]
 
     // The profile substrate's inspection/drive surface (Phase 0 --
     // docs/APHOTIC_UNIFIED_VISION.md section 3.5). Lives here rather than

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,126 @@
+# Host Handover
+
+This branch adds concurrent host leases, terminal recovery and read-only
+passthrough drift checks. It does not launch a VM or change boot configuration.
+
+## Lease API
+
+Run `aphotic handover rehearse plan.json` to read snapshots and check claims.
+Review its output before `aphotic handover acquire plan.json --confirm`.
+Use `aphotic handover status` to inspect journals and
+`aphotic handover recover <id>` or `release <id>` to restore one workload.
+Recovery of file stages works from a TTY without Quickshell. Shelter recovery
+needs its registered provider; a missing provider leaves a recovery-required
+journal and retains the reservation.
+
+A plan uses this shape:
+
+```json
+{
+  "id": "build-session-1",
+  "owner": "dev",
+  "plane": "dev",
+  "label": "Build session",
+  "resources": [
+    {"key": "memory", "amount": 4096, "unit": "MiB", "exclusive": false},
+    {"key": "cpu", "amount": 4, "unit": "threads", "exclusive": false}
+  ],
+  "stages": []
+}
+```
+
+Each workload gets its own journal. CPU and RAM reservations share a bounded
+capacity; device keys require exclusive ownership. Separate devices allow
+concurrent leases. The CLI enforces a host reserve and Flow also checks its
+existing claims. Reservations describe ownership, not measured usage or a
+kernel allocation. They do not constrain processes outside Aphotic.
+
+`handover.py` exposes `Engine.rehearse`, `acquire`, `status`, `load` and
+`recover`. It inserts a reservation stage before the caller's ordered stages:
+
+- `file`: `id`, `kind`, absolute `path`, replacement `content`. The executor
+  saves content, mode, group and extended attributes before replacement. It
+  refuses device paths, symlinks, hardlinks, another user's files, oversized
+  files and its own journal directory. Recovery compares the current value
+  with the value it wrote before restoring. File inode identity and timestamps
+  are not restored by this version.
+- `shelter`: `id`, `kind`, `owner`. The profile must pass `canShelter` and
+  provide `handoverState()`, `handoverShelter(target)` and
+  `handoverRestore(target)`. State is a string of at most 64 characters;
+  the applied target is `sheltered`. Both setters must return true only after
+  the state reader confirms the effect. Asynchronous providers need a future
+  acknowledgement contract. Existing graceful-stop hooks do not meet this
+  contract and the executor does not call them.
+
+The executor snapshots all stages before the first effect, writes intent
+before each stage, then records completion. It unwinds in reverse order after
+failure. Failed undo retains the reservation. Journals live under
+`$XDG_STATE_HOME/aphotic/handover` with private permissions. A nonblocking file
+lock serializes acquisition and recovery. File writes and journals use atomic
+replacement and fsync. Recovery preserves intervening user edits and reports
+the conflict instead of claiming success.
+
+`Handover.qml` watches the aggregate journal, exposes incomplete leases in Flow,
+imports stage receipts and opens workload passports through the shipped API.
+ResourceEngine rejects new claims that violate a lease. Restart does not resume
+an incomplete transaction. One event-driven file watch is the new idle cost;
+there is no discovery timer or libvirt poll. Known live AgentEvents sessions
+require `acknowledgeAgents: true`; the bridge does not start the agent feed, so
+this is not a fresh census when no existing reader holds that feed.
+
+## Passthrough drift
+
+`aphotic handover drift [--json]`, `aphotic doctor`, `aphotic status` and
+`aphotic diff` report the optional `[passthrough]` section of `aphotic.toml`.
+An absent section opts out and causes no hardware probe. An invalid section
+reports INVALID. UNKNOWN evidence cannot produce READY.
+
+```toml
+[passthrough]
+modules = ["vfio", "vfio_pci", "vfio_iommu_type1"]
+kernel_parameters = ["intel_iommu=on"]
+initramfs_images = ["/boot/initramfs-linux.img"]
+
+[[passthrough.devices]]
+pci = "0000:01:00.0"
+vendor = "10de"
+device = "2684"
+driver = "vfio-pci"
+group_members = ["0000:01:00.0", "0000:01:00.1"]
+```
+
+This is an example schema, not a configuration to apply. Record each device
+and its actual group members after hardware discovery. Compare uses device
+IDs, driver bindings, exact group membership, running kernel parameters,
+loaded modules and the modules listed from each named initramfs image.
+`lsinitcpio` failure yields UNKNOWN. Display ownership from boot-VGA and DRM
+connectors can force MANUAL ACTION REQUIRED. Unknown display ownership blocks
+READY. These checks do not prove that a guest boots or that its GPU resets.
+
+`passthrough.py` exposes `validate`, `discover`, `compare` and `report`. Future
+launch code must require READY immediately before transferring hardware. This
+branch has no launch or rebind path, no automatic repair, no ACS override and
+no boot apply. The existing reconcile command does not repair passthrough.
+
+## Evidence and next work
+
+Validated directly: CLI journal/file operations in temporary directories,
+TTY recovery without a shell binary, independent lease release, lock refusal,
+metadata restoration, malformed input handling and a windowless Quickshell
+probe that compiles and instantiates the bridge.
+
+Validated dry-run or mocked: failure after each stage, restart recovery,
+provider shelter/restore hooks, resource conflicts and passthrough sysfs and
+initramfs fixtures. Existing Flow, profile, plugin gates and status/diff checks
+also run against this branch.
+
+Requires physical VFIO validation: GPU ownership transfer, guest startup,
+reset, Looking Glass, disk isolation during a real guest session and restoration
+after guest exit. No host mutation occurred during development.
+
+Next: integrate a real reversible background-work provider; add fresh agent
+session acknowledgement; add a journal-backed workload-exit adapter and bounded
+history retention; connect readiness to VM launch; implement the allowlisted
+storage lease, automount exclusion and mountability-aware restoration; add GPU
+and domain lifecycle stages with rollback tests. The companion VM experiment
+remains local and inactive. It is not part of this PR.

--- a/profiles/base/full.toml
+++ b/profiles/base/full.toml
@@ -3,7 +3,7 @@ name = "full"
 description = "Full install: today's complete package set"
 
 [packages]
-prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "libnotify", "procps-ng", "util-linux", "gawk"]
+prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "libnotify", "procps-ng", "util-linux", "mkinitcpio", "gawk"]
 # qt6-imageformats is what lets the shell decode WebP, TIFF, TGA and
 # JPEG 2000; Qt reads only PNG, JPEG, GIF and SVG without it. Desktop pet
 # sprite sheets are WebP wherever they come from, and an image Qt cannot

--- a/profiles/base/minimal.toml
+++ b/profiles/base/minimal.toml
@@ -3,7 +3,7 @@ name = "minimal"
 description = "Bare Hyprland + Quickshell bar, no extras"
 
 [packages]
-prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "libnotify", "procps-ng", "util-linux", "gawk"]
+prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcontrols2", "qt5-graphicaleffects", "gtk3", "polkit-gnome", "pipewire", "wireplumber", "jq", "curl", "wl-clipboard", "cliphist", "python", "python-requests", "python-pillow", "pacman-contrib", "kvantum", "kvantum-qt5", "lm_sensors", "pciutils", "nvidia-utils", "radeontop", "intel-gpu-tools", "glib2", "dbus", "libnotify", "procps-ng", "util-linux", "mkinitcpio", "gawk"]
 # qt6-imageformats is what lets the shell decode WebP, TIFF, TGA and
 # JPEG 2000; Qt reads only PNG, JPEG, GIF and SVG without it. Desktop pet
 # sprite sheets are WebP wherever they come from, and an image Qt cannot

--- a/tests/test_handover.py
+++ b/tests/test_handover.py
@@ -1,0 +1,249 @@
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+MODULE = Path(__file__).resolve().parents[1] / 'Configs/.local/lib/aphotic/handover.py'
+
+
+def module():
+    assert MODULE.exists(), 'durable handover executor is missing'
+    spec = importlib.util.spec_from_file_location('handover', MODULE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class Bridge:
+    def __init__(self):
+        self.leases = {}
+    def call(self, method, payload):
+        if method == 'reserve':
+            self.leases[payload['id']] = payload
+        elif method == 'release':
+            self.leases.pop(payload['id'], None)
+        return {'ok': True, 'claims': [], 'agents': []}
+
+
+def plan(tmp_path, name='a'):
+    targets = [tmp_path / f'{name}-{i}' for i in range(3)]
+    for i, target in enumerate(targets):
+        target.write_text(f'before-{i}')
+        target.chmod(0o640)
+    return {'id': name, 'owner': 'test', 'plane': 'dev', 'label': name,
+            'resources': [{'key': 'memory', 'amount': 1024, 'unit': 'MiB', 'exclusive': False}],
+            'stages': [{'id': f'file-{i}', 'kind': 'file', 'path': str(p), 'content': 'leased'} for i, p in enumerate(targets)]}
+
+
+@pytest.mark.parametrize('failure', range(4))
+def test_reverse_rollback_at_every_stage(tmp_path, failure):
+    m = module()
+    p = plan(tmp_path)
+    bridge = Bridge()
+    engine = m.Engine(tmp_path / 'state', bridge)
+    original = engine.apply_stage
+    seen = []
+    def induced(stage):
+        original(stage)
+        seen.append(stage['id'])
+        if len(seen) == failure + 1:
+            raise RuntimeError('induced failure')
+    engine.apply_stage = induced
+    with pytest.raises(m.HandoverError, match='induced failure'):
+        engine.acquire(p)
+    for i in range(3):
+        assert (tmp_path / f'a-{i}').read_text() == f'before-{i}'
+        assert (tmp_path / f'a-{i}').stat().st_mode & 0o777 == 0o640
+    assert not bridge.leases
+    assert engine.status()[0]['status'] == 'restored'
+
+
+def test_crash_after_effect_is_recoverable_without_shell(tmp_path):
+    m = module()
+    p = plan(tmp_path)
+    engine = m.Engine(tmp_path / 'state', Bridge())
+    original = engine.apply_stage
+    def crash(stage):
+        original(stage)
+        if stage['id'] == 'file-1':
+            raise KeyboardInterrupt()
+    engine.apply_stage = crash
+    with pytest.raises(KeyboardInterrupt):
+        engine.acquire(p)
+    restarted = m.Engine(tmp_path / 'state', Bridge())
+    restarted.recover('a')
+    assert all((tmp_path / f'a-{i}').read_text() == f'before-{i}' for i in range(3))
+
+
+def test_preserves_intervening_edit_and_retains_reservation(tmp_path):
+    m = module()
+    p = plan(tmp_path)
+    engine = m.Engine(tmp_path / 'state', Bridge())
+    engine.acquire(p)
+    (tmp_path / 'a-1').write_text('user edit')
+    result = engine.recover('a')
+    assert result['status'] == 'recovery-required'
+    assert (tmp_path / 'a-1').read_text() == 'user edit'
+    assert result['stages'][0]['status'] == 'applied'
+
+
+def test_rehearsal_is_read_only(tmp_path):
+    m = module()
+    p = plan(tmp_path)
+    state = tmp_path / 'absent'
+    result = m.Engine(state, Bridge()).rehearse(p)
+    assert not state.exists()
+    assert len(result['stages']) == 4
+    assert (tmp_path / 'a-0').read_text() == 'before-0'
+
+
+def test_multiple_workloads_capacity_and_device_conflicts(tmp_path):
+    m = module()
+    engine = m.Engine(tmp_path / 'state', Bridge())
+    a, b = plan(tmp_path, 'a'), plan(tmp_path, 'b')
+    a['resources'].append({'key': 'pci:0000:01:00.0', 'amount': 1, 'exclusive': True})
+    b['resources'].append({'key': 'pci:0000:02:00.0', 'amount': 1, 'exclusive': True})
+    engine.acquire(a)
+    engine.acquire(b)
+    assert len([x for x in engine.status() if x['status'] == 'active']) == 2
+    with pytest.raises(m.HandoverError, match='already'):
+        engine.acquire(a)
+    c = plan(tmp_path, 'c')
+    c['resources'] = a['resources']
+    with pytest.raises(m.HandoverError, match='pci:'):
+        engine.acquire(c)
+    engine.recover('a')
+    assert engine.load('b')['status'] == 'active'
+
+
+def test_malformed_and_unknown_stage_rejected_without_writes(tmp_path):
+    m = module()
+    p = plan(tmp_path)
+    p['stages'][1]['kind'] = 'command'
+    with pytest.raises(m.HandoverError):
+        m.Engine(tmp_path / 'state', Bridge()).rehearse(p)
+    assert not (tmp_path / 'state').exists()
+
+
+def test_tty_status_does_not_need_quickshell(tmp_path):
+    module()
+    proc = subprocess.run([sys.executable, str(MODULE), '--state-dir', str(tmp_path / 'state'), 'status'], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == []
+    assert not (tmp_path / 'state').exists()
+
+
+def test_tty_recovery_after_restart_without_display(tmp_path):
+    m = module()
+    p = plan(tmp_path)
+    state = tmp_path / 'state'
+    engine = m.Engine(state, Bridge())
+    engine.acquire(p)
+    import os
+    env = dict(os.environ, PATH='/nonexistent')
+    proc = subprocess.run([sys.executable, str(MODULE), '--state-dir', str(state), 'recover', 'a'],
+                          capture_output=True, text=True, env=env)
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)['status'] == 'restored'
+    assert all((tmp_path / f'a-{i}').read_text() == f'before-{i}' for i in range(3))
+
+
+def test_lock_prevents_interleaved_acquisition(tmp_path):
+    m = module()
+    engine = m.Engine(tmp_path / 'state', Bridge())
+    p = plan(tmp_path)
+    with engine.lock():
+        with pytest.raises(m.HandoverError, match='in progress'):
+            m.Engine(tmp_path / 'state', Bridge()).acquire(p)
+
+
+def test_cpu_and_memory_reservations_keep_host_capacity(tmp_path):
+    m = module()
+    engine = m.Engine(tmp_path / 'state', Bridge())
+    p = plan(tmp_path)
+    for resource in ({'key': 'memory', 'amount': 10**12, 'unit': 'MiB'}, {'key': 'cpu', 'amount': 10**8}):
+        p['resources'] = [resource]
+        with pytest.raises(m.HandoverError, match='capacity'):
+            engine.rehearse(p)
+
+
+def test_missing_shell_refuses_acquire_before_any_file_effect(tmp_path):
+    m = module()
+    p = plan(tmp_path)
+    class Missing:
+        def call(self, *args):
+            raise m.HandoverError('Flow bridge unavailable')
+    with pytest.raises(m.HandoverError, match='unavailable'):
+        m.Engine(tmp_path / 'state', Missing()).acquire(p)
+    assert all((tmp_path / f'a-{i}').read_text() == f'before-{i}' for i in range(3))
+
+
+def test_cannot_lease_journal_or_lock_files(tmp_path):
+    m = module()
+    state = tmp_path / 'state'
+    state.mkdir(mode=0o700)
+    p = plan(tmp_path)
+    for name in ('.lock', 'index.json', 'a.json'):
+        p['stages'][0]['path'] = str(state / name)
+        with pytest.raises(m.HandoverError, match='journal'):
+            m.Engine(state, Bridge()).rehearse(p)
+
+
+def test_shelter_owner_cannot_be_held_by_two_leases(tmp_path):
+    m = module()
+    class ShelterBridge(Bridge):
+        def call(self, method, payload):
+            if method == 'shelterSnapshot':
+                return {'ok': True, 'value': 'full'}
+            return super().call(method, payload)
+    engine = m.Engine(tmp_path / 'state', ShelterBridge())
+    a, b = plan(tmp_path, 'a'), plan(tmp_path, 'b')
+    for p in (a, b):
+        p['stages'] = [{'id': 'shelter', 'kind': 'shelter', 'owner': 'background'}]
+    engine.acquire(a)
+    with pytest.raises(m.HandoverError, match='shelter'):
+        engine.rehearse(b)
+
+
+def test_reserved_index_id_refused(tmp_path):
+    m = module()
+    p = plan(tmp_path)
+    p['id'] = 'index'
+    with pytest.raises(m.HandoverError, match='reserved'):
+        m.Engine(tmp_path / 'state', Bridge()).rehearse(p)
+
+
+def test_corrupt_neighbor_does_not_prevent_known_lease_recovery(tmp_path):
+    m = module()
+    p = plan(tmp_path)
+    engine = m.Engine(tmp_path / 'state', Bridge())
+    engine.acquire(p)
+    (tmp_path / 'state/broken.json').write_text('{')
+    assert engine.recover('a')['status'] == 'restored'
+    assert json.loads((tmp_path / 'state/index.json').read_text())['errors']
+    assert (tmp_path / 'a-0').read_text() == 'before-0'
+
+
+@pytest.mark.parametrize('bad', [None, [], 'memory', 3])
+def test_malformed_resource_is_a_controlled_refusal(tmp_path, bad):
+    m = module()
+    p = plan(tmp_path)
+    p['resources'] = [bad]
+    with pytest.raises(m.HandoverError):
+        m.Engine(tmp_path / 'state', Bridge()).rehearse(p)
+
+
+def test_file_restore_keeps_group_and_extended_attributes(tmp_path):
+    import os
+    m = module()
+    p = plan(tmp_path)
+    target = tmp_path / 'a-0'
+    os.setxattr(target, 'user.handover-test', b'prior')
+    before = m.file_state(target)
+    engine = m.Engine(tmp_path / 'state', Bridge())
+    engine.acquire(p)
+    engine.recover('a')
+    assert m.file_state(target) == before

--- a/tests/test_handover_runtime.sh
+++ b/tests/test_handover_runtime.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+command -v qs >/dev/null || { echo 'SKIP: qs unavailable'; exit 0; }
+PROBE=$(mktemp "$ROOT/Configs/quickshell/aphotic/_probe_handover_XXXXXX.qml")
+TESTHOME=$(mktemp -d)
+trap 'rm -f "$PROBE"; rm -rf "$TESTHOME"' EXIT
+cat > "$PROBE" <<'QML'
+import QtQuick
+import Quickshell
+import qs.services.profile
+ShellRoot {
+    property string ownerState: "already-off"
+    function check(ok, message) { if (!ok) throw new Error(message); }
+    Component.onCompleted: {
+        ResourceEngine.declareResource("memory", {capacity: 64000, safetyMargin: 0.1});
+        const a = {id: "vm-a", owner: "example", plane: "gaming", label: "A", resources: [{key: "pci:01", amount: 1, exclusive: true}]};
+        const b = {id: "vm-b", owner: "example", plane: "gaming", label: "B", resources: [{key: "pci:02", amount: 1, exclusive: true}]};
+        check(Handover.reserve(a).ok, "first lease");
+        check(Handover.reserve(b).ok, "second lease");
+        check(ResourceEngine.claimsFor("pci:01").length === 1, "claim visible");
+        check(WorkloadPassports.live.length === 2, "two passports");
+        check(!Handover.reserve(Object.assign({}, a, {id: "vm-c"})).ok, "exclusive conflict refused");
+        check(ResourceEngine.register({id: "other", owner: "other", resource: "pci:01", amount: 1}).blocked, "registration blocked");
+        check(ResourceEngine.claimsFor("pci:01").length === 1, "blocked registration not inserted");
+        Handover.releaseLease({id: "vm-a"});
+        check(ResourceEngine.claimsFor("pci:01").length === 0 && ResourceEngine.claimsFor("pci:02").length === 1, "independent release");
+        ProfileEngine.register({id: "background", onShelter: function() {}, onUnshelter: function() {},
+            handoverState: () => ownerState,
+            handoverShelter: target => { ownerState = target; return true; },
+            handoverRestore: target => { ownerState = target; return true; }});
+        const before = Handover.shelterSnapshot({owner: "background"});
+        check(before.ok && before.value === "already-off", "exact snapshot");
+        const stage = {owner: "background", before: before.value, after: "sheltered"};
+        check(Handover.shelterChange(stage, false).ok && ownerState === "sheltered", "shelter effect");
+        check(Handover.shelterChange(stage, true).ok && ownerState === "already-off", "exact restore");
+        Handover.shelterChange(stage, false);
+        ownerState = "user-edit";
+        check(!Handover.shelterChange(stage, true).ok && ownerState === "user-edit", "preserve intervening change");
+        check(!Handover.shelterSnapshot({owner: "unsupported"}).ok, "unsupported provider refuses");
+        Handover.ingest(JSON.stringify({schema: 1, leases: [Object.assign({}, a, {status: "acquiring", stages: [{id: "reserve", kind: "reserve", status: "applying"}]})]}));
+        check(Handover.recovery.length === 1, "interrupted journal surfaced");
+        check(ActionReceipts.all.some(r => r.kind === "handover" && r.status === "requested"), "receipt is pending not applied");
+        Handover.ingest(JSON.stringify({schema: 1, leases: [], errors: [{file: "broken.json"}]}));
+        check(ResourceEngine.leaseRecoveryBlocked && !Handover.preview(a).ok, "corrupt neighbor fails closed");
+        console.log("PASS handover runtime");
+    }
+}
+QML
+result=0
+HOME="$TESTHOME" XDG_STATE_HOME="$TESTHOME/state" XDG_RUNTIME_DIR="$TESTHOME" QT_QPA_PLATFORM=offscreen QT_FORCE_STDERR_LOGGING=1 timeout 4 qs -p "$PROBE" > "$TESTHOME/output" 2>&1 || result=$?
+[[ "$result" == 0 || "$result" == 124 ]] || { cat "$TESTHOME/output"; exit 1; }
+grep -q 'PASS handover runtime' "$TESTHOME/output" || { cat "$TESTHOME/output"; exit 1; }
+echo 'PASS: handover QML runtime'

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -1,0 +1,93 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+SOURCE = Path(__file__).resolve().parents[1] / 'Configs/.local/lib/aphotic/passthrough.py'
+spec = importlib.util.spec_from_file_location('passthrough', SOURCE)
+p = importlib.util.module_from_spec(spec)
+if SOURCE.exists(): spec.loader.exec_module(p)
+
+class PassthroughDrift(unittest.TestCase):
+    def desired(self):
+        return {'devices': [{'pci': '0000:01:00.0', 'vendor': '10de', 'device': '2684', 'driver': 'vfio-pci',
+                             'group_members': ['0000:01:00.0', '0000:01:00.1']}],
+                'modules': ['vfio_pci'], 'kernel_parameters': ['intel_iommu=on'],
+                'initramfs_images': ['/boot/initramfs-linux.img']}
+
+    def actual(self):
+        return {'devices': {'0000:01:00.0': {'vendor': '10de', 'device': '2684', 'driver': 'vfio-pci',
+                    'group_members': ['0000:01:00.0', '0000:01:00.1'], 'display': False}},
+                'modules': ['vfio_pci'], 'kernel_parameters': ['quiet', 'intel_iommu=on'],
+                'initramfs': {'/boot/initramfs-linux.img': ['vfio_pci']}}
+
+    def test_missing_section_opts_out_without_probe(self):
+        self.assertTrue(hasattr(p, 'report'), 'Passthrough drift report is missing')
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'aphotic.toml'
+            path.write_text('[install]\nlayers = ["gaming"]\n')
+            self.assertEqual(p.report(path, probe=lambda desired: self.fail('opt-out probed host')),
+                             {'opted_in': False, 'status': 'OPTED OUT', 'checks': []})
+
+    def test_clean_and_drift(self):
+        desired, actual = self.desired(), self.actual()
+        self.assertEqual(p.compare(desired, actual)['status'], 'READY')
+        actual['devices']['0000:01:00.0']['driver'] = 'nvidia'
+        actual['devices']['0000:01:00.0']['group_members'].append('0000:02:00.0')
+        actual['initramfs']['/boot/initramfs-linux.img'] = []
+        result = p.compare(desired, actual)
+        self.assertEqual(result['status'], 'DRIFTED')
+        self.assertEqual(sum(c['status'] == 'DRIFTED' for c in result['checks']), 3)
+        self.assertTrue(any('initramfs' in c['key'] and 'vfio_pci' in c['key'] for c in result['checks']))
+
+    def test_unknown_initramfs_is_not_ready(self):
+        actual = self.actual()
+        actual['initramfs']['/boot/initramfs-linux.img'] = None
+        self.assertEqual(p.compare(self.desired(), actual)['status'], 'UNKNOWN')
+
+    def test_display_gpu_blocks_even_if_declared(self):
+        actual = self.actual()
+        actual['devices']['0000:01:00.0']['display'] = True
+        self.assertEqual(p.compare(self.desired(), actual)['status'], 'MANUAL ACTION REQUIRED')
+        actual['devices']['0000:01:00.0']['display'] = None
+        self.assertNotEqual(p.compare(self.desired(), actual)['status'], 'READY')
+
+    def test_missing_device_and_parameters(self):
+        actual = self.actual()
+        actual['devices'] = {}
+        actual['kernel_parameters'] = []
+        actual['modules'] = []
+        self.assertEqual(p.compare(self.desired(), actual)['status'], 'DRIFTED')
+
+    def test_malformed_and_empty_config_refused(self):
+        for desired in ({}, {'devices': 'bad'}, dict(self.desired(), modules='vfio'),
+                        dict(self.desired(), devices=[{'pci': '/dev/sda'}]),
+                        dict(self.desired(), surprise='ignored')):
+            with self.subTest(desired=desired), self.assertRaises(ValueError): p.validate(desired)
+
+    def test_sysfs_discovery_and_initramfs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            node = root / 'sys/bus/pci/devices/0000:01:00.0'
+            node.mkdir(parents=True)
+            (node / 'vendor').write_text('0x10de\n')
+            (node / 'device').write_text('0x2684\n')
+            (node / 'boot_vga').write_text('0\n')
+            driver = root / 'sys/bus/pci/drivers/vfio-pci'
+            driver.mkdir(parents=True)
+            (node / 'driver').symlink_to(driver)
+            group = root / 'sys/kernel/iommu_groups/55'
+            (group / 'devices').mkdir(parents=True)
+            (group / 'devices/0000:01:00.0').touch()
+            (group / 'devices/0000:01:00.1').touch()
+            (node / 'iommu_group').symlink_to(group)
+            (root / 'sys/module/vfio_pci').mkdir(parents=True)
+            (root / 'proc').mkdir()
+            (root / 'proc/cmdline').write_text('quiet intel_iommu=on')
+            actual = p.discover(self.desired(), root=root,
+                listing=lambda path: 'usr/lib/modules/kernel/vfio-pci.ko.zst\n')
+            self.assertEqual(p.compare(self.desired(), actual)['status'], 'READY')
+            self.assertEqual(actual['devices']['0000:01:00.0']['group_members'],
+                             ['0000:01:00.0', '0000:01:00.1'])
+
+if __name__ == '__main__': unittest.main()

--- a/tests/test_plugin_dependency_gate.sh
+++ b/tests/test_plugin_dependency_gate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TESTHOME=$(mktemp -d)
+trap 'rm -rf "$TESTHOME"' EXIT
+export HOME="$TESTHOME" XDG_CONFIG_HOME="$TESTHOME/config" XDG_STATE_HOME="$TESTHOME/state" XDG_DATA_HOME="$TESTHOME/data" APHOTIC_DOTS_DIR="$TESTHOME/dots"
+source "$ROOT/Configs/.local/lib/aphotic/globalcontrol.sh"
+source "$ROOT/Configs/.local/lib/aphotic/commands/cmd_plugin.sh"
+fail() { echo "FAIL: $*"; exit 1; }
+mkdir -p "$APHOTIC_PLUGINS_DIR/consumer/cli" "$APHOTIC_DOTS_DIR"
+manifest="$APHOTIC_PLUGINS_DIR/consumer/plugin.toml"
+cat > "$manifest" <<'TOML'
+[plugin]
+name = "consumer"
+version = "1.0.0"
+capabilities = ["cli", "ui-surface", "profile", "action"]
+[cli]
+command = "example"
+script = "cli/run.sh"
+requires_plugin = "prerequisite"
+requires_layer = "gaming"
+[ui.workspace]
+component = "Panel.qml"
+requires_plugin = "prerequisite"
+[profile]
+id = "example"
+component = "Profile.qml"
+requires_plugin = "prerequisite"
+[action]
+id = "example"
+component = "Action.qml"
+requires_plugin = "prerequisite"
+TOML
+printf 'true\n' > "$APHOTIC_PLUGINS_DIR/consumer/cli/run.sh"
+if aphotic_plugin_cli_resolve example >/dev/null; then fail 'missing prerequisite allowed CLI'; fi
+mkdir -p "$APHOTIC_PLUGINS_DIR/prerequisite"
+printf '[plugin]\nname = "prerequisite"\n' > "$APHOTIC_PLUGINS_DIR/prerequisite/plugin.toml"
+aphotic_plugin_cli_resolve example >/dev/null || fail 'enabled prerequisite blocked CLI'
+printf '{"disabled":["prerequisite"]}\n' > "$APHOTIC_PLUGINS_STATE_FILE"
+if aphotic_plugin_cli_resolve example >/dev/null; then fail 'disabled prerequisite allowed CLI'; fi
+[[ -z "$(aphotic_plugin_cli_top_level)" ]] || fail 'disabled prerequisite visible in help'
+printf '{"disabled":[]}\n' > "$APHOTIC_PLUGINS_STATE_FILE"
+printf '[install]\nlayers = ["ai"]\n' > "$APHOTIC_DOTS_DIR/aphotic.toml"
+if aphotic_plugin_cli_resolve example >/dev/null; then fail 'disabled layer allowed CLI'; fi
+for result in "$(_aphotic_plugin_cli_json "$manifest")" "$(_aphotic_plugin_surface_json "$manifest" ui.workspace workspace)" "$(_aphotic_plugin_profile_json "$manifest")" "$(_aphotic_plugin_action_entry_json "$manifest" action)"; do
+    [[ "$(jq -r .requires_plugin <<<"$result")" == prerequisite ]] || fail 'dependency lost in serialization'
+done
+_aphotic_plugin_registry_sync consumer
+[[ "$(_aphotic_plugin_describe consumer | jq -r .drifted)" == false ]] || fail 'fresh registry drifted'
+sed -i '/requires_plugin/d; /requires_layer/d' "$manifest"
+_aphotic_plugin_registry_sync consumer
+jq 'walk(if type == "object" then del(.requires_plugin) else . end) | del(.installed.consumer.cli.requires_layer)' "$APHOTIC_PLUGINS_STATE_FILE" > "$TESTHOME/old.json"
+mv "$TESTHOME/old.json" "$APHOTIC_PLUGINS_STATE_FILE"
+[[ "$(_aphotic_plugin_describe consumer | jq -r .drifted)" == false ]] || fail 'old ungated registry drifted'
+printf '\nrequires_plugin = "prerequisite"\n' >> "$manifest"
+[[ "$(_aphotic_plugin_describe consumer | jq -r .drifted)" == true ]] || fail 'new prerequisite did not drift'
+echo 'PASS: plugin dependency gates' 

--- a/tests/test_plugin_dependency_runtime.sh
+++ b/tests/test_plugin_dependency_runtime.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+command -v qs >/dev/null || { echo 'SKIP: qs unavailable'; exit 0; }
+PROBE=$(mktemp "$ROOT/Configs/quickshell/aphotic/_probe_dependency_XXXXXX.qml")
+TESTHOME=$(mktemp -d)
+trap 'rm -f "$PROBE"; rm -rf "$TESTHOME"' EXIT
+cat > "$PROBE" <<'QML'
+import QtQuick
+import Quickshell
+import qs.services
+ShellRoot {
+    Component.onCompleted: {
+        const consumer = {ui: {surfaces: [{surface: "workspace", component: "Panel.qml", requires_plugin: "parent"}]}, profile: {id: "example", component: "Profile.qml", requires_plugin: "parent"}, actions: [{id: "example", component: "Action.qml", requires_plugin: "parent"}]};
+        const states = [{installed: {consumer: consumer}, disabled: []}, {installed: {consumer: consumer, parent: {}}, disabled: []}, {installed: {consumer: consumer, parent: {}}, disabled: ["parent"]}];
+        for (let i = 0; i < states.length; i++) {
+            PluginRegistry._data = states[i];
+            const expected = i === 1 ? 1 : 0;
+            if (PluginRegistry.surfacesFor("workspace").length !== expected || PluginRegistry.profileRegistrations.length !== expected || PluginRegistry.actionRegistrations.length !== expected)
+                throw new Error("dependency gate failed for state " + i);
+        }
+        console.log("PASS dependency runtime");
+    }
+}
+QML
+result=0
+HOME="$TESTHOME" XDG_RUNTIME_DIR="$TESTHOME" QT_QPA_PLATFORM=offscreen QT_FORCE_STDERR_LOGGING=1 timeout 4 qs -p "$PROBE" > "$TESTHOME/output" 2>&1 || result=$?
+[[ "$result" == 0 || "$result" == 124 ]] || { cat "$TESTHOME/output"; exit 1; }
+grep -q 'PASS dependency runtime' "$TESTHOME/output" || { cat "$TESTHOME/output"; exit 1; }
+echo 'PASS: plugin dependency QML runtime'

--- a/tests/test_profile_substrate.sh
+++ b/tests/test_profile_substrate.sh
@@ -38,12 +38,15 @@ for s in ProfileEngine ResourceEngine; do
 done
 
 # Zero cost when no profile is active: the substrate owns no timer and
-# watches no file. StateSnapshot's two Process objects are on-demand only.
+# watches no file except the durable handover journal. StateSnapshot's two Process objects are on-demand only.
 for f in "$SUB"/*.qml "$UI"/*.qml; do
   grep -qE '^\s*Timer\s*\{' "$f" && fail "$f declares a Timer -- the substrate must add no polling"
-  grep -q 'FileView' "$f" && fail "$f uses a FileView -- the substrate must add no always-on file watch"
+  [[ "$f" == "$SUB/Handover.qml" ]] || ! grep -q 'FileView' "$f" || fail "$f uses a FileView -- the substrate must add no always-on file watch"
   grep -qE '^\s*Timer\s*\{|triggeredOnStart' "$f" && fail "$f looks like it polls"
 done
+
+[[ "$(grep -cE '^\s*FileView\s*\{' "$SUB/Handover.qml")" -eq 1 ]] || fail "handover must use one journal watch"
+grep -qE '^\s*Process\s*\{' "$SUB/Handover.qml" && fail "handover must not own a process"
 
 # Comments in these files legitimately name the things the code must never
 # do ("never touches kernel/sysctl"), so the safety greps below read code


### PR DESCRIPTION
## Problem

Flow can negotiate shared claims, but it has no durable host handover transaction or terminal recovery. Passthrough prerequisites can drift after kernel, driver or firmware changes without a readiness report.

## Plan

Add per-workload journals and typed reversible stages, expose leases through Flow, and compare optional declared passthrough state with the host. Keep concurrent workloads independent and retain reservations when restoration fails.

## Resolution

- Add handover rehearsal, acquisition, status, release and TTY recovery. Snapshot before effects, journal stage intent, unwind in reverse order and preserve intervening edits.
- Support concurrent CPU/RAM reservations and exclusive device claims. Reject resource conflicts, duplicate leases, overlapping file/shelter ownership and malformed plans.
- Add Flow recovery notices, workload passports, stage receipts and an exact-state shelter provider contract. Unsupported providers refuse; existing stop hooks are not used for suspension.
- Add passthrough drift to doctor, status, diff and handover drift. Check IDs, bindings, group membership, kernel parameters, loaded modules, initramfs contents and display ownership. An absent section opts out without probing.
- Add generic manifest prerequisite gates. Document APIs, limits and continuation work in HANDOVER.md.

Validated directly: temporary-file journal operations and TTY recovery; windowless Quickshell bridge and dependency-gate probes; Flow/profile and status/diff regressions.

Validated dry-run or mocked: rollback after each stage, interrupted acquisition, independent leases, shelter provider effects, and passthrough hardware/initramfs fixtures.

Requires physical VFIO validation: hardware transfer, guest startup/reset, storage isolation and Looking Glass. Live inspection found the target GPU still driving the display. No host mutation, rebind, boot apply, disk attachment or guest launch occurred.

This is a draft foundation PR. VM launch, built-in model/build suspension adapters, automatic workload-exit restoration, passthrough repair/apply and a fresh agent-session census remain follow-up work. The VM plugin experiment stays local. No merge requested.
