### PR TITLE
Recover from a stale AUR build cache instead of failing forever

### DIFF
--- a/lib/install/packages.sh
+++ b/lib/install/packages.sh
@@ -115,6 +115,42 @@ _resolve_install_cmd() {
   PKG_INSTALL_CMD=("$AUR_HELPER" -S --noconfirm --removemake)
 }
 
+# yay and paru keep a git clone of the PKGBUILD plus every downloaded
+# source under a build dir nothing ever prunes (yay's cleanAfter is false by
+# default). A build that fails or gets interrupted leaves a half-written
+# tarball there, and makepkg validates that file on the next run rather than
+# fetching it again: "One or more files did not pass the validity check".
+# A modified PKGBUILD blocks the helper's own `git pull` the same way, which
+# under --noconfirm (no clean-build menu) surfaces as two attempts, exit 1
+# and a demand for manual intervention. Neither state clears on its own, so
+# every later run fails the same way on a package that is fine.
+_aur_build_dir() {
+  local pkg="$1" cache="${XDG_CACHE_HOME:-$HOME/.cache}" dir
+  for dir in "$cache/yay/$pkg" "$cache/paru/clone/$pkg"; do
+    [[ -d "$dir/.git" ]] && { echo "$dir"; return 0; }
+  done
+  return 1
+}
+
+# Clears the derived files in that build dir. Returns 0 only when it removed
+# something, so the caller knows a retry has a reason to behave differently.
+_clear_aur_build_cache() {
+  local pkg="$1" dir
+  dir=$(_aur_build_dir "$pkg") || return 1
+  # A tracked file the user edited is theirs. Resetting it would throw away
+  # a deliberate PKGBUILD change, which rule 5 does not allow this script to
+  # do on its own, so name it and stop.
+  if [[ -n "$(git -C "$dir" status --porcelain --untracked-files=no 2>/dev/null)" ]]; then
+    echo -e "$CWR   $dir has local edits to tracked files, so the AUR helper cannot update it."
+    echo -e "$CWR   Left alone. Review them, then discard with: git -C $dir checkout -- ."
+    return 1
+  fi
+  # Everything untracked in there was downloaded or built, never authored.
+  git -C "$dir" clean -fdx &>> "$INSTLOG" || return 1
+  echo -e "$CNT   Cleared stale downloads under $dir and retrying once."
+  return 0
+}
+
 # A failure used to print nothing but "check the install.log" -- on a log
 # that is megabytes of pacman progress bars, the one line that says why
 # (an unresolved target, a bad signature, a 404 off a stale mirror) is
@@ -155,25 +191,37 @@ install_software() {
   [[ -t 1 ]] || echo -en "$CNT - Now installing $pkg "
   local PKG_INSTALL_CMD=()
   _resolve_install_cmd "$pkg"
-  "${PKG_INSTALL_CMD[@]}" "$pkg" &>> "$INSTLOG" &
-  local pkg_pid=$!
-  show_progress "$pkg_pid" "installing $pkg"
-  local rc=0
-  wait "$pkg_pid" 2>/dev/null || rc=$?
 
-  if _pkg_installed "$pkg"; then
-    echo -e "$COK - $pkg was installed."
-    return 0
-  fi
+  # Two attempts at most, and the second one only happens after the stale
+  # build cache that caused the first failure is gone. A retry that changes
+  # nothing just fails twice as slowly.
+  local rc=0 pkg_pid
+  local attempt
+  for attempt in 1 2; do
+    "${PKG_INSTALL_CMD[@]}" "$pkg" &>> "$INSTLOG" &
+    pkg_pid=$!
+    show_progress "$pkg_pid" "installing $pkg"
+    rc=0
+    wait "$pkg_pid" 2>/dev/null || rc=$?
 
-  # 130/143: the helper died from the user's Ctrl+C or a TERM, not from
-  # anything wrong with the package. Now that an optional failure no
-  # longer aborts, skipping on a signal would make an interrupt
-  # unstoppable -- it would just walk to the next package.
-  if ((rc == 130 || rc == 143)); then
-    echo -e "$CER - Interrupted while installing $pkg -- stopping here. Nothing further will be installed."
-    exit "$rc"
-  fi
+    if _pkg_installed "$pkg"; then
+      echo -e "$COK - $pkg was installed."
+      return 0
+    fi
+
+    # 130/143: the helper died from the user's Ctrl+C or a TERM, not from
+    # anything wrong with the package. Now that an optional failure no
+    # longer aborts, skipping on a signal would make an interrupt
+    # unstoppable -- it would just walk to the next package.
+    if ((rc == 130 || rc == 143)); then
+      echo -e "$CER - Interrupted while installing $pkg -- stopping here. Nothing further will be installed."
+      exit "$rc"
+    fi
+
+    ((attempt == 1)) || break
+    echo -e "$CWR - $pkg did not build. Checking whether a stale AUR build cache explains it..."
+    _clear_aur_build_cache "$pkg" || break
+  done
 
   # An AUR package with no helper on PATH is its own diagnosis, and the
   # generic "submit an issue" line sends the user down the wrong path.

--- a/tests/test_packages_aur_cache_recovery.sh
+++ b/tests/test_packages_aur_cache_recovery.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# tests/test_packages_aur_cache_recovery.sh
+#
+# A failed AUR build leaves a half-written source tarball in the helper's
+# build dir. makepkg validates that file on the next run instead of fetching
+# it again, so every later install fails with "did not pass the validity
+# check" on a package that is fine. install_software clears the derived
+# files and retries once, and leaves a user-edited PKGBUILD alone.
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR=$(mktemp -d)
+trap '/bin/rm -rf "$WORKDIR"' EXIT
+PATH_BACKUP="$PATH"
+
+CNT="[NOTE]"; COK="[OK]"; CER="[ERROR]"; CWR="[WARNING]"
+APHOTIC_ISSUES_URL="https://example.invalid/issues"
+DRY_RUN=0
+INSTLOG="$WORKDIR/install.log"
+: > "$INSTLOG"
+: > "$WORKDIR/installed"
+
+export XDG_CACHE_HOME="$WORKDIR/cache"
+FAKE_BIN="$WORKDIR/bin"
+/bin/mkdir -p "$FAKE_BIN" "$XDG_CACHE_HOME"
+
+# Nothing is in a repo, so every package here routes to the AUR helper.
+/bin/cat > "$FAKE_BIN/pacman" <<EOF
+#!/usr/bin/env bash
+op="\$1"; shift
+case "\$op" in
+  -Qq) /bin/grep -qxF "\$1" "$WORKDIR/installed" 2>/dev/null ;;
+  -Si) exit 1 ;;
+  *) exit 0 ;;
+esac
+EOF
+/bin/chmod +x "$FAKE_BIN/pacman"
+
+# Stands in for makepkg's source validation: the build succeeds only once
+# the stale tarball is gone from the build dir.
+/bin/cat > "$FAKE_BIN/yay" <<EOF
+#!/usr/bin/env bash
+op="\$1"; shift
+pkg=""
+for a in "\$@"; do [[ "\$a" == -* ]] || pkg="\$a"; done
+[[ "\$op" == "-S" ]] || exit 0
+echo "attempt \$pkg" >> "$WORKDIR/attempts"
+if [[ -e "$XDG_CACHE_HOME/yay/\$pkg/\$pkg-1.0.tar.gz" ]]; then
+  echo "==> ERROR: One or more files did not pass the validity check!"
+  exit 1
+fi
+echo "\$pkg" >> "$WORKDIR/installed"
+EOF
+/bin/chmod +x "$FAKE_BIN/yay"
+
+# A build dir in the state a killed build leaves behind: a clean checkout
+# with a partial download sitting next to it.
+seed_build_dir() {
+  local pkg="$1"
+  local dir="$XDG_CACHE_HOME/yay/$pkg"
+  /bin/rm -rf "$dir"
+  /bin/mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email test@example.invalid
+  git -C "$dir" config user.name test
+  echo "pkgname=$pkg" > "$dir/PKGBUILD"
+  git -C "$dir" add PKGBUILD
+  git -C "$dir" commit -qm initial
+  printf 'truncated' > "$dir/$pkg-1.0.tar.gz"
+}
+
+export PATH="$FAKE_BIN:$PATH_BACKUP"
+# shellcheck source=/dev/null
+source "$ROOT/lib/install/packages.sh"
+set +e
+AUR_HELPER="yay"
+
+# 1. Stale tarball: the first build fails its checksum, the cache is cleared
+#    and the second build succeeds.
+: > "$WORKDIR/attempts"
+seed_build_dir stale-pkg
+out=$(install_software stale-pkg 2>&1) || fail "stale-pkg should recover after the cache is cleared: $out"
+[[ $(/bin/grep -c . "$WORKDIR/attempts") == "2" ]] \
+  || fail "expected exactly two build attempts, got $(/bin/cat "$WORKDIR/attempts")"
+[[ "$out" == *"Cleared stale downloads"* ]] || fail "expected the cache-clear notice, got: $out"
+[[ "$out" == *"was installed"* ]] || fail "expected success after the retry, got: $out"
+[[ -e "$XDG_CACHE_HOME/yay/stale-pkg/stale-pkg-1.0.tar.gz" ]] \
+  && fail "the stale tarball should have been removed"
+[[ -f "$XDG_CACHE_HOME/yay/stale-pkg/PKGBUILD" ]] \
+  || fail "the tracked PKGBUILD must survive the clean"
+
+# 2. A PKGBUILD the user edited is theirs. No clean, no retry, and the
+#    message names the directory.
+: > "$WORKDIR/attempts"
+: > "$WORKDIR/installed"
+seed_build_dir edited-pkg
+echo "# a deliberate local change" >> "$XDG_CACHE_HOME/yay/edited-pkg/PKGBUILD"
+out=$(install_software edited-pkg optional 2>&1)
+[[ $(/bin/grep -c . "$WORKDIR/attempts") == "1" ]] \
+  || fail "a user-edited PKGBUILD must not trigger a retry, got $(/bin/cat "$WORKDIR/attempts")"
+[[ "$out" == *"local edits to tracked files"* ]] || fail "expected the local-edit warning, got: $out"
+[[ "$out" == *"Left alone"* ]] || fail "expected the leave-it-alone notice, got: $out"
+/bin/grep -qF "a deliberate local change" "$XDG_CACHE_HOME/yay/edited-pkg/PKGBUILD" \
+  || fail "the user's PKGBUILD edit was discarded"
+
+# 3. No build dir at all (a repo package, or a first-ever build): one
+#    attempt, no retry, nothing invented.
+: > "$WORKDIR/attempts"
+out=$(install_software never-built optional 2>&1)
+[[ $(/bin/grep -c . "$WORKDIR/attempts") == "1" ]] \
+  || fail "expected a single attempt with no build dir, got $(/bin/cat "$WORKDIR/attempts")"
+
+export PATH="$PATH_BACKUP"
+echo "PASS: AUR build cache recovery"


### PR DESCRIPTION
## Problem

An install that fails once at an AUR package keeps failing at the same
package, and re-running install.sh never clears it. Two shapes of the same
cause, both hit on one machine this week:

```
error: ... exit status 1 ... manual intervention is required
==> ERROR: One or more files did not pass the validity check!
```

yay keeps a git clone of the PKGBUILD and every downloaded source under
`~/.cache/yay/<pkg>` (paru uses `~/.cache/paru/clone/<pkg>`). Nothing prunes
it, and yay's `cleanAfter` is false by default. A build that fails or gets
interrupted leaves a truncated tarball behind, and makepkg validates that
file on the next run rather than fetching it again, so the checksum never
matches. A modified PKGBUILD stops the helper's own `git pull`, which under
`--noconfirm` (no clean-build menu) becomes two attempts, exit 1 and a
demand for manual intervention.

Neither state clears on its own. The package is fine, the network is fine,
and the only way out is knowing that `~/.cache/yay` exists.

## Plan

Clear the derived files and try once more. A retry that changes nothing just
fails twice as slowly, so the second attempt only runs when the first one
actually removed something.

Draw the line at what git tracks. Untracked files in that directory were
downloaded or built. A tracked file that differs from HEAD is a PKGBUILD the
user edited, and rule 5 does not let this script throw that away on its own,
so it gets named instead of reset.

## Resolution

- `_aur_build_dir` finds the helper's clone for a package, checking yay's
  layout then paru's, honouring `XDG_CACHE_HOME`.
- `_clear_aur_build_cache` runs `git clean -fdx` there and returns success
  only when it removed something. With local edits to tracked files it
  prints the directory, leaves it alone, and gives the command to discard
  them.
- `install_software` wraps the install in at most two attempts, and the
  second runs only after a successful clear. A package with no build dir at
  all, including every repo package, still gets exactly one attempt.

`tests/test_packages_aur_cache_recovery.sh` covers all three: a stale
tarball that recovers on the retry, a user-edited PKGBUILD that is preserved
with no retry, and the no-build-dir case.

102 Python tests and every shell suite pass.

To verify by hand: `printf x > ~/.cache/yay/<pkg>/<pkg>-<ver>.tar.gz` on a
package that is not installed, then run install.sh and watch it clear the
directory and build.
