### PR TITLE
Fix minimal fonts and first-session wallpaper setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install pytest
         run: pip install pytest
 
+      - name: Install Lua for startup tests
+        run: sudo apt-get update && sudo apt-get install -y lua5.4
+
       - name: Run bash test suite
         run: |
           fail=0

--- a/Configs/hypr/startup.lua
+++ b/Configs/hypr/startup.lua
@@ -20,17 +20,17 @@ hl.on("hyprland.start", function()
     -- ever told awww-daemon what to show, leaving "No wallpaper set"
     -- until SUPER+SHIFT+W was used manually. Polls for the daemon's
     -- socket itself rather than assuming the sleep above was long enough.
-    hl.exec_cmd("aphotic theme ensure-default")
+    hl.exec_cmd("~/.local/bin/aphotic theme ensure-default")
     -- Connects only if Settings.vpnAutoConnect is true (checked inside
     -- the command itself, see cmd_vpn.sh's `autostart` subcommand) --
     -- warns and no-ops without passwordless sudo, same as everything
     -- else in commands/README.md's sudoers section.
-    hl.exec_cmd("aphotic vpn autostart")
+    hl.exec_cmd("~/.local/bin/aphotic vpn autostart")
     -- No-op unless the installed version changed since the last time this
     -- ran (see cmd_whatsnew.sh) -- catches "git pull without a fresh
     -- install.sh run" as well as the normal post-install case, which
     -- already triggers this same command directly from install.sh.
-    hl.exec_cmd("aphotic whatsnew")
+    hl.exec_cmd("~/.local/bin/aphotic whatsnew")
 
     -- Cursor theme/size, icon theme, and gtk-theme used to be hardcoded
     -- here, but that meant every reboot silently overwrote whatever was

--- a/install.sh
+++ b/install.sh
@@ -490,6 +490,8 @@ main() {
     fi
   fi
 
+  write_aphotic_toml "$APHOTIC_TOML" "$PROFILE" "$LAYERS" "$THEME" "$ISNVIDIA" "$AUR_HELPER" "$(date -Iseconds)" "$ISAMD"
+
   if [[ "$want_configs" == "1" ]]; then
     CFG_COPIED=1
     deploy_user_configs
@@ -499,22 +501,12 @@ main() {
     fi
     install_vscode_extensions
 
-    # Hyprland's exec-once only fires at its own startup, never on a config
-    # reload -- if a graphical session is already up (e.g. Omarchy's sddm
-    # autologin straight into Hyprland, or install.sh just run from a
-    # terminal inside an existing session), aphotic-shell.service's exec-once
-    # start already silently missed its one chance. Start it explicitly now.
-    if systemctl --user is-active --quiet graphical-session.target; then
-      echo -e "$CNT - A graphical session is already running -- starting the shell now rather than waiting on Hyprland's exec-once, which won't fire again for this session."
-      restart_shell_if_enabled
-    fi
+    initialize_graphical_session
   fi
 
   print_stage 7 "Shell setup"
   activate_starship
   activate_zsh
-
-  write_aphotic_toml "$APHOTIC_TOML" "$PROFILE" "$LAYERS" "$THEME" "$ISNVIDIA" "$AUR_HELPER" "$(date -Iseconds)" "$ISAMD"
 
   echo -e "\n\e[1;32m── Install summary ──\e[0m"
   echo -e "  Profile:       $PROFILE"

--- a/lib/install/config_deploy.sh
+++ b/lib/install/config_deploy.sh
@@ -455,6 +455,26 @@ restart_shell_if_enabled() {
   fi
 }
 
+start_awww_daemon_if_needed() {
+  command -v awww-daemon >/dev/null 2>&1 || return 0
+  local user_id
+  user_id="$(id -u)"
+  pgrep -u "$user_id" -x awww-daemon >/dev/null 2>&1 && return 0
+  echo -e "$CNT - Starting awww-daemon for the active graphical session..."
+  awww-daemon &>> "$INSTLOG" &
+  disown 2>/dev/null || true
+}
+
+initialize_graphical_session() {
+  systemctl --user is-active --quiet graphical-session.target || return 0
+  echo -e "$CNT - A graphical session is already running -- initializing the wallpaper and shell now."
+  start_awww_daemon_if_needed
+  if [[ -x "$HOME/.local/bin/aphotic" ]]; then
+    "$HOME/.local/bin/aphotic" theme ensure-default &>> "$INSTLOG" || echo -e "$CWR - Could not initialize the default theme; the shell will still start (run 'aphotic theme ensure-default' manually if the wallpaper is blank)."
+  fi
+  restart_shell_if_enabled
+}
+
 config_sync() {
   if [[ ! -f "$APHOTIC_TOML" ]]; then
     echo -e "$CWR - No aphotic.toml found -- inferring the installed profile from packages so the System pane isn't stuck on \"unknown\"."

--- a/profiles/base/minimal.toml
+++ b/profiles/base/minimal.toml
@@ -16,4 +16,4 @@ prep = ["qt5-wayland", "qt5ct", "qt6-wayland", "qt6ct", "qt5-svg", "qt5-quickcon
 # codeberg archive that gets regenerated, and the -git one now builds
 # 4.0.0-alpha. lib/install/wallust.sh installs the upstream static binary
 # against a pinned sha256 instead, and never fails the install.
-main = ["quickshell", "qt6-shadertools", "qt6-imageformats", "qt6-multimedia", "ffmpeg", "kitty", "awww", "xdg-desktop-portal-hyprland", "matugen", "openvpn", "swappy", "grim", "slurp", "brightnessctl", "swaylock-effects", "hypridle", "cava"]
+main = ["quickshell", "qt6-shadertools", "qt6-imageformats", "qt6-multimedia", "ffmpeg", "kitty", "awww", "xdg-desktop-portal-hyprland", "matugen", "openvpn", "swappy", "grim", "slurp", "brightnessctl", "swaylock-effects", "hypridle", "cava", "ttf-jetbrains-mono-nerd", "ttf-material-symbols-variable", "inter-font"]

--- a/tests/test_install_graphical_session.sh
+++ b/tests/test_install_graphical_session.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+TESTHOME="$WORKDIR/home"
+FAKEBIN="$WORKDIR/bin"
+EVENTS="$WORKDIR/events"
+DAEMON_MARK="$WORKDIR/awww-daemon.running"
+mkdir -p "$TESTHOME/.local/bin" "$FAKEBIN" "$TESTHOME/Aphotic-Hypr"
+: > "$EVENTS"
+
+export HOME="$TESTHOME"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_STATE_HOME="$HOME/.local/state"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_RUNTIME_DIR="$WORKDIR/runtime"
+export APHOTIC_DOTS_DIR="$ROOT"
+export APHOTIC_SDDM_THEME_DIR="$WORKDIR/no-sddm"
+export COPY_CONFIGS=1
+export GREETD_PREVIEW=0
+export PATH="$FAKEBIN:/usr/bin:/bin"
+export INSTLOG="$WORKDIR/install.log"
+export CNT='[NOTE]'
+export CWR='[WARNING]'
+export COK='[OK]'
+export DETECTED_OMARCHY=0
+export CONFIG_ONLY=0
+export LAYERS_KNOWN=1
+export GRAPHICAL=1
+export APHOTIC_TOML="$TESTHOME/Aphotic-Hypr/aphotic.toml"
+export PROFILE=minimal
+export LAYERS=""
+export THEME=beta
+export ISNVIDIA=false
+export AUR_HELPER=""
+export ISAMD=false
+
+cat > "$FAKEBIN/systemctl" <<'SYSTEMCTL'
+#!/usr/bin/env bash
+case "$*" in
+  *"is-active"*"graphical-session.target"*)
+    [[ "${GRAPHICAL:-0}" == "1" ]]
+    ;;
+  *"is-enabled"*aphotic-shell.service*)
+    exit 0
+    ;;
+  *show*)
+    echo 0
+    ;;
+  *restart*aphotic-shell.service*)
+    echo restart >> "$INSTALL_EVENTS"
+    ;;
+esac
+SYSTEMCTL
+chmod +x "$FAKEBIN/systemctl"
+
+cat > "$FAKEBIN/pgrep" <<'PGREP'
+#!/usr/bin/env bash
+if [[ "$1" == "-u" ]]; then
+  [[ -f "$AWWW_DAEMON_MARK" ]]
+  exit $?
+fi
+if [[ "$1" == "-f" ]]; then
+  exit 0
+fi
+exit 1
+PGREP
+chmod +x "$FAKEBIN/pgrep"
+
+cat > "$FAKEBIN/awww-daemon" <<'AWWW'
+#!/usr/bin/env bash
+echo daemon >> "$INSTALL_EVENTS"
+touch "$AWWW_DAEMON_MARK"
+AWWW
+chmod +x "$FAKEBIN/awww-daemon"
+
+cat > "$FAKEBIN/awww" <<'AWWW'
+#!/usr/bin/env bash
+case "$1" in
+  query) [[ -f "$AWWW_DAEMON_MARK" ]] && echo '{}' ;;
+  img)
+    [[ -f "$HOME/Aphotic-Hypr/aphotic.toml" ]] || exit 42
+    echo image >> "$INSTALL_EVENTS"
+    ;;
+  *) exit 1 ;;
+esac
+AWWW
+chmod +x "$FAKEBIN/awww"
+for executable in wallust sudo; do
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKEBIN/$executable"
+  chmod +x "$FAKEBIN/$executable"
+done
+printf '#!/usr/bin/env bash\nexit 1\n' > "$FAKEBIN/sudo"
+
+export INSTALL_EVENTS="$EVENTS"
+export AWWW_DAEMON_MARK="$DAEMON_MARK"
+mkdir -p "$TESTHOME/.local/state/aphotic"
+
+source "$ROOT/lib/install/wizard.sh"
+source "$ROOT/lib/install/config_deploy.sh"
+print_stage() { :; }
+setup_login_manager_theme() { :; }
+install_vscode_extensions() { :; }
+deploy_user_configs() {
+  ln -sf "$ROOT/Configs/.local/bin/aphotic" "$HOME/.local/bin/aphotic"
+  for theme in alpha beta; do
+    mkdir -p "$XDG_CONFIG_HOME/awww/$theme"
+    printf '[theme]\ndisplay_name = "%s"\n[wallpaper]\ndefault = "one.jpg"\n' "$theme" > "$XDG_CONFIG_HOME/awww/$theme/theme.toml"
+    : > "$XDG_CONFIG_HOME/awww/$theme/one.jpg"
+  done
+}
+sed -n '/^  print_stage 6 /,/^  print_stage 7 /p' "$ROOT/install.sh" > "$WORKDIR/deploy-stage.sh"
+run_install_stage() {
+  source "$WORKDIR/deploy-stage.sh"
+}
+
+run_install_stage
+
+mapfile -t first_run < "$EVENTS"
+[[ "${first_run[*]}" == "daemon image restart" ]] \
+  || fail "expected daemon, theme initialization, and shell restart order; got: ${first_run[*]}"
+[[ -f "$TESTHOME/.local/state/aphotic/theme.json" ]] \
+  || fail "theme initializer did not create state"
+[[ "$(jq -r .theme "$XDG_STATE_HOME/aphotic/theme.json")" == "beta" ]] \
+  || fail "theme initialization did not use the saved install selection"
+
+printf '{"theme":"gruvbox"}\n' > "$TESTHOME/.local/state/aphotic/theme.json"
+: > "$EVENTS"
+run_install_stage
+mapfile -t second_run < "$EVENTS"
+[[ "${second_run[*]}" == "restart" ]] \
+  || fail "existing daemon should not be started twice; got: ${second_run[*]}"
+grep -q 'gruvbox' "$TESTHOME/.local/state/aphotic/theme.json" \
+  || fail "existing theme state was overwritten"
+
+export GRAPHICAL=0
+: > "$EVENTS"
+run_install_stage
+[[ ! -s "$EVENTS" ]] || fail "non-graphical session should not start daemon or restart shell"
+
+echo "PASS: active-session initialization is ordered, idempotent, and gated"

--- a/tests/test_profiles_real.py
+++ b/tests/test_profiles_real.py
@@ -16,6 +16,12 @@ def test_minimal_profile_excludes_extras():
     assert "hyprland" not in result["main"], "hyprland is orchestrator-special-cased, not profile data"
 
 
+def test_minimal_profile_ships_shell_fonts():
+    result = merge_packages(str(ROOT / "profiles/base/minimal.toml"), [])
+    for package in ["ttf-material-symbols-variable", "inter-font", "ttf-jetbrains-mono-nerd"]:
+        assert package in result["main"], f"{package} missing from minimal shell profile"
+
+
 def test_full_profile_has_expected_packages():
     result = merge_packages(str(ROOT / "profiles/base/full.toml"), [])
     for pkg in ["quickshell", "firefox", "starship", "sddm", "matugen"]:
@@ -126,6 +132,7 @@ def test_multiple_layers_and_custom_apps_all_merge():
 
 if __name__ == "__main__":
     test_minimal_profile_excludes_extras()
+    test_minimal_profile_ships_shell_fonts()
     test_full_profile_has_expected_packages()
     test_gaming_layer_adds_packages()
     test_exploit_layer_adds_packages()

--- a/tests/test_startup_path.sh
+++ b/tests/test_startup_path.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+TESTHOME="$WORKDIR/home"
+mkdir -p "$TESTHOME/.local/bin"
+LOG="$WORKDIR/aphotic.log"
+
+cat > "$TESTHOME/.local/bin/aphotic" <<EOF
+#!/usr/bin/env bash
+printf '%s\\n' "\$*" >> "$LOG"
+EOF
+chmod +x "$TESTHOME/.local/bin/aphotic"
+
+cat > "$WORKDIR/harness.lua" <<'EOF'
+local home = os.getenv("TEST_HOME")
+local log = os.getenv("APHOTIC_TEST_LOG")
+
+local function shell_quote(value)
+    return "'" .. value:gsub("'", "'\\\\''") .. "'"
+end
+
+hl = {}
+function hl.on(name, callback)
+    assert(name == "hyprland.start")
+    callback()
+end
+
+function hl.exec_cmd(command)
+    if command:match("^aphotic ") or command:match("^~/.local/bin/aphotic ") then
+        local wrapped = "env -i HOME=" .. shell_quote(home) ..
+            " PATH='/usr/bin:/bin' sh -c " .. shell_quote(command .. " >> " .. shell_quote(log))
+        local ok, _, status = os.execute(wrapped)
+        assert(ok == true and status == 0, "startup command failed: " .. command)
+    end
+end
+
+dofile(os.getenv("APHOTIC_STARTUP"))
+EOF
+
+TEST_HOME="$TESTHOME" APHOTIC_TEST_LOG="$LOG" APHOTIC_STARTUP="$ROOT/Configs/hypr/startup.lua" \
+  lua "$WORKDIR/harness.lua" \
+  || fail "startup could not resolve Aphotic CLI without ~/.local/bin on PATH"
+
+grep -qx 'theme ensure-default' "$LOG" \
+  || fail "startup did not execute theme ensure-default through the user-local CLI"
+grep -qx 'vpn autostart' "$LOG" \
+  || fail "startup did not execute vpn autostart through the user-local CLI"
+grep -qx 'whatsnew' "$LOG" \
+  || fail "startup did not execute whatsnew through the user-local CLI"
+
+echo "PASS: startup resolves Aphotic CLI without login PATH"


### PR DESCRIPTION
## Problem

A fresh minimal install with no layers omits the fonts used by the shell. Material Symbols icons can render as names such as `bluetooth` and `dashboard`.

Wallpaper initialization has two gaps. Hyprland startup invokes `aphotic` through PATH, which may omit `~/.local/bin` in a display-manager session. An install inside an active graphical session restarts the shell before saving the install config and does not initialize the wallpaper daemon or theme.

## Plan

Include the shell fonts in the minimal base, resolve startup commands through the user-local CLI, and save the selected configuration before initializing an active session. Reuse the existing default-theme command so reinstalling preserves an existing theme.

## Resolution

- Added Material Symbols, Inter, and JetBrains Mono Nerd Font to minimal.
- Updated startup CLI paths and active-session initialization order. An existing wallpaper daemon is reused, and a theme initialization failure warns without preventing shell startup.
- Added tests for the zero-layer package set, startup without a login PATH, and the install deployment stage using the real theme CLI with isolated state. CI installs Lua for the startup test.

Validation: 56 shell suites and 104 Python tests pass. Bash syntax, Lua syntax, and diff checks pass. Moving the config write after initialization makes the deployment test fail; restoring the fix passes. Local ShellCheck was unavailable; the PR workflow runs it.

Draft #201 overlaps the base profile but changes its `prep` list. This patch changes only minimal's `main` list and preserves that work.

Unresolved validation:

- The dev VM at `10.0.0.40:22` was unreachable with `No route to host`; end-to-end installer validation on that VM remains outstanding.
- Font resolution, first-session wallpaper display, and QML warnings on the affected laptop remain unverified.
- The cause of reported lag remains unconfirmed without the laptop's service journal around the glitches and manual reload. No performance change is included.
- Wiki profile and troubleshooting edits are prepared locally for publication after integration.
