### PR TITLE
Install repo packages with pacman instead of the AUR helper

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,7 @@ main() {
   AUR_HELPER=""
   AUR_HELPER=$(ensure_aur_helper) || AUR_HELPER=""
   if [[ -z "$AUR_HELPER" ]]; then
-    echo -e "$CWR - No AUR helper (yay/paru) is available on PATH. AUR packages will fail to resolve."
+    echo -e "$CWR - No AUR helper (yay/paru) is available on PATH. Repo packages still install through pacman; only the AUR-only ones will be reported and skipped."
     echo -e "$CWR   Fix it manually: sudo pacman -S --needed base-devel git && git clone https://aur.archlinux.org/yay.git /tmp/yay && cd /tmp/yay && makepkg -si"
   else
     echo -e "$COK - Using AUR helper: $AUR_HELPER"

--- a/lib/install/nvidia.sh
+++ b/lib/install/nvidia.sh
@@ -44,8 +44,11 @@ install_nvidia_driver() {
     fi
 
     echo -e "$CNT - Uninstalling existing NVIDIA driver (${DETECTED_NVIDIA_DRIVER}) before installing Aphotic's recommended nvidia-open-dkms..."
+    # pacman, not "$AUR_HELPER": removal never needs an AUR helper, and an
+    # empty one (failed yay bootstrap) would run as the empty command and
+    # report a driver that "wouldn't uninstall cleanly" when nothing tried.
     # shellcheck disable=SC2086
-    "$AUR_HELPER" -R --noconfirm $(echo "$DETECTED_NVIDIA_DRIVER" | tr ',' ' ') &>> "$INSTLOG" || {
+    sudo pacman -R --noconfirm $(echo "$DETECTED_NVIDIA_DRIVER" | tr ',' ' ') &>> "$INSTLOG" || {
       echo -e "$CER - Failed to remove the existing driver (${DETECTED_NVIDIA_DRIVER}) -- see ${INSTLOG}. Not proceeding with a fresh install on top of a driver that wouldn't uninstall cleanly."
       return 1
     }

--- a/lib/install/packages.sh
+++ b/lib/install/packages.sh
@@ -71,6 +71,69 @@ _package_in_list() {
   [[ $'\n'"$2"$'\n' == *$'\n'"$1"$'\n'* ]]
 }
 
+# Installed-state and repo lookups go to pacman directly. Routing them
+# through "$AUR_HELPER" meant an empty helper (a failed yay bootstrap, which
+# install.sh only warns about) ran as the empty command: every package died
+# with a bare "command not found" in the log, starting with the first entry
+# of the base prep list, qt5-wayland, which is a plain repo package pacman
+# would have installed without an AUR helper at all.
+_pkg_installed() {
+  pacman -Qq "$1" &>/dev/null
+}
+
+_pkg_in_repos() {
+  pacman -Si "$1" &>/dev/null
+}
+
+# Omarchy's pacman-guard hook wants its documented opt-out on direct pacman
+# calls (same reason install.sh's -Syu carries it).
+_pacman_install_cmd() {
+  PKG_INSTALL_CMD=(sudo)
+  [[ "${DETECTED_OMARCHY:-0}" == "1" ]] && PKG_INSTALL_CMD+=(env OMARCHY_ALLOW_DIRECT_PACMAN=1)
+  PKG_INSTALL_CMD+=(pacman -S --needed --noconfirm)
+  return 0
+}
+
+# Fills PKG_INSTALL_CMD with what should install <package>: pacman for
+# anything a configured repo carries, the AUR helper otherwise. Preferring
+# pacman for repo packages also keeps a helper from fuzzy-matching a repo
+# name onto a broken AUR package (the lib32-gamemode-git trap install.sh's
+# multilib step already calls out). With no helper at all, pacman still gets
+# the attempt so the log carries a real "target not found" rather than a
+# "command not found" that says nothing about the package.
+_resolve_install_cmd() {
+  local pkg="$1"
+  if [[ -z "${AUR_HELPER:-}" ]] || _pkg_in_repos "$pkg"; then
+    _pacman_install_cmd
+    return 0
+  fi
+  # --removemake: AUR builds (wallust-git needs rust, python-pyamdgpuinfo
+  # needs cython/python-build/python-installer, etc.) otherwise leave their
+  # makedepends behind as orphans forever -- harmless, but Omarchy's own
+  # `omarchy update` surfaces exactly those as "orphan packages" and offers
+  # to remove them, which reads as if it's targeting Aphotic's own install.
+  PKG_INSTALL_CMD=("$AUR_HELPER" -S --noconfirm --removemake)
+}
+
+# A failure used to print nothing but "check the install.log" -- on a log
+# that is megabytes of pacman progress bars, the one line that says why
+# (an unresolved target, a bad signature, a 404 off a stale mirror) is
+# unfindable. Surface it where the failure is reported.
+_print_install_failure_detail() {
+  [[ -n "${INSTLOG:-}" && -r "${INSTLOG:-}" ]] || return 0
+  local detail
+  detail=$(tail -n 200 "$INSTLOG" 2>/dev/null \
+    | tr '\r' '\n' \
+    | sed $'s/\033\\[[0-9;?]*[a-zA-Z]//g' \
+    | grep -iE '^[[:space:]]*(error|warning|::.*failed|.*: command not found)' \
+    | tail -n 5)
+  [[ -n "$detail" ]] || return 0
+  echo -e "$CER   Last error lines from $INSTLOG:"
+  while IFS= read -r line; do
+    echo -e "$CER     $line"
+  done <<< "$detail"
+}
+
 # install_software <package> [required|optional]
 #
 # Defaults to "required" -- every direct caller (hyprland, the NVIDIA
@@ -79,7 +142,7 @@ _package_in_list() {
 # added: those are reported with an issue link and skipped.
 install_software() {
   local pkg="$1" requirement="${2:-required}"
-  if "$AUR_HELPER" -Q "$pkg" &>> /dev/null ; then
+  if _pkg_installed "$pkg"; then
     echo -e "$COK - $pkg is already installed."
     return 0
   fi
@@ -90,18 +153,15 @@ install_software() {
   # On a terminal the spinner line carries the name itself; only the
   # non-TTY branch (no spinner) needs it printed up front.
   [[ -t 1 ]] || echo -en "$CNT - Now installing $pkg "
-  # --removemake: AUR builds (wallust-git needs rust, python-pyamdgpuinfo
-  # needs cython/python-build/python-installer, etc.) otherwise leave their
-  # makedepends behind as orphans forever -- harmless, but Omarchy's own
-  # `omarchy update` surfaces exactly those as "orphan packages" and offers
-  # to remove them, which reads as if it's targeting Aphotic's own install.
-  "$AUR_HELPER" -S --noconfirm --removemake "$pkg" &>> "$INSTLOG" &
+  local PKG_INSTALL_CMD=()
+  _resolve_install_cmd "$pkg"
+  "${PKG_INSTALL_CMD[@]}" "$pkg" &>> "$INSTLOG" &
   local pkg_pid=$!
   show_progress "$pkg_pid" "installing $pkg"
   local rc=0
   wait "$pkg_pid" 2>/dev/null || rc=$?
 
-  if "$AUR_HELPER" -Q "$pkg" &>> /dev/null ; then
+  if _pkg_installed "$pkg"; then
     echo -e "$COK - $pkg was installed."
     return 0
   fi
@@ -115,9 +175,17 @@ install_software() {
     exit "$rc"
   fi
 
+  # An AUR package with no helper on PATH is its own diagnosis, and the
+  # generic "submit an issue" line sends the user down the wrong path.
+  local why=""
+  if [[ -z "${AUR_HELPER:-}" ]] && ! _pkg_in_repos "$pkg"; then
+    why="$pkg isn't in any configured repo and no AUR helper (yay/paru) is on PATH, so nothing could build it."
+  fi
+
   if [[ "$requirement" == "optional" ]]; then
     FAILED_OPTIONAL_PACKAGES+=("$pkg")
     echo -e "$CER - Error installing -- $pkg -- Submit issue request for install package -- $pkg"
+    [[ -n "$why" ]] && echo -e "$CWR   $why"
     echo -e "$CWR   Skipped, the install continues. Output: $INSTLOG"
     echo -e "$CWR   $(_issue_url_for "$pkg")"
     return 0
@@ -125,6 +193,11 @@ install_software() {
 
   echo -e "$CER - $pkg install had failed, please check the install.log"
   echo -e "$CER   $pkg is required, so the install can't continue without it."
+  if [[ -n "$why" ]]; then
+    echo -e "$CER   $why"
+  else
+    _print_install_failure_detail
+  fi
   echo -e "$CER   Submit issue request for install package -- $pkg"
   echo -e "$CER   $(_issue_url_for "$pkg")"
   exit 1

--- a/lib/install/system_prep.sh
+++ b/lib/install/system_prep.sh
@@ -24,6 +24,18 @@ enable_core_services() {
   sudo systemctl enable --now bluetooth.service &>> "$INSTLOG"
   echo -e "$CNT - Enabling display manager (sddm)..."
   sudo systemctl enable sddm &>> "$INSTLOG"
+  # pacman, not "$AUR_HELPER": a removal never needs an AUR helper, and an
+  # empty one (failed yay bootstrap) would just run as the empty command.
+  # Only name portals that are actually installed -- pacman -R aborts the
+  # whole transaction on the first "target not found", so passing both
+  # unconditionally meant one absent portal left the other one installed.
   echo -e "$CNT - Removing conflicting desktop portals..."
-  "$AUR_HELPER" -R --noconfirm xdg-desktop-portal-gnome xdg-desktop-portal-gtk &>> "$INSTLOG" || true
+  local portals=()
+  local portal
+  for portal in xdg-desktop-portal-gnome xdg-desktop-portal-gtk; do
+    pacman -Qq "$portal" &>/dev/null && portals+=("$portal")
+  done
+  if ((${#portals[@]} > 0)); then
+    sudo pacman -R --noconfirm "${portals[@]}" &>> "$INSTLOG" || true
+  fi
 }

--- a/tests/test_packages_install_routing.sh
+++ b/tests/test_packages_install_routing.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# tests/test_packages_install_routing.sh
+#
+# install_software must not need an AUR helper for a package a repo already
+# carries. Before this, every package went through "$AUR_HELPER", so a
+# failed yay bootstrap left it empty and the first base prep package
+# (qt5-wayland, a plain repo package) died with "command not found".
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR=$(mktemp -d)
+trap '/bin/rm -rf "$WORKDIR"' EXIT
+PATH_BACKUP="$PATH"
+
+CNT="[NOTE]"; COK="[OK]"; CER="[ERROR]"; CWR="[WARNING]"
+APHOTIC_ISSUES_URL="https://example.invalid/issues"
+DRY_RUN=0
+INSTLOG="$WORKDIR/install.log"
+: > "$INSTLOG"
+
+FAKE_BIN="$WORKDIR/bin"
+/bin/mkdir -p "$FAKE_BIN"
+
+# pacman stub: repo-pkg is in the repos, aur-pkg is not, and nothing is
+# installed until -S lands it (recorded in $WORKDIR/installed).
+/bin/cat > "$FAKE_BIN/pacman" <<EOF
+#!/usr/bin/env bash
+op="\$1"; shift
+case "\$op" in
+  -Qq) /bin/grep -qxF "\$1" "$WORKDIR/installed" 2>/dev/null ;;
+  -Si) [[ "\$1" == "repo-pkg" ]] ;;
+  -S)
+    for a in "\$@"; do
+      [[ "\$a" == -* ]] && continue
+      if [[ "\$a" != "repo-pkg" ]]; then
+        echo "error: target not found: \$a"
+        exit 1
+      fi
+      echo "\$a" >> "$WORKDIR/installed"
+      echo "pacman installed \$a" >> "$WORKDIR/calls"
+    done
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+/bin/chmod +x "$FAKE_BIN/pacman"
+
+/bin/cat > "$FAKE_BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+/bin/chmod +x "$FAKE_BIN/sudo"
+
+/bin/cat > "$FAKE_BIN/yay" <<EOF
+#!/usr/bin/env bash
+op="\$1"; shift
+if [[ "\$op" == "-S" ]]; then
+  for a in "\$@"; do
+    [[ "\$a" == -* ]] && continue
+    echo "\$a" >> "$WORKDIR/installed"
+    echo "yay installed \$a" >> "$WORKDIR/calls"
+  done
+fi
+EOF
+/bin/chmod +x "$FAKE_BIN/yay"
+
+export PATH="$FAKE_BIN:$PATH_BACKUP"
+: > "$WORKDIR/installed"
+: > "$WORKDIR/calls"
+
+# shellcheck source=/dev/null
+source "$ROOT/lib/install/packages.sh"
+set +e
+
+# 1. Repo package with no AUR helper at all: must install via pacman.
+AUR_HELPER=""
+out=$(install_software repo-pkg 2>&1) || fail "repo-pkg failed with no AUR helper: $out"
+/bin/grep -qxF "pacman installed repo-pkg" "$WORKDIR/calls" \
+  || fail "repo-pkg was not routed to pacman (calls: $(/bin/cat "$WORKDIR/calls"))"
+
+# 2. Already-installed check must not shell out to the empty helper either.
+out=$(install_software repo-pkg 2>&1) || fail "second repo-pkg call failed: $out"
+[[ "$out" == *"already installed"* ]] || fail "expected already-installed short-circuit, got: $out"
+
+# 3. An AUR-only package with no helper fails with the real reason, not a
+#    bare "check the log".
+: > "$WORKDIR/calls"
+out=$(install_software aur-pkg optional 2>&1) || fail "optional aur-pkg should not abort the run"
+[[ "$out" == *"no AUR helper"* ]] || fail "expected the missing-helper reason, got: $out"
+[[ "$out" == *"Skipped, the install continues"* ]] || fail "an optional failure must say the install carries on, got: $out"
+
+# 4. With a helper present, an AUR-only package goes to the helper and a
+#    repo package still goes to pacman.
+: > "$WORKDIR/calls"
+AUR_HELPER="yay"
+out=$(install_software aur-pkg 2>&1) || fail "aur-pkg failed with a helper present: $out"
+/bin/grep -qxF "yay installed aur-pkg" "$WORKDIR/calls" || fail "aur-pkg was not routed to the AUR helper"
+
+: > "$WORKDIR/calls"
+: > "$WORKDIR/installed"
+out=$(install_software repo-pkg 2>&1) || fail "repo-pkg failed with a helper present: $out"
+/bin/grep -qxF "pacman installed repo-pkg" "$WORKDIR/calls" \
+  || fail "repo-pkg should prefer pacman even when an AUR helper exists"
+
+export PATH="$PATH_BACKUP"
+echo "PASS: package install routing"


### PR DESCRIPTION
## Problem

An install on a new device stopped at the first package with:

```
[ERROR] - qt5-wayland install had failed, please check the install.log
[ERROR]   qt5-wayland is required, so the install can't continue without it.
```

qt5-wayland is the first entry of `prep` in both base profiles and a plain
repo package. Nothing was wrong with it.

`install_software` ran every package through `"$AUR_HELPER"`. When the yay
bootstrap fails, install.sh warns and carries on with `AUR_HELPER` empty, so
the check became `"" -Q qt5-wayland`, which bash runs as the empty command
and returns 127 for. That output lands in install.log, so the terminal names
the package and says nothing about the helper. Every later package would
have failed the same way.

The two removal paths carried the same bug: an empty helper in
`enable_core_services` and in the NVIDIA driver replacement. The second one
reports a driver that "wouldn't uninstall cleanly" when nothing ran.

## Plan

Stop treating the AUR helper as the only way to install anything. pacman
handles what a configured repo carries; the helper is for the rest. That
keeps a failed yay bootstrap from costing more than the AUR-only packages,
and it closes a second trap the multilib step already warns about, where a
helper fuzzy-matches a repo name onto a broken AUR package such as
lib32-gamemode-git.

Also make a failure say why. install.log runs to megabytes of pacman
progress bars, and the one line that explains a bad signature or a stale
mirror is not findable by hand.

## Resolution

- `install_software` queries installed state with `pacman -Qq` and routes an
  install by whether `pacman -Si` finds the package. Repo packages go to
  `sudo pacman -S --needed --noconfirm`, AUR-only packages to the helper with
  `--removemake` as before. On Omarchy the direct pacman calls carry
  `OMARCHY_ALLOW_DIRECT_PACMAN=1`, the same opt-out the `-Syu` uses.
- With no helper on PATH, a package that no repo carries fails with that as
  the stated reason rather than a generic issue link.
- A required-package failure prints the last error lines from install.log.
- Portal removal filters to portals that are installed. `pacman -R` aborts
  the whole transaction on the first "target not found", so passing both
  names left one portal behind when the other was absent. Visible in a real
  log as `error: target not found: xdg-desktop-portal-gnome`.
- NVIDIA driver removal uses `sudo pacman -R`.
- `tests/test_packages_install_routing.sh` covers the four routing cases
  against a stubbed pacman and yay. tests.yml picks it up.

Left out: the yay bootstrap itself is unchanged. A device that cannot build
yay still cannot install AUR packages. It gets a working desktop and a list
of what it skipped.

To verify on a machine with no AUR helper: `./install.sh --profile minimal`
installs the base shell and reports the AUR-only packages at the end instead
of stopping on qt5-wayland.
